### PR TITLE
Reduce some schema duplication

### DIFF
--- a/schemas/dsa_common.json
+++ b/schemas/dsa_common.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DsaPublicKey": {
+      "type": "object",
+      "properties": {
+        "g": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the generator of the multiplicative subgroup"
+        },
+        "keySize": {
+          "type": "integer",
+          "description": "the key size in bits"
+        },
+        "p": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the modulus p"
+        },
+        "q": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the order of the generator g"
+        },
+        "type": {
+          "type": "string",
+          "description": "the key type",
+          "enum": [
+            "DsaPublicKey"
+          ]
+        },
+        "y": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the public key value"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/dsa_p1363_verify_schema.json
+++ b/schemas/dsa_p1363_verify_schema.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "key": {
-          "$ref": "#/definitions/DsaPublicKey",
+          "$ref": "dsa_common.json#/definitions/DsaPublicKey",
           "description": "unencoded EC public key"
         },
         "keyDer": {
@@ -39,43 +39,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "DsaPublicKey": {
-      "type": "object",
-      "properties": {
-        "g": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the generator of the multiplicative subgroup"
-        },
-        "keySize": {
-          "type": "integer",
-          "description": "the key size in bits"
-        },
-        "p": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the modulus p"
-        },
-        "q": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the generator g"
-        },
-        "type": {
-          "type": "string",
-          "description": "the key type",
-          "enum": [
-            "DsaPublicKey"
-          ]
-        },
-        "y": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the public key value"
-        }
-      },
       "additionalProperties": false
     },
     "SignatureTestVector": {

--- a/schemas/dsa_p1363_verify_schema_v1.json
+++ b/schemas/dsa_p1363_verify_schema_v1.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "publicKey": {
-          "$ref": "#/definitions/DsaPublicKey",
+          "$ref": "dsa_common.json#/definitions/DsaPublicKey",
           "description": "unencoded EC public key"
         },
         "publicKeyDer": {
@@ -39,43 +39,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "DsaPublicKey": {
-      "type": "object",
-      "properties": {
-        "g": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the generator of the multiplicative subgroup"
-        },
-        "keySize": {
-          "type": "integer",
-          "description": "the key size in bits"
-        },
-        "p": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the modulus p"
-        },
-        "q": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the generator g"
-        },
-        "type": {
-          "type": "string",
-          "description": "the key type",
-          "enum": [
-            "DsaPublicKey"
-          ]
-        },
-        "y": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the public key value"
-        }
-      },
       "additionalProperties": false
     },
     "SignatureTestVector": {

--- a/schemas/dsa_verify_schema.json
+++ b/schemas/dsa_verify_schema.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "key": {
-          "$ref": "#/definitions/DsaPublicKey",
+          "$ref": "dsa_common.json#/definitions/DsaPublicKey",
           "description": "unenocded DSA public key"
         },
         "keyDer": {
@@ -38,43 +38,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "DsaPublicKey": {
-      "type": "object",
-      "properties": {
-        "g": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the generator of the multiplicative subgroup"
-        },
-        "keySize": {
-          "type": "integer",
-          "description": "the key size in bits"
-        },
-        "p": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the modulus p"
-        },
-        "q": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the generator g"
-        },
-        "type": {
-          "type": "string",
-          "description": "the key type",
-          "enum": [
-            "DsaPublicKey"
-          ]
-        },
-        "y": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the public key value"
-        }
-      },
       "additionalProperties": false
     },
     "AsnSignatureTestVector": {

--- a/schemas/dsa_verify_schema_v1.json
+++ b/schemas/dsa_verify_schema_v1.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "publicKey": {
-          "$ref": "#/definitions/DsaPublicKey",
+          "$ref": "dsa_common.json#/definitions/DsaPublicKey",
           "description": "unenocded DSA public key"
         },
         "publicKeyDer": {
@@ -38,43 +38,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "DsaPublicKey": {
-      "type": "object",
-      "properties": {
-        "g": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the generator of the multiplicative subgroup"
-        },
-        "keySize": {
-          "type": "integer",
-          "description": "the key size in bits"
-        },
-        "p": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the modulus p"
-        },
-        "q": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the generator g"
-        },
-        "type": {
-          "type": "string",
-          "description": "the key type",
-          "enum": [
-            "DsaPublicKey"
-          ]
-        },
-        "y": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the public key value"
-        }
-      },
       "additionalProperties": false
     },
     "AsnSignatureTestVector": {

--- a/schemas/ecdsa_common.json
+++ b/schemas/ecdsa_common.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "EcPublicKey": {
+      "type": "object",
+      "properties": {
+        "curve": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EcUnnamedGroup"
+            },
+            {
+              "type": "string",
+              "description": "the name of the EC group"
+            }
+          ],
+          "description": "the EC group used by this public key"
+        },
+        "keySize": {
+          "type": "integer",
+          "description": "the key size in bits"
+        },
+        "type": {
+          "type": "string",
+          "description": "the key type",
+          "enum": [
+            "EcPublicKey"
+          ]
+        },
+        "uncompressed": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "encoded public key point"
+        },
+        "wx": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the x-coordinate of the public key point"
+        },
+        "wy": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the y-coordinate of the public key point"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EcUnnamedGroup": {
+      "type": "object",
+      "properties": {
+        "a": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "coefficient a of the elliptic curve equation"
+        },
+        "b": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "coefficient b of the elliptic curve equation"
+        },
+        "gx": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the x-coordinate of the generator"
+        },
+        "gy": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the y-coordinate of the generator"
+        },
+        "h": {
+          "type": "integer",
+          "description": "the cofactor"
+        },
+        "n": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the order of the generator"
+        },
+        "p": {
+          "type": "string",
+          "format": "BigInt",
+          "description": "the order of the underlying field"
+        },
+        "type": {
+          "type": "string",
+          "description": "an unnamed EC group over a prime field in Weierstrass form",
+          "enum": [
+            "PrimeOrderCurve"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/ecdsa_p1363_verify_schema.json
+++ b/schemas/ecdsa_p1363_verify_schema.json
@@ -17,8 +17,8 @@
           "description": "[optional] the public key in webcrypto format"
         },
         "key": {
-          "$ref": "#/definitions/EcPublicKey",
-          "description": "unenocded EC public key"
+          "$ref": "ecdsa_common.json#/definitions/EcPublicKey",
+          "description": "unencoded EC public key"
         },
         "keyDer": {
           "type": "string",
@@ -42,97 +42,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "EcPublicKey": {
-      "type": "object",
-      "properties": {
-        "curve": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/EcUnnamedGroup"
-            },
-            {
-              "type": "string",
-              "description": "the name of the EC group"
-            }
-          ],
-          "description": "the EC group used by this public key"
-        },
-        "keySize": {
-          "type": "integer",
-          "description": "the key size in bits"
-        },
-        "type": {
-          "type": "string",
-          "description": "the key type",
-          "enum": [
-            "EcPublicKey"
-          ]
-        },
-        "uncompressed": {
-          "type": "string",
-          "format": "HexBytes",
-          "description": "encoded public key point"
-        },
-        "wx": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the x-coordinate of the public key point"
-        },
-        "wy": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the y-coordinate of the public key point"
-        }
-      },
-      "additionalProperties": false
-    },
-    "EcUnnamedGroup": {
-      "type": "object",
-      "properties": {
-        "a": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "coefficient a of the elliptic curve equation"
-        },
-        "b": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "coefficient b of the elliptic curve equation"
-        },
-        "gx": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the x-coordinate of the generator"
-        },
-        "gy": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the y-coordinate of the generator"
-        },
-        "h": {
-          "type": "integer",
-          "description": "the cofactor"
-        },
-        "n": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the generator"
-        },
-        "p": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the underlying field"
-        },
-        "type": {
-          "type": "string",
-          "description": "an unnamed EC group over a prime field in Weierstrass form",
-          "enum": [
-            "PrimeOrderCurve"
-          ]
-        }
-      },
       "additionalProperties": false
     },
     "SignatureTestVector": {

--- a/schemas/ecdsa_p1363_verify_schema.json
+++ b/schemas/ecdsa_p1363_verify_schema.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "jwk": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "[optional] the public key in webcrypto format"
         },
         "key": {

--- a/schemas/ecdsa_p1363_verify_schema_v1.json
+++ b/schemas/ecdsa_p1363_verify_schema_v1.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "publicKey": {
-          "$ref": "#/definitions/EcPublicKey",
+          "$ref": "ecdsa_common.json#/definitions/EcPublicKey",
           "description": "unencoded EC public key"
         },
         "publicKeyJwk": {
@@ -41,50 +41,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "EcPublicKey": {
-      "type": "object",
-      "properties": {
-        "curve": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/EcUnnamedGroup"
-            },
-            {
-              "type": "string",
-              "description": "the name of the EC group"
-            }
-          ],
-          "description": "the EC group used by this public key"
-        },
-        "keySize": {
-          "type": "integer",
-          "description": "the key size in bits"
-        },
-        "type": {
-          "type": "string",
-          "description": "the key type",
-          "enum": [
-            "EcPublicKey"
-          ]
-        },
-        "uncompressed": {
-          "type": "string",
-          "format": "HexBytes",
-          "description": "encoded public key point"
-        },
-        "wx": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the x-coordinate of the public key point"
-        },
-        "wy": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the y-coordinate of the public key point"
-        }
-      },
       "additionalProperties": false
     },
     "PublicKeyJwkEc": {
@@ -118,53 +74,6 @@
         "y": {
           "type": "string",
           "description": "the y-coordinate of an EC key point"
-        }
-      },
-      "additionalProperties": false
-    },
-    "EcUnnamedGroup": {
-      "type": "object",
-      "properties": {
-        "a": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "coefficient a of the elliptic curve equation"
-        },
-        "b": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "coefficient b of the elliptic curve equation"
-        },
-        "gx": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the x-coordinate of the generator"
-        },
-        "gy": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the y-coordinate of the generator"
-        },
-        "h": {
-          "type": "integer",
-          "description": "the cofactor"
-        },
-        "n": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the generator"
-        },
-        "p": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the underlying field"
-        },
-        "type": {
-          "type": "string",
-          "description": "an unnamed EC group over a prime field in Weierstrass form",
-          "enum": [
-            "PrimeOrderCurve"
-          ]
         }
       },
       "additionalProperties": false

--- a/schemas/ecdsa_p1363_verify_schema_v1.json
+++ b/schemas/ecdsa_p1363_verify_schema_v1.json
@@ -17,7 +17,7 @@
           "description": "unencoded EC public key"
         },
         "publicKeyJwk": {
-          "$ref": "#/definitions/PublicKeyJwkEc"
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey"
         },
         "publicKeyDer": {
           "type": "string",
@@ -41,41 +41,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "PublicKeyJwkEc": {
-      "type": "object",
-      "properties": {
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "EC"
-          ]
-        },
-        "crv": {
-          "type": "string",
-          "description": "which defined curve to use",
-          "enum": [
-            "P-256",
-            "P-384",
-            "P-521",
-            "secp256k1"
-          ]
-        },
-        "x": {
-          "type": "string",
-          "description": "the x-coordinate of an EC key point"
-        },
-        "y": {
-          "type": "string",
-          "description": "the y-coordinate of an EC key point"
-        }
-      },
       "additionalProperties": false
     },
     "SignatureTestVector": {

--- a/schemas/ecdsa_verify_schema.json
+++ b/schemas/ecdsa_verify_schema.json
@@ -13,8 +13,8 @@
           "$ref": "common.json#/definitions/Source"
         },
         "key": {
-          "$ref": "#/definitions/EcPublicKey",
-          "description": "unenocded EC public key"
+          "$ref": "ecdsa_common.json#/definitions/EcPublicKey",
+          "description": "unencoded EC public key"
         },
         "keyDer": {
           "type": "string",
@@ -38,97 +38,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "EcPublicKey": {
-      "type": "object",
-      "properties": {
-        "curve": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/EcUnnamedGroup"
-            },
-            {
-              "type": "string",
-              "description": "the name of the EC group"
-            }
-          ],
-          "description": "the EC group used by this public key"
-        },
-        "keySize": {
-          "type": "integer",
-          "description": "the key size in bits"
-        },
-        "type": {
-          "type": "string",
-          "description": "the key type",
-          "enum": [
-            "EcPublicKey"
-          ]
-        },
-        "uncompressed": {
-          "type": "string",
-          "format": "HexBytes",
-          "description": "encoded public key point"
-        },
-        "wx": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the x-coordinate of the public key point"
-        },
-        "wy": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the y-coordinate of the public key point"
-        }
-      },
-      "additionalProperties": false
-    },
-    "EcUnnamedGroup": {
-      "type": "object",
-      "properties": {
-        "a": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "coefficient a of the elliptic curve equation"
-        },
-        "b": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "coefficient b of the elliptic curve equation"
-        },
-        "gx": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the x-coordinate of the generator"
-        },
-        "gy": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the y-coordinate of the generator"
-        },
-        "h": {
-          "type": "integer",
-          "description": "the cofactor"
-        },
-        "n": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the generator"
-        },
-        "p": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the underlying field"
-        },
-        "type": {
-          "type": "string",
-          "description": "an unnamed EC group over a prime field in Weierstrass form",
-          "enum": [
-            "PrimeOrderCurve"
-          ]
-        }
-      },
       "additionalProperties": false
     },
     "AsnSignatureTestVector": {

--- a/schemas/ecdsa_verify_schema_v1.json
+++ b/schemas/ecdsa_verify_schema_v1.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "publicKey": {
-          "$ref": "#/definitions/EcPublicKey",
+          "$ref": "ecdsa_common.json#/definitions/EcPublicKey",
           "description": "unencoded EC public key"
         },
         "publicKeyDer": {
@@ -38,97 +38,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "EcPublicKey": {
-      "type": "object",
-      "properties": {
-        "curve": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/EcUnnamedGroup"
-            },
-            {
-              "type": "string",
-              "description": "the name of the EC group"
-            }
-          ],
-          "description": "the EC group used by this public key"
-        },
-        "keySize": {
-          "type": "integer",
-          "description": "the key size in bits"
-        },
-        "type": {
-          "type": "string",
-          "description": "the key type",
-          "enum": [
-            "EcPublicKey"
-          ]
-        },
-        "uncompressed": {
-          "type": "string",
-          "format": "HexBytes",
-          "description": "encoded public key point"
-        },
-        "wx": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the x-coordinate of the public key point"
-        },
-        "wy": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the y-coordinate of the public key point"
-        }
-      },
-      "additionalProperties": false
-    },
-    "EcUnnamedGroup": {
-      "type": "object",
-      "properties": {
-        "a": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "coefficient a of the elliptic curve equation"
-        },
-        "b": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "coefficient b of the elliptic curve equation"
-        },
-        "gx": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the x-coordinate of the generator"
-        },
-        "gy": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the y-coordinate of the generator"
-        },
-        "h": {
-          "type": "integer",
-          "description": "the cofactor"
-        },
-        "n": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the generator"
-        },
-        "p": {
-          "type": "string",
-          "format": "BigInt",
-          "description": "the order of the underlying field"
-        },
-        "type": {
-          "type": "string",
-          "description": "an unnamed EC group over a prime field in Weierstrass form",
-          "enum": [
-            "PrimeOrderCurve"
-          ]
-        }
-      },
       "additionalProperties": false
     },
     "AsnSignatureTestVector": {

--- a/schemas/eddsa_verify_schema.json
+++ b/schemas/eddsa_verify_schema.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "jwk": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "the private key in webcrypto format"
         },
         "key": {

--- a/schemas/eddsa_verify_schema_v1.json
+++ b/schemas/eddsa_verify_schema_v1.json
@@ -26,7 +26,7 @@
           "description": "PEM encoded public key"
         },
         "publicKeyJwk": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "the public key in webcrypto format"
         },
         "tests": {

--- a/schemas/json_web_crypto_common.json
+++ b/schemas/json_web_crypto_common.json
@@ -32,9 +32,11 @@
           "type": "string",
           "description": "the family of algorithms the key belongs to",
           "enum": [
+            "",
             "oct",
             "EC",
-            "RSA"
+            "RSA",
+            "OKP"
           ]
         },
         "k": {
@@ -74,9 +76,14 @@
           "description": "which defined curve to use",
           "enum": [
             "P-256",
+            "P-256K",
             "P-384",
             "P-521",
-            "secp256k1"
+            "secp256k1",
+            "X448",
+            "X25519",
+            "Ed25519",
+            "Ed448"
           ]
         },
         "x": {

--- a/schemas/json_web_crypto_common.json
+++ b/schemas/json_web_crypto_common.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "JsonWebKey": {
+      "type": "object",
+      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
+      "properties": {
+        "alg": {
+          "type": "string",
+          "description": "the encryption/signing algorithm to use"
+        },
+        "use": {
+          "type": "string",
+          "description": "what type of crypto operation to perform",
+          "enum": [
+            "sig",
+            "enc"
+          ]
+        },
+        "key_ops": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description" : "an alternative to use"
+        },
+        "kid": {
+          "type": "string",
+          "description": "the ID of the key entry"
+        },
+        "kty": {
+          "type": "string",
+          "description": "the family of algorithms the key belongs to",
+          "enum": [
+            "oct",
+            "EC",
+            "RSA"
+          ]
+        },
+        "k": {
+          "type": "string",
+          "description": "the secret key value of an oct key"
+        },
+        "n": {
+          "type": "string",
+          "description": "the public modulus of an RSA key"
+        },
+        "e": {
+          "type": "string",
+          "description": "the public exponent of an RSA key"
+        },
+        "p": {
+          "type": "string",
+          "description": "the first prime factgor of an RSA key"
+        },
+        "q": {
+          "type": "string",
+          "description": "the second prime factor of an RSA key"
+        },
+        "dp": {
+          "type": "string",
+          "description": "the first factor Chinese Remainder Theorem exponent of an RSA key"
+        },
+        "dq": {
+          "type": "string",
+          "description": "the second factor Chinese Remainder Theorem exponent of an RSA key"
+        },
+        "qi": {
+          "type": "string",
+          "description": "the first factor Chinese Remainder Theorem coefficient of an RSA key"
+        },
+        "crv": {
+          "type": "string",
+          "description": "which defined curve to use",
+          "enum": [
+            "P-256",
+            "P-384",
+            "P-521",
+            "secp256k1"
+          ]
+        },
+        "x": {
+          "type": "string",
+          "description": "the x-coordinate of an EC key point"
+        },
+        "y": {
+          "type": "string",
+          "description": "the y-coordinate of an EC key point"
+        },
+        "d": {
+          "type": "string",
+          "description": "the private key value of an EC key or private exponent for RSA"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsonWebKeyset": {
+      "type": "object",
+      "description": "see https://tools.ietf.org/html/rfc7517#section-5",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JsonWebKey"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsonWebKeyOrKeyset": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/JsonWebKeyset"
+        },
+        {
+          "$ref": "#/definitions/JsonWebKey"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/json_web_crypto_schema.json
+++ b/schemas/json_web_crypto_schema.json
@@ -17,25 +17,11 @@
           "description": "a description of what these tests have in common"
         },
         "private": {
-          "oneOf" : [
-            {
-              "$ref": "#/definitions/JsonWebKeyset"
-            },
-            {
-              "$ref": "#/definitions/JsonWebKey"
-            }
-          ],
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKeyOrKeyset",
           "description": "the private or secret key in webcrypto format"
         },
         "public": {
-          "oneOf" : [
-            {
-              "$ref": "#/definitions/JsonWebKeyset"
-            },
-            {
-              "$ref": "#/definitions/JsonWebKey"
-            }
-          ],
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKeyOrKeyset",
           "description": "[optional] the public key in webcrypto format"
         },
         "tests": {
@@ -47,104 +33,6 @@
       },
       "additionalProperties": false,
       "required": ["source"]
-    },
-    "JsonWebKey": {
-      "type": "object",
-      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
-      "properties": {
-        "alg": {
-          "type": "string",
-          "description": "the encryption/signing algorithm to use"
-        },
-        "use": {
-          "type": "string",
-          "description": "what type of crypto operation to perform",
-          "enum": [
-            "sig",
-            "enc"
-          ]
-        },
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "oct",
-            "EC",
-            "RSA"
-          ]
-        },
-        "k": {
-          "type": "string",
-          "description": "the secret key value of an oct key"
-        },
-        "n": {
-          "type": "string",
-          "description": "the public modulus of an RSA key"
-        },
-        "e": {
-          "type": "string",
-          "description": "the public exponent of an RSA key"
-        },
-        "p": {
-          "type": "string",
-          "description": "the first prime factgor of an RSA key"
-        },
-        "q": {
-          "type": "string",
-          "description": "the second prime factor of an RSA key"
-        },
-        "dp": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "dq": {
-          "type": "string",
-          "description": "the second factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "qi": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem coefficient of an RSA key"
-        },
-        "crv": {
-          "type": "string",
-          "description": "which defined curve to use",
-          "enum": [
-            "P-256",
-            "P-384",
-            "P-521"
-          ]
-        },
-        "x": {
-          "type": "string",
-          "description": "the x-coordinate of an EC key point"
-        },
-        "y": {
-          "type": "string",
-          "description": "the y-coordinate of an EC key point"
-        },
-        "d": {
-          "type": "string",
-          "description": "the private key value of an EC key or private exponent for RSA"
-        }
-      },
-      "additionalProperties": false
-    },
-    "JsonWebKeyset": {
-      "type": "object",
-      "description": "see https://tools.ietf.org/html/rfc7517#section-5",
-      "properties": {
-        "keys": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/JsonWebKey"
-          }
-        }
-      },
-      "additionalProperties": false
     },
     "JsonWebCryptoTestVector": {
       "type": "object",

--- a/schemas/json_web_encryption_schema.json
+++ b/schemas/json_web_encryption_schema.json
@@ -17,12 +17,12 @@
           "description": "a description of what these tests have in common"
         },
         "private": {
-           "$ref": "#/definitions/JsonWebKey",
-           "description": "the private key"
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
+          "description": "the private key"
         },
         "public": {
-              "$ref": "#/definitions/JsonWebKey",
-              "description": "the [optional] public key"
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
+          "description": "the [optional] public key"
         },
         "tests": {
           "type": "array",
@@ -33,90 +33,6 @@
       },
       "additionalProperties": false,
       "required": ["source"]
-    },
-    "JsonWebKey": {
-      "type": "object",
-      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
-      "properties": {
-        "alg": {
-          "type": "string",
-          "description": "the encryption algorithm to use"
-        },
-        "use": {
-          "type": "string",
-          "description": "what type of crypto operation to perform",
-          "enum": [
-            "enc"
-          ]
-        },
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "oct",
-            "EC",
-            "RSA"
-          ]
-        },
-        "k": {
-          "type": "string",
-          "description": "the secret key value of an oct key"
-        },
-        "n": {
-          "type": "string",
-          "description": "the public modulus of an RSA key"
-        },
-        "e": {
-          "type": "string",
-          "description": "the public exponent of an RSA key"
-        },
-        "p": {
-          "type": "string",
-          "description": "the first prime factgor of an RSA key"
-        },
-        "q": {
-          "type": "string",
-          "description": "the second prime factor of an RSA key"
-        },
-        "dp": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "dq": {
-          "type": "string",
-          "description": "the second factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "qi": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem coefficient of an RSA key"
-        },
-        "crv": {
-          "type": "string",
-          "description": "which defined curve to use",
-          "enum": [
-            "P-256",
-            "P-384",
-            "P-521"
-          ]
-        },
-        "x": {
-          "type": "string",
-          "description": "the x-coordinate of an EC key point"
-        },
-        "y": {
-          "type": "string",
-          "description": "the y-coordinate of an EC key point"
-        },
-        "d": {
-          "type": "string",
-          "description": "the private key value of an EC key or private exponent for RSA"
-        }
-      },
-      "additionalProperties": false
     },
     "Recipient" : {
       "type" : "object",

--- a/schemas/json_web_key_schema.json
+++ b/schemas/json_web_key_schema.json
@@ -17,11 +17,11 @@
           "description": "a description of what these tests have in common"
         },
         "private": {
-          "$ref": "#/definitions/JsonWebKeyset",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKeyset",
           "description": "the private or secret keyset in webcrypto format"
         },
         "public": {
-          "$ref": "#/definitions/JsonWebKeyset",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKeyset",
           "description": "the public keyset in webcrypto format"
         },
         "tests": {
@@ -33,104 +33,6 @@
       },
       "additionalProperties": false,
       "required": ["source"]
-    },
-    "JsonWebKey": {
-      "type": "object",
-      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
-      "properties": {
-        "alg": {
-          "type": "string",
-          "description": "the encryption/signing algorithm to use"
-        },
-        "use": {
-          "type": "string",
-          "description": "what type of crypto operation to perform",
-          "enum": [
-            "sig",
-            "enc"
-          ]
-        },
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "oct",
-            "EC",
-            "RSA"
-          ]
-        },
-        "k": {
-          "type": "string",
-          "description": "the secret key value of an oct key"
-        },
-        "n": {
-          "type": "string",
-          "description": "the public modulus of an RSA key"
-        },
-        "e": {
-          "type": "string",
-          "description": "the public exponent of an RSA key"
-        },
-        "p": {
-          "type": "string",
-          "description": "the first prime factgor of an RSA key"
-        },
-        "q": {
-          "type": "string",
-          "description": "the second prime factor of an RSA key"
-        },
-        "dp": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "dq": {
-          "type": "string",
-          "description": "the second factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "qi": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem coefficient of an RSA key"
-        },
-        "crv": {
-          "type": "string",
-          "description": "which defined curve to use",
-          "enum": [
-            "P-256",
-            "P-384",
-            "P-521"
-          ]
-        },
-        "x": {
-          "type": "string",
-          "description": "the x-coordinate of an EC key point"
-        },
-        "y": {
-          "type": "string",
-          "description": "the y-coordinate of an EC key point"
-        },
-        "d": {
-          "type": "string",
-          "description": "the private key value of an EC key or private exponent for RSA"
-        }
-      },
-      "additionalProperties": false
-    },
-    "JsonWebKeyset": {
-      "type": "object",
-      "description": "see https://tools.ietf.org/html/rfc7517#section-5",
-      "properties": {
-        "keys": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/JsonWebKey"
-          }
-        }
-      },
-      "additionalProperties": false
     },
     "JsonWebKeyTestVector": {
       "type": "object",

--- a/schemas/json_web_signature_schema.json
+++ b/schemas/json_web_signature_schema.json
@@ -17,12 +17,12 @@
           "description": "a description of what these tests have in common"
         },
         "private": {
-          "$ref": "#/definitions/JsonWebKey",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "the private or secret key in webcrypto format"
         },
         "public": {
-           "$ref": "#/definitions/JsonWebKey",
-           "description": "[optional] the public key in webcrypto format"
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
+          "description": "[optional] the public key in webcrypto format"
         },
         "tests": {
           "type": "array",
@@ -33,94 +33,6 @@
       },
       "additionalProperties": false,
       "required": ["source"]
-    },
-    "JsonWebKey": {
-      "type": "object",
-      "description": "see https://tools.ietf.org/html/rfc7517#section-4 and https://tools.ietf.org/html/rfc7518#section-6",
-      "properties": {
-        "alg": {
-          "type": "string",
-          "description": "the signing algorithm to use"
-        },
-        "use": {
-          "type": "string",
-          "description": "what type of crypto operation to perform"
-        },
-        "key_ops": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description" : "an alternative to use"
-        },
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "oct",
-            "EC",
-            "RSA"
-          ]
-        },
-        "k": {
-          "type": "string",
-          "description": "the secret key value of an oct key"
-        },
-        "n": {
-          "type": "string",
-          "description": "the public modulus of an RSA key"
-        },
-        "e": {
-          "type": "string",
-          "description": "the public exponent of an RSA key"
-        },
-        "p": {
-          "type": "string",
-          "description": "the first prime factgor of an RSA key"
-        },
-        "q": {
-          "type": "string",
-          "description": "the second prime factor of an RSA key"
-        },
-        "dp": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "dq": {
-          "type": "string",
-          "description": "the second factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "qi": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem coefficient of an RSA key"
-        },
-        "crv": {
-          "type": "string",
-          "description": "which defined curve to use",
-          "enum": [
-            "P-256",
-            "P-384",
-            "P-521"
-          ]
-        },
-        "x": {
-          "type": "string",
-          "description": "the x-coordinate of an EC key point"
-        },
-        "y": {
-          "type": "string",
-          "description": "the y-coordinate of an EC key point"
-        },
-        "d": {
-          "type": "string",
-          "description": "the private key value of an EC key or private exponent for RSA"
-        }
-      },
-      "additionalProperties": false
     },
     "JsonWebSignatureTestVector": {
       "type": "object",

--- a/schemas/rsa_common.json
+++ b/schemas/rsa_common.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "PrivateKey": {
+      "type": "object",
+      "properties": {
+        "modulus": {
+          "type": "string",
+          "format": "BigInt"
+        },
+        "publicExponent": {
+          "type": "string",
+          "format": "BigInt"
+        },
+        "privateExponent": {
+          "type": "string",
+          "format": "BigInt"
+        },
+        "prime1": {
+          "type": "string",
+          "format": "BigInt"
+        },
+        "prime2": {
+          "type": "string",
+          "format": "BigInt"
+        },
+        "exponent1": {
+          "type": "string",
+          "format": "BigInt"
+        },
+        "exponent2": {
+          "type": "string",
+          "format": "BigInt"
+        },
+        "coefficient": {
+          "type": "string",
+          "format": "BigInt"
+        },
+        "otherPrimeInfos": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "Hex"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/rsaes_oaep_decrypt_schema.json
+++ b/schemas/rsaes_oaep_decrypt_schema.json
@@ -40,7 +40,7 @@
           "description": "The modulus of the key"
         },
         "privateKeyJwk": {
-          "$ref": "#/definitions/PrivateKeyJwkRsa"
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey"
         },
         "privateKeyPem": {
           "type": "string",
@@ -64,61 +64,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "PrivateKeyJwkRsa": {
-      "type": "object",
-      "properties": {
-        "alg": {
-          "type": "string",
-          "description": "the encryption/signing algorithm to use"
-        },
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "oct",
-            "EC",
-            "RSA"
-          ]
-        },
-        "n": {
-          "type": "string",
-          "description": "the public modulus of an RSA key"
-        },
-        "e": {
-          "type": "string",
-          "description": "the public exponent of an RSA key"
-        },
-        "p": {
-          "type": "string",
-          "description": "the first prime factor of an RSA key"
-        },
-        "q": {
-          "type": "string",
-          "description": "the second prime factor of an RSA key"
-        },
-        "dp": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "dq": {
-          "type": "string",
-          "description": "the second factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "qi": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem coefficient of an RSA key"
-        },
-        "d": {
-          "type": "string",
-          "description": "the private key value of an EC key or private exponent for RSA"
-        }
-      },
       "additionalProperties": false
     },
     "RsaesOaepTestVector": {

--- a/schemas/rsaes_oaep_decrypt_schema_v1.json
+++ b/schemas/rsaes_oaep_decrypt_schema_v1.json
@@ -25,7 +25,7 @@
           "description": "The hash function used for the message generating function."
         },
         "privateKey": {
-          "$ref": "#/definitions/PrivateKey"
+          "$ref": "rsa_common.json#/definitions/PrivateKey"
         },
         "privateKeyPem": {
           "type": "string",
@@ -52,54 +52,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "PrivateKey": {
-      "type": "object",
-      "properties": {
-        "modulus": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "privateExponent": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "publicExponent": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "prime1": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "prime2": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "exponent1": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "exponent2": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "coefficient": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "otherPrimeInfos": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "Hex"
-            }
-          }
-        }
-      },
       "additionalProperties": false
     },
     "RsaesOaepTestVector": {

--- a/schemas/rsaes_oaep_decrypt_schema_v1.json
+++ b/schemas/rsaes_oaep_decrypt_schema_v1.json
@@ -38,7 +38,7 @@
           "description": "Pkcs 8 encoded private key."
         },
         "privateKeyJwk": {
-          "$ref": "#/definitions/PrivateKeyJwkRsa"
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey"
         },
         "sha": {
           "type": "string",
@@ -98,61 +98,6 @@
               "format": "Hex"
             }
           }
-        }
-      },
-      "additionalProperties": false
-    },
-    "PrivateKeyJwkRsa": {
-      "type": "object",
-      "properties": {
-        "alg": {
-          "type": "string",
-          "description": "the encryption/signing algorithm to use"
-        },
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "oct",
-            "EC",
-            "RSA"
-          ]
-        },
-        "n": {
-          "type": "string",
-          "description": "the public modulus of an RSA key"
-        },
-        "e": {
-          "type": "string",
-          "description": "the public exponent of an RSA key"
-        },
-        "p": {
-          "type": "string",
-          "description": "the first prime factor of an RSA key"
-        },
-        "q": {
-          "type": "string",
-          "description": "the second prime factor of an RSA key"
-        },
-        "dp": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "dq": {
-          "type": "string",
-          "description": "the second factor Chinese Remainder Theorem exponent of an RSA key"
-        },
-        "qi": {
-          "type": "string",
-          "description": "the first factor Chinese Remainder Theorem coefficient of an RSA key"
-        },
-        "d": {
-          "type": "string",
-          "description": "the private key value of an EC key or private exponent for RSA"
         }
       },
       "additionalProperties": false

--- a/schemas/rsaes_pkcs1_decrypt_schema.json
+++ b/schemas/rsaes_pkcs1_decrypt_schema.json
@@ -28,7 +28,7 @@
           "description": "The modulus of the key"
         },
         "privateKeyJwk": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "JWK encoded private key"
         },
         "privateKeyPem": {

--- a/schemas/rsaes_pkcs1_decrypt_schema_v1.json
+++ b/schemas/rsaes_pkcs1_decrypt_schema_v1.json
@@ -16,7 +16,7 @@
           "$ref": "#/definitions/RsaPrivateKey"
         },
         "privateKeyJwk": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "JWK encoded private key"
         },
         "privateKeyPem": {

--- a/schemas/rsaes_pkcs1_decrypt_schema_v1.json
+++ b/schemas/rsaes_pkcs1_decrypt_schema_v1.json
@@ -13,7 +13,7 @@
           "$ref": "common.json#/definitions/Source"
         },
         "privateKey": {
-          "$ref": "#/definitions/RsaPrivateKey"
+          "$ref": "rsa_common.json#/definitions/PrivateKey"
         },
         "privateKeyJwk": {
           "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
@@ -41,44 +41,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "RsaPrivateKey": {
-      "type": "object",
-      "properties": {
-        "modulus": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "publicExponent": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "privateExponent": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "prime1": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "prime2": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "exponent1": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "exponent2": {
-          "type": "string",
-          "format": "BigInt"
-        },
-        "coefficient": {
-          "type": "string",
-          "format": "BigInt"
-        }
-      },
       "additionalProperties": false
     },
     "RsaesPkcs1TestVector": {

--- a/schemas/rsassa_pkcs1_generate_schema.json
+++ b/schemas/rsassa_pkcs1_generate_schema.json
@@ -33,7 +33,7 @@
           "description": "DER encoding of the public key"
         },
         "keyJwk": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "[Optional] Private key in JWK format"
         },
         "keyPem": {
@@ -56,7 +56,7 @@
           "description": "DER encoding of the PKCS8 private key"
         },
         "privateKeyJwk": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "[Optional] Private key in JWK format"
         },
         "privateKeyPem": {

--- a/schemas/rsassa_pkcs1_verify_schema.json
+++ b/schemas/rsassa_pkcs1_verify_schema.json
@@ -33,7 +33,7 @@
           "description": "ASN encoding of the public key"
         },
         "keyJwk": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "Public key in JWK format"
         },
         "keyPem": {

--- a/schemas/rsassa_pkcs1_verify_schema_v1.json
+++ b/schemas/rsassa_pkcs1_verify_schema_v1.json
@@ -43,7 +43,7 @@
           }
         },
         "keyJwk": {
-          "$ref": "#/definitions/PublicKeyJwkRsa"
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey"
         },
         "keySize": {
           "type": "integer",
@@ -61,35 +61,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "PublicKeyJwkRsa": {
-      "type": "object",
-      "properties": {
-        "alg": {
-          "type": "string",
-          "description": "the encryption/signing algorithm to use"
-        },
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "RSA"
-          ]
-        },
-        "n": {
-          "type": "string",
-          "description": "the public modulus of an RSA key"
-        },
-        "e": {
-          "type": "string",
-          "description": "the public exponent of an RSA key"
-        }
-      },
       "additionalProperties": false
     },
     "SignatureTestVector": {

--- a/schemas/rsassa_pss_verify_schema_v1.json
+++ b/schemas/rsassa_pss_verify_schema_v1.json
@@ -43,7 +43,7 @@
           "description": "Pem encoded public key"
         },
         "publicKeyJwk": {
-          "$ref": "#/definitions/PublicKeyJwkRsa"
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey"
         },
         "keySize": {
           "type": "integer",
@@ -73,35 +73,6 @@
         }
       },
       "required": ["source"],
-      "additionalProperties": false
-    },
-    "PublicKeyJwkRsa": {
-      "type": "object",
-      "properties": {
-        "alg": {
-          "type": "string",
-          "description": "the encryption/signing algorithm to use"
-        },
-        "kid": {
-          "type": "string",
-          "description": "the ID of the key entry"
-        },
-        "kty": {
-          "type": "string",
-          "description": "the family of algorithms the key belongs to",
-          "enum": [
-            "RSA"
-          ]
-        },
-        "n": {
-          "type": "string",
-          "description": "the public modulus of an RSA key"
-        },
-        "e": {
-          "type": "string",
-          "description": "the public exponent of an RSA key"
-        }
-      },
       "additionalProperties": false
     },
     "RsassaPssTestVector": {

--- a/schemas/xdh_jwk_comp_schema.json
+++ b/schemas/xdh_jwk_comp_schema.json
@@ -38,11 +38,11 @@
           "description": "A brief description of the test case"
         },
         "public": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "the public key in jwk format"
         },
         "private": {
-          "type": "object",
+          "$ref": "json_web_crypto_common.json#/definitions/JsonWebKey",
           "description": "the private key in jwk format"
         },
         "shared": {


### PR DESCRIPTION
This branch lifts out some common object schemas so they can be referenced across multiple schema files.

For JWKs there was a mix of two approaches in use prior to this branch:

1. Using a superset JWK schema for both public/private keys, and all supported algorithms/params.
2. Using more narrowly defined schemas (e.g. specifically a public key, or specifically an RSA public key)

For now I've centralized on the first approach and introduced a common superset definition, but if there's another preference I can revisit.

Resolves https://github.com/C2SP/wycheproof/issues/141