### PR TITLE
Initial linting/validation of JSON vectors and associated schemas

### DIFF
--- a/.github/workflows/vectorlint.yml
+++ b/.github/workflows/vectorlint.yml
@@ -1,0 +1,38 @@
+name: Vector Lint
+
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Lint vectors/schemas
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check if modules are tidy
+        run: |
+          go mod tidy
+          if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
+            echo "go.mod or go.sum are not tidy. Please run 'go mod tidy' locally and commit changes."
+            git diff go.mod go.sum
+            exit 1
+          fi
+
+      - name: Verify formatting
+        # 'gofmt -l .' to list files whose formatting differs from gofmt's
+        # 'test -z' to verify that the output is empty
+        run: test -z "$(gofmt -l .)"
+
+      - name: Run vectorlint
+        run: go run ./tools/vectorlint

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/c2sp/wycheproof
+
+go 1.23.6
+
+require github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
+
+require golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -1,0 +1,194 @@
+// vectorlint analyzes vector files to flag potential issues
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func main() {
+	schemaDirectory := flag.String("schemas-dir", "schemas", "directory containing schema files")
+	vectorsDirectories := flag.String("vectors-dir", "testvectors_v1,testvectors", "comma separated directories containing vector files")
+	vectorFilter := flag.String("vector-filter", "", "only validate vector files matching the provided pattern")
+
+	flag.Parse()
+
+	vectorDirectoryParts := strings.Split(*vectorsDirectories, ",")
+
+	log.Printf("reading schemas from %q\n", *schemaDirectory)
+	log.Printf("reading vectors from %q\n", vectorDirectoryParts)
+
+	var vectorRegex *regexp.Regexp
+	if *vectorFilter != "" {
+		vectorRegex = regexp.MustCompile(*vectorFilter)
+		log.Printf("filtering vectors with %q\n", *vectorFilter)
+	}
+
+	schemaCompiler := jsonschema.NewCompiler()
+
+	for _, f := range customFormats {
+		schemaCompiler.RegisterFormat(&f)
+	}
+
+	var total, valid, invalid, noSchema, ignored int
+	for _, vectorDir := range vectorDirectoryParts {
+		err := filepath.WalkDir(vectorDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.IsDir() || !strings.HasSuffix(d.Name(), ".json") {
+				return nil
+			}
+
+			if vectorRegex != nil && !vectorRegex.MatchString(d.Name()) {
+				return nil
+			}
+
+			vectorData, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("failed to read %s: %w", path, err)
+			}
+
+			total++
+
+			var vector struct {
+				Schema string `json:"schema"`
+			}
+
+			if err := json.Unmarshal(vectorData, &vector); err != nil {
+				log.Printf("❌ %q: invalid vector JSON data: %s\n", path, err)
+				invalid++
+				return nil
+			}
+
+			if vector.Schema == "" {
+				log.Printf("❌ %q: no schema specified\n", path)
+				noSchema++
+				return nil
+			}
+
+			if missingSchemas[vector.Schema] {
+				log.Printf("⚠️ %q: ignoring missing schema %q\n", path, vector.Schema)
+				ignored++
+				return nil
+			}
+
+			schemaPath := filepath.Join(*schemaDirectory, vector.Schema)
+			if _, err := os.Stat(schemaPath); os.IsNotExist(err) {
+				log.Printf("❌ %q: referenced schema %q not found\n", path, vector.Schema)
+				invalid++
+				return nil
+			}
+
+			schema, err := schemaCompiler.Compile(schemaPath)
+			if err != nil {
+				log.Printf("❌ %q: invalid schema %q: %s\n", path, vector.Schema, err)
+				invalid++
+				return nil
+			}
+
+			var instance any
+			if err := json.Unmarshal(vectorData, &instance); err != nil {
+				log.Printf("❌ %q: invalid vector JSON data: %s\n", path, err)
+				invalid++
+				return nil
+			}
+
+			if err := schema.Validate(instance); err != nil {
+				log.Printf("❌ %q: vector doesn't validate with schema: %s\n", path, err)
+				invalid++
+				return nil
+			}
+
+			log.Printf("✅ %q: validates with %q\n", path, vector.Schema)
+			valid++
+			return nil
+		})
+		if err != nil {
+			fmt.Printf("Error walking directory: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	log.Printf("linted %d vector files\n", total)
+	log.Printf("valid: %d\n", valid)
+	log.Printf("invalid: %d\n", invalid)
+	log.Printf("no schema: %d\n", noSchema)
+	log.Printf("ignored: %d\n", ignored)
+
+	os.Exit(invalid)
+}
+
+var (
+	// TODO(XXX): some _v1 vectors reference schema files that don't exist. Until fixed, ignore these schemas.
+	missingSchemas = map[string]bool{
+		// testvectors_v1/aes_ff1_base*_test.json:
+		"fpe_str_test_schema.json": true,
+
+		// testvectors_v1/aes_ff1_radix*_test.json:
+		"fpe_list_test_schema.json": true,
+
+		// testvectors_v1/ec_prime_order_curves_test.json:
+		"ec_curve_test_schema.json": true,
+
+		// testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
+		"ecdsa_bitcoin_verify_schema.json": true,
+
+		// testvectors_v1/pbes2_hmacsha*_aes_*_test.json:
+		"pbe_test_schema.json": true,
+
+		// testvectors_v1/pbkdf2_hmacsha*_test.json:
+		"pbkdf_test_schema.json": true,
+
+		// testvectors_v1/rsa_pss_*_sha*_mgf*_params_test.json
+		// testvectors_v1/rsa_pss_misc_params_test.json:
+		"rsassa_pss_with_parameters_verify_schema.json": true,
+	}
+
+	customFormats = []jsonschema.Format{
+		{
+			Name: "Asn",
+			// TODO(XXX): validate "Asn" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "Der",
+			// TODO(XXX): validate "Der" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "EcCurve",
+			// TODO(XXX): validate "EcCurve" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "HexBytes",
+			// TODO(XXX): validate "HexBytes" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "BigInt",
+			// TODO(XXX): validate "BigInt" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "Pem",
+			// TODO(XXX): validate "Pem" format.
+			Validate: noValidateFormat,
+		},
+	}
+)
+
+// noValidateFormat is a placeholder Format.Validate callback that performs no validation of the input.
+func noValidateFormat(_ any) error {
+	return nil
+}


### PR DESCRIPTION
:wave: Here's the start on some CI infrastructure and vector/schema validation. I suspect we can come up with lots of other interesting properties to lint for, but for now I'm focused on the JSON schemas. This PR is a good place to start, but isn't an end-state and comes with several TODOs for follow-up.

### tools: add vector linting tool
This commit initializes a Go module for the repo, adding a single command under `tools/vectorlint`.

The new `vectorlint` tool can be provided a directory of schemas, and one or more directories of test vectors. It will process all vectors to check that:

* the vector JSON is valid JSON content
* the vector JSON references a schema JSON file that exists
* the schema JSON compiles
* the vector JSON is valid according to its referenced schema

This initial work has some important limitations to be addressed with follow-up PRs:

1. There are 7 schemas referenced by vector files in `testvectors_v1/` that don't exist. For now these are tracked in a `missingSchemas` map and the tool ignores vectors that ref these. We should add the missing schemas and remove the `missingSchemas` entries. 

2. The schemas use a number of custom formats. To get started I've implemented the format validation as a no-op. We should add validation logic for each custom format and remove the no-op validation.

3. The schema's don't include `"additionalProperties":false`, so unknown fields are allowed.

### ci: add simple GitHub actions vectorlint CI

Ensures the Go code remains nicely formatted, builds without error, and that the `vectorlint` tool finds no issues.

This task is run for pushes, PRs, and on a cron schedule to prevent any unexpected regressions/issues.

Here's [an example passing run](https://github.com/cpu/wycheproof/actions/runs/13909922164/job/38921691561) from my fork.

### Example output:

<details>
<summary>Output from go run ./tools/vectorlint:</summary>

```
2025/03/17 17:07:57 reading schemas from "schemas"
2025/03/17 17:07:57 reading vectors from ["testvectors_v1" "testvectors"]
2025/03/17 17:07:57 ✅ "testvectors_v1/a128cbc_hs256_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/a192cbc_hs384_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/a256cbc_hs512_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aead_aes_siv_cmac_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aegis128L_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aegis128_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aegis256_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_cbc_pkcs5_test.json": validates with "ind_cpa_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_ccm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_cmac_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_eax_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base10_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base16_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base26_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base32_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base36_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base45_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base62_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base64_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_base85_test.json": ignoring missing schema "fpe_str_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix10_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix16_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix255_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix256_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix26_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix32_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix36_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix45_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix62_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix64_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix65535_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix65536_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/aes_ff1_radix85_test.json": ignoring missing schema "fpe_list_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_gcm_siv_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_gcm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_gmac_test.json": validates with "mac_with_iv_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_kwp_test.json": validates with "keywrap_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_wrap_test.json": validates with "keywrap_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aes_xts_test.json": validates with "ind_cpa_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aria_cbc_pkcs5_test.json": validates with "ind_cpa_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aria_ccm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aria_cmac_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aria_gcm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aria_kwp_test.json": validates with "keywrap_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/aria_wrap_test.json": validates with "keywrap_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ascon128_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ascon128a_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ascon80pq_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/camellia_cbc_pkcs5_test.json": validates with "ind_cpa_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/camellia_ccm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/camellia_cmac_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/camellia_wrap_test.json": validates with "keywrap_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/chacha20_poly1305_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/dsa_2048_224_sha224_p1363_test.json": validates with "dsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/dsa_2048_224_sha224_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/dsa_2048_224_sha256_p1363_test.json": validates with "dsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/dsa_2048_224_sha256_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/dsa_2048_256_sha256_p1363_test.json": validates with "dsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/dsa_2048_256_sha256_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/dsa_3072_256_sha256_p1363_test.json": validates with "dsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/dsa_3072_256_sha256_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/ec_prime_order_curves_test.json": ignoring missing schema "ec_curve_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_brainpoolP224r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_brainpoolP256r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_brainpoolP320r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_brainpoolP384r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_brainpoolP512r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp224r1_ecpoint_test.json": validates with "ecdh_ecpoint_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp224r1_pem_test.json": validates with "ecdh_pem_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp224r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp256k1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp256k1_webcrypto_test.json": validates with "ecdh_webcrypto_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp256r1_ecpoint_test.json": validates with "ecdh_ecpoint_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp256r1_pem_test.json": validates with "ecdh_pem_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp256r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp256r1_webcrypto_test.json": validates with "ecdh_webcrypto_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp384r1_ecpoint_test.json": validates with "ecdh_ecpoint_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp384r1_pem_test.json": validates with "ecdh_pem_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp384r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp384r1_webcrypto_test.json": validates with "ecdh_webcrypto_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp521r1_ecpoint_test.json": validates with "ecdh_ecpoint_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp521r1_pem_test.json": validates with "ecdh_pem_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp521r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdh_secp521r1_webcrypto_test.json": validates with "ecdh_webcrypto_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP224r1_sha224_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP224r1_sha3_224_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP256r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP256r1_sha3_256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP320r1_sha384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP320r1_sha3_384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP384r1_sha384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP384r1_sha3_384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP512r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_brainpoolP512r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp160k1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp160r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp160r2_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp192k1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp192r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224k1_sha224_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224k1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha224_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha3_224_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha3_256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_shake128_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp224r1_shake128_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json": ignoring missing schema "ecdsa_bitcoin_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_sha3_256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_shake128_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_shake128_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_shake256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256k1_shake256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_sha3_256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_shake128_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_shake128_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp256r1_webcrypto_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_sha384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_sha3_384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_shake256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_shake256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp384r1_webcrypto_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp521r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp521r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp521r1_shake256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp521r1_shake256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ecdsa_secp521r1_webcrypto_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ed25519_test.json": validates with "eddsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/ed448_test.json": validates with "eddsa_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hkdf_sha1_test.json": validates with "hkdf_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hkdf_sha256_test.json": validates with "hkdf_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hkdf_sha384_test.json": validates with "hkdf_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hkdf_sha512_test.json": validates with "hkdf_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha1_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha224_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha256_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha384_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha3_224_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha3_256_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha3_384_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha3_512_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha512_224_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha512_256_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sha512_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/hmac_sm3_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/kmac128_no_customization_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/kmac256_no_customization_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/morus1280_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/morus640_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha1_aes_128_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha1_aes_192_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha1_aes_256_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha224_aes_128_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha224_aes_192_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha224_aes_256_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha256_aes_128_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha256_aes_192_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha256_aes_256_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha384_aes_128_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha384_aes_192_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha384_aes_256_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha512_aes_128_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha512_aes_192_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbes2_hmacsha512_aes_256_test.json": ignoring missing schema "pbe_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbkdf2_hmacsha1_test.json": ignoring missing schema "pbkdf_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbkdf2_hmacsha224_test.json": ignoring missing schema "pbkdf_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbkdf2_hmacsha256_test.json": ignoring missing schema "pbkdf_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbkdf2_hmacsha384_test.json": ignoring missing schema "pbkdf_test_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/pbkdf2_hmacsha512_test.json": ignoring missing schema "pbkdf_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/primality_test.json": validates with "primality_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha1_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha224_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha224_mgf1sha224_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha256_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha256_mgf1sha256_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha384_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha384_mgf1sha384_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha512_224_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha512_224_mgf1sha512_224_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha512_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_2048_sha512_mgf1sha512_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_3072_sha256_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_3072_sha256_mgf1sha256_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_3072_sha512_256_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_3072_sha512_256_mgf1sha512_256_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_3072_sha512_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_3072_sha512_mgf1sha512_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_4096_sha256_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_4096_sha256_mgf1sha256_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_4096_sha512_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_4096_sha512_mgf1sha512_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_oaep_misc_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pkcs1_2048_test.json": validates with "rsaes_pkcs1_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pkcs1_3072_test.json": validates with "rsaes_pkcs1_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pkcs1_4096_test.json": validates with "rsaes_pkcs1_decrypt_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/rsa_pss_2048_sha1_mgf1_20_params_test.json": ignoring missing schema "rsassa_pss_with_parameters_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_sha1_mgf1_20_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/rsa_pss_2048_sha256_mgf1_0_params_test.json": ignoring missing schema "rsassa_pss_with_parameters_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_sha256_mgf1_0_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/rsa_pss_2048_sha256_mgf1_32_params_test.json": ignoring missing schema "rsassa_pss_with_parameters_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_sha256_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_sha256_mgf1sha1_20_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_sha384_mgf1_48_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_sha512_224_mgf1_28_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_sha512_256_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/rsa_pss_2048_sha512_mgf1sha256_32_params_test.json": ignoring missing schema "rsassa_pss_with_parameters_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_shake128_params_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_shake128_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_2048_shake256_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/rsa_pss_3072_sha256_mgf1_32_params_test.json": ignoring missing schema "rsassa_pss_with_parameters_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_3072_sha256_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_3072_shake128_params_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_3072_shake128_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_3072_shake256_params_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_3072_shake256_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_4096_sha256_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_4096_sha384_mgf1_48_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/rsa_pss_4096_sha512_mgf1_32_params_test.json": ignoring missing schema "rsassa_pss_with_parameters_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_4096_sha512_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/rsa_pss_4096_sha512_mgf1_64_params_test.json": ignoring missing schema "rsassa_pss_with_parameters_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_4096_sha512_mgf1_64_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_4096_shake256_params_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_4096_shake256_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ⚠️ "testvectors_v1/rsa_pss_misc_params_test.json": ignoring missing schema "rsassa_pss_with_parameters_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_pss_misc_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha224_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha3_224_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha3_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha3_384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha3_512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha512_224_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha512_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_2048_sha512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_3072_sha256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_3072_sha384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_3072_sha3_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_3072_sha3_384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_3072_sha3_512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_3072_sha512_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_3072_sha512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_4096_sha256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_4096_sha384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_4096_sha512_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_4096_sha512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_8192_sha256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_8192_sha384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_signature_8192_sha512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_three_primes_oaep_2048_sha1_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_three_primes_oaep_3072_sha224_mgf1sha224_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/rsa_three_primes_oaep_4096_sha256_mgf1sha256_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/seed_ccm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/seed_gcm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/seed_wrap_test.json": validates with "keywrap_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/siphash_1_3_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/siphash_2_4_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/siphash_4_8_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/siphashx_2_4_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/siphashx_4_8_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/sm4_ccm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/sm4_gcm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:57 ✅ "testvectors_v1/vmac_128_test.json": validates with "mac_with_iv_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/vmac_64_test.json": validates with "mac_with_iv_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/x25519_asn_test.json": validates with "xdh_asn_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/x25519_jwk_test.json": validates with "xdh_jwk_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/x25519_pem_test.json": validates with "xdh_pem_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/x25519_test.json": validates with "xdh_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/x448_asn_test.json": validates with "xdh_asn_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/x448_jwk_test.json": validates with "xdh_jwk_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/x448_pem_test.json": validates with "xdh_pem_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/x448_test.json": validates with "xdh_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors_v1/xchacha20_poly1305_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aead_aes_siv_cmac_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aegis128L_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aegis128_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aegis256_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aes_cbc_pkcs5_test.json": validates with "ind_cpa_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aes_ccm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aes_cmac_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aes_eax_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aes_gcm_siv_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aes_gcm_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/aes_siv_cmac_test.json": validates with "daead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/chacha20_poly1305_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_2048_224_sha224_p1363_test.json": validates with "dsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_2048_224_sha224_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_2048_224_sha256_p1363_test.json": validates with "dsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_2048_224_sha256_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_2048_256_sha256_p1363_test.json": validates with "dsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_2048_256_sha256_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_3072_256_sha256_p1363_test.json": validates with "dsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_3072_256_sha256_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/dsa_test.json": validates with "dsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_brainpoolP224r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_brainpoolP256r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_brainpoolP320r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_brainpoolP384r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_brainpoolP512r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp224r1_ecpoint_test.json": validates with "ecdh_ecpoint_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp224r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp256k1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp256r1_ecpoint_test.json": validates with "ecdh_ecpoint_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp256r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp384r1_ecpoint_test.json": validates with "ecdh_ecpoint_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp384r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp521r1_ecpoint_test.json": validates with "ecdh_ecpoint_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_secp521r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_sect283k1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_sect283r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_sect409k1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_sect409r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_sect571k1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_sect571r1_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_test.json": validates with "ecdh_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdh_webcrypto_test.json": validates with "ecdh_webcrypto_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP224r1_sha224_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP224r1_sha224_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP256r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP256r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP320r1_sha384_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP320r1_sha384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP384r1_sha384_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP384r1_sha384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP512r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_brainpoolP512r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp160k1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp160k1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp160r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp160r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp160r2_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp160r2_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp192k1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp192k1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp192r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp192r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha224_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha224_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha3_224_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha3_256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp224r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256k1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256k1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256k1_sha3_256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256k1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256k1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256k1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256r1_sha256_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256r1_sha256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256r1_sha3_256_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp256r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp384r1_sha384_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp384r1_sha384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp384r1_sha3_384_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp384r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp384r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp384r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp521r1_sha3_512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp521r1_sha512_p1363_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_secp521r1_sha512_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_test.json": validates with "ecdsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ecdsa_webcrypto_test.json": validates with "ecdsa_p1363_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/ed448_test.json": validates with "eddsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/eddsa_test.json": validates with "eddsa_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/gmac_test.json": validates with "mac_with_iv_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hkdf_sha1_test.json": validates with "hkdf_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hkdf_sha256_test.json": validates with "hkdf_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hkdf_sha384_test.json": validates with "hkdf_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hkdf_sha512_test.json": validates with "hkdf_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha1_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha224_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha256_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha384_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha3_224_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha3_256_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha3_384_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha3_512_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/hmac_sha512_test.json": validates with "mac_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/json_web_crypto_test.json": validates with "json_web_crypto_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/json_web_encryption_test.json": validates with "json_web_encryption_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/json_web_key_test.json": validates with "json_web_key_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/json_web_signature_test.json": validates with "json_web_signature_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/kw_test.json": validates with "keywrap_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/kwp_test.json": validates with "keywrap_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/primality_test.json": validates with "primality_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha1_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha224_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha224_mgf1sha224_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha256_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha256_mgf1sha256_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha384_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha384_mgf1sha384_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha512_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_2048_sha512_mgf1sha512_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_3072_sha256_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_3072_sha256_mgf1sha256_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_3072_sha512_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_3072_sha512_mgf1sha512_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_4096_sha256_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_4096_sha256_mgf1sha256_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_4096_sha512_mgf1sha1_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_4096_sha512_mgf1sha512_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_oaep_misc_test.json": validates with "rsaes_oaep_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pkcs1_2048_test.json": validates with "rsaes_pkcs1_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pkcs1_3072_test.json": validates with "rsaes_pkcs1_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pkcs1_4096_test.json": validates with "rsaes_pkcs1_decrypt_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_2048_sha1_mgf1_20_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_2048_sha256_mgf1_0_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_2048_sha256_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_2048_sha512_256_mgf1_28_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_2048_sha512_256_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_3072_sha256_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_4096_sha256_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_4096_sha512_mgf1_32_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_pss_misc_test.json": validates with "rsassa_pss_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_sig_gen_misc_test.json": validates with "rsassa_pkcs1_generate_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha224_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha3_224_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha3_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha3_384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha3_512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha512_224_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha512_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_2048_sha512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_3072_sha256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_3072_sha384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_3072_sha3_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_3072_sha3_384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_3072_sha3_512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_3072_sha512_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_3072_sha512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_4096_sha384_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_4096_sha512_256_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_4096_sha512_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/rsa_signature_test.json": validates with "rsassa_pkcs1_verify_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/vmac_128_test.json": validates with "mac_with_iv_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/vmac_64_test.json": validates with "mac_with_iv_test_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/x25519_asn_test.json": validates with "xdh_asn_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/x25519_jwk_test.json": validates with "xdh_jwk_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/x25519_pem_test.json": validates with "xdh_pem_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/x25519_test.json": validates with "xdh_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/x448_asn_test.json": validates with "xdh_asn_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/x448_jwk_test.json": validates with "xdh_jwk_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/x448_pem_test.json": validates with "xdh_pem_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/x448_test.json": validates with "xdh_comp_schema.json"
2025/03/17 17:07:58 ✅ "testvectors/xchacha20_poly1305_test.json": validates with "aead_test_schema.json"
2025/03/17 17:07:58 linted 487 vector files
2025/03/17 17:07:58 valid: 435
2025/03/17 17:07:58 invalid: 0
2025/03/17 17:07:58 no schema: 0
2025/03/17 17:07:58 ignored: 52
```

</details>
