### PR TITLE
schemas: fix typo in json web crypto schemas

### DIFF
--- a/schemas/json_web_crypto_schema.json
+++ b/schemas/json_web_crypto_schema.json
@@ -46,7 +46,7 @@
     },
     "JsonWebKey": {
       "type": "object",
-      "desription": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
+      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
       "properties": {
         "alg": {
           "type": "string",

--- a/schemas/json_web_encryption_schema.json
+++ b/schemas/json_web_encryption_schema.json
@@ -32,7 +32,7 @@
     },
     "JsonWebKey": {
       "type": "object",
-      "desription": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
+      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
       "properties": {
         "alg": {
           "type": "string",

--- a/schemas/json_web_key_schema.json
+++ b/schemas/json_web_key_schema.json
@@ -32,7 +32,7 @@
     },
     "JsonWebKey": {
       "type": "object",
-      "desription": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
+      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
       "properties": {
         "alg": {
           "type": "string",

--- a/schemas/json_web_signature_schema.json
+++ b/schemas/json_web_signature_schema.json
@@ -32,7 +32,7 @@
     },
     "JsonWebKey": {
       "type": "object",
-      "desription": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
+      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
       "properties": {
         "alg": {
           "type": "string",


### PR DESCRIPTION
"desription" vs "description".

This fell out as an easy fix from first efforts trying to validate the existing JSON vectors against their schemas.