### PR TITLE
Lightly validate custom data formats

### DIFF
--- a/schemas/ecdh_pem_test_schema_v1.json
+++ b/schemas/ecdh_pem_test_schema_v1.json
@@ -1,0 +1,101 @@
+{
+  "type": "object",
+  "definitions": {
+    "EcdhPemTestGroup": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "EcdhPemTest"
+          ]
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EcdhPemTestVector"
+          }
+        }
+      }
+    },
+    "EcdhPemTestVector": {
+      "type": "object",
+      "properties": {
+        "tcId": {
+          "type": "integer",
+          "description": "Identifier of the test case"
+        },
+        "comment": {
+          "type": "string",
+          "description": "A brief description of the test case"
+        },
+        "public": {
+          "type": "string",
+          "format": "Pem",
+          "description": "Pem encoded public key"
+        },
+        "private": {
+          "type": "string",
+          "format": "Pem",
+          "description": "Pem encoded private key"
+        },
+        "shared": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "The shared secret key"
+        },
+        "result": {
+          "type": "string",
+          "description": "Test result",
+          "enum": [
+            "valid",
+            "invalid",
+            "acceptable"
+          ]
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of flags"
+        }
+      }
+    }
+  },
+  "properties": {
+    "algorithm": {
+      "type": "string",
+      "description": "the primitive tested in the test file"
+    },
+    "generatorVersion": {
+      "type": "string",
+      "description": "the version of the test vectors."
+    },
+    "header": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "additional documentation"
+    },
+    "notes": {
+      "type": "object",
+      "description": "a description of the labels used in the test vectors"
+    },
+    "numberOfTests": {
+      "type": "integer",
+      "description": "the number of test vectors in this test"
+    },
+    "schema": {
+      "enum": [
+        "ecdh_pem_test_schema_v1.json"
+      ]
+    },
+    "testGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EcdhPemTestGroup"
+      }
+    }
+  }
+}

--- a/testvectors_v1/ecdh_secp224r1_pem_test.json
+++ b/testvectors_v1/ecdh_secp224r1_pem_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDH",
-  "schema" : "ecdh_pem_test_schema.json",
+  "schema" : "ecdh_pem_test_schema_v1.json",
   "generatorVersion" : "0.9rc5",
   "numberOfTests" : 714,
   "header" : [

--- a/testvectors_v1/ecdh_secp256r1_pem_test.json
+++ b/testvectors_v1/ecdh_secp256r1_pem_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDH",
-  "schema" : "ecdh_pem_test_schema.json",
+  "schema" : "ecdh_pem_test_schema_v1.json",
   "generatorVersion" : "0.9rc5",
   "numberOfTests" : 612,
   "header" : [

--- a/testvectors_v1/ecdh_secp384r1_pem_test.json
+++ b/testvectors_v1/ecdh_secp384r1_pem_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDH",
-  "schema" : "ecdh_pem_test_schema.json",
+  "schema" : "ecdh_pem_test_schema_v1.json",
   "generatorVersion" : "0.9rc5",
   "numberOfTests" : 1047,
   "header" : [

--- a/testvectors_v1/ecdh_secp521r1_pem_test.json
+++ b/testvectors_v1/ecdh_secp521r1_pem_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDH",
-  "schema" : "ecdh_pem_test_schema.json",
+  "schema" : "ecdh_pem_test_schema_v1.json",
   "generatorVersion" : "0.9rc5",
   "numberOfTests" : 916,
   "header" : [

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
 	"fmt"
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -182,9 +183,8 @@ var (
 			Validate: noValidateFormat,
 		},
 		{
-			Name: "Pem",
-			// TODO(XXX): validate "Pem" format.
-			Validate: noValidateFormat,
+			Name:     "Pem",
+			Validate: validatePem,
 		},
 	}
 )
@@ -205,5 +205,19 @@ func validateHex(value any) error {
 		return fmt.Errorf("invalid HexBytes value: %v: %w", value, err)
 	}
 
+	return nil
+}
+
+func validatePem(value any) error {
+	strVal, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("invalid non-string Pem value: %v", value)
+	}
+
+	_, rest := pem.Decode([]byte(strVal))
+	if len(rest) != 0 {
+		return fmt.Errorf("invalid Pem value: unexpected trailing bytes %x", rest)
+	}
+	
 	return nil
 }

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -179,8 +179,8 @@ var (
 		},
 		{
 			Name: "BigInt",
-			// TODO(XXX): validate "BigInt" format.
-			Validate: noValidateFormat,
+			// For big integers, we can validate the format is valid hex but not much else.
+			Validate: validateHex,
 		},
 		{
 			Name:     "Pem",
@@ -218,6 +218,6 @@ func validatePem(value any) error {
 	if len(rest) != 0 {
 		return fmt.Errorf("invalid Pem value: unexpected trailing bytes %x", rest)
 	}
-	
+
 	return nil
 }

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -172,8 +172,8 @@ var (
 		},
 		{
 			Name: "EcCurve",
-			// TODO(XXX): validate "EcCurve" format.
-			Validate: noValidateFormat,
+			// TODO(XXX): Seems like the EcCurve format should be defined as an enum?
+			Validate: validateCurve,
 		},
 		{
 			Name:     "HexBytes",
@@ -222,4 +222,18 @@ func validatePem(value any) error {
 	}
 
 	return nil
+}
+
+func validateCurve(value any) error {
+	strVal, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("invalid non-string EcCurve value: %v", value)
+	}
+
+	switch strVal {
+	case "curve25519", "curve448":
+		return nil
+	default:
+		return fmt.Errorf("invalid EcCurve: unknown curve name: %v", value)
+	}
 }

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -165,8 +165,9 @@ var (
 		},
 		{
 			Name: "Der",
-			// TODO(XXX): validate "Der" format.
-			Validate: noValidateFormat,
+			// For DER-encoded data, we can validate the format is valid hex, but to decode
+			// further we need to know the expected structure of the data.
+			Validate: validateHex,
 		},
 		{
 			Name: "EcCurve",

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -160,8 +160,9 @@ var (
 	customFormats = []jsonschema.Format{
 		{
 			Name: "Asn",
-			// TODO(XXX): validate "Asn" format.
-			Validate: noValidateFormat,
+			// For ASN.1 data we can validate the format is valid hex, but to decode
+			// further we need to know the expected structure (and encoding) of the data.
+			Validate: validateHex,
 		},
 		{
 			Name: "Der",


### PR DESCRIPTION
Continuing from https://github.com/C2SP/wycheproof/pull/129 by wiring up some light format validation.

I think most of this is uncontroversial, but the "schemas: fork ecdh_pem_test_schema.json for v1 vectors" commit is an interesting case that fell out of trying to validate `BigInt` type fields.

As [mentioned in this comment](https://github.com/C2SP/wycheproof/pull/129#issuecomment-2731755247) the JSON schems in-repo are for what I've been calling the v0 test vectors in `testvectors`. However, many of the v1 test vectors in `testvectors_v1` reference the same schema names, even if they don't describe the same data shape.

This "works" while our validation is extremely lax, but as we tighten up the validation, we'll need to do more work to add compatible schemas for the v1 vectors. In particular, doing a pass to add required fields to the existing schemas, or to add `"additionalProperties":false` will show that many of the vectors that pass validation today don't truly match the spirit of the referenced schema. I think that's OK: new additions will be strictly validated from the start, and we can burn down these mismatches as time/energy/interest permits.