### PR TITLE
schemas: fix various typos

### DIFF
--- a/testvectors_v1/aead_aes_siv_cmac_test.json
+++ b/testvectors_v1/aead_aes_siv_cmac_test.json
@@ -21,7 +21,7 @@
     },
     "Pseudorandom" : {
       "bugType" : "FUNCTIONALITY",
-      "description" : "The test vector contains pseudorandomly generated inputs. The goal of the test vector is to check the correctness of the implementation for various sizes of the input parameters. Because of the S2V constrution it is possible to use IVs longer than a block size."
+      "description" : "The test vector contains pseudorandomly generated inputs. The goal of the test vector is to check the correctness of the implementation for various sizes of the input parameters. Because of the S2V construction it is possible to use IVs longer than a block size."
     }
   },
   "testGroups" : [

--- a/testvectors_v1/aes_wrap_test.json
+++ b/testvectors_v1/aes_wrap_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "CounterOverflow" : {
       "bugType" : "FUNCTIONALITY",
-      "description" : "The test vector contains a value that is long enough so that the round counter becames larger than 256."
+      "description" : "The test vector contains a value that is long enough so that the round counter becomes larger than 256."
     },
     "EmptyKey" : {
       "bugType" : "AUTH_BYPASS",

--- a/testvectors_v1/aria_wrap_test.json
+++ b/testvectors_v1/aria_wrap_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "CounterOverflow" : {
       "bugType" : "FUNCTIONALITY",
-      "description" : "The test vector contains a value that is long enough so that the round counter becames larger than 256."
+      "description" : "The test vector contains a value that is long enough so that the round counter becomes larger than 256."
     },
     "EmptyKey" : {
       "bugType" : "AUTH_BYPASS",

--- a/testvectors_v1/camellia_wrap_test.json
+++ b/testvectors_v1/camellia_wrap_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "CounterOverflow" : {
       "bugType" : "FUNCTIONALITY",
-      "description" : "The test vector contains a value that is long enough so that the round counter becames larger than 256."
+      "description" : "The test vector contains a value that is long enough so that the round counter becomes larger than 256."
     },
     "EmptyKey" : {
       "bugType" : "AUTH_BYPASS",

--- a/testvectors_v1/dsa_2048_224_sha224_p1363_test.json
+++ b/testvectors_v1/dsa_2048_224_sha224_p1363_test.json
@@ -8,7 +8,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences."
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences."
     },
     "IntegerOverflow" : {
       "bugType" : "CAN_OF_WORMS",
@@ -18,7 +18,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=1 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/dsa_2048_224_sha224_test.json
+++ b/testvectors_v1/dsa_2048_224_sha224_test.json
@@ -7,7 +7,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences."
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences."
     },
     "BerEncodedSignature" : {
       "bugType" : "BER_ENCODING",
@@ -33,7 +33,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=1 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -43,7 +43,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2022-24884"

--- a/testvectors_v1/dsa_2048_224_sha256_p1363_test.json
+++ b/testvectors_v1/dsa_2048_224_sha256_p1363_test.json
@@ -8,7 +8,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences."
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences."
     },
     "IntegerOverflow" : {
       "bugType" : "CAN_OF_WORMS",
@@ -18,7 +18,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=1 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/dsa_2048_224_sha256_test.json
+++ b/testvectors_v1/dsa_2048_224_sha256_test.json
@@ -7,7 +7,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences."
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences."
     },
     "BerEncodedSignature" : {
       "bugType" : "BER_ENCODING",
@@ -33,7 +33,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=1 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -43,7 +43,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2022-24884"

--- a/testvectors_v1/dsa_2048_256_sha256_p1363_test.json
+++ b/testvectors_v1/dsa_2048_256_sha256_p1363_test.json
@@ -8,7 +8,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences."
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences."
     },
     "IntegerOverflow" : {
       "bugType" : "CAN_OF_WORMS",
@@ -18,7 +18,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=1 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/dsa_2048_256_sha256_test.json
+++ b/testvectors_v1/dsa_2048_256_sha256_test.json
@@ -7,7 +7,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences."
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences."
     },
     "BerEncodedSignature" : {
       "bugType" : "BER_ENCODING",
@@ -33,7 +33,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=1 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -43,7 +43,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2022-24884"

--- a/testvectors_v1/dsa_3072_256_sha256_p1363_test.json
+++ b/testvectors_v1/dsa_3072_256_sha256_p1363_test.json
@@ -8,7 +8,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences."
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences."
     },
     "IntegerOverflow" : {
       "bugType" : "CAN_OF_WORMS",
@@ -18,7 +18,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=1 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/dsa_3072_256_sha256_test.json
+++ b/testvectors_v1/dsa_3072_256_sha256_test.json
@@ -7,7 +7,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences."
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences."
     },
     "BerEncodedSignature" : {
       "bugType" : "BER_ENCODING",
@@ -33,7 +33,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=1 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -43,7 +43,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2022-24884"

--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -34,7 +34,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha224_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha224_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -50,7 +50,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -60,7 +60,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha3_224_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha3_224_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -50,7 +50,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -60,7 +60,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -34,7 +34,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -50,7 +50,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -60,7 +60,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha3_256_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha3_256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -50,7 +50,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -60,7 +60,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -26,7 +26,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha384_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha3_384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha3_384_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -34,7 +34,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha384_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -50,7 +50,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -60,7 +60,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha3_384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha3_384_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -50,7 +50,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -60,7 +60,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha3_512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -50,7 +50,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -60,7 +60,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -34,7 +34,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -50,7 +50,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -60,7 +60,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -26,7 +26,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp160k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160k1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -26,7 +26,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp160r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160r1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -26,7 +26,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp160r2_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160r2_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -26,7 +26,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp192k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp192k1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -26,7 +26,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp192r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp192r1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -26,7 +26,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp224k1_sha224_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha224_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -26,7 +26,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp224k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -42,7 +42,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -52,7 +52,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp224r1_sha224_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha224_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp224r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224r1_sha3_224_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha3_224_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224r1_sha3_256_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha3_256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha3_512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp224r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp224r1_shake128_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_shake128_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp224r1_shake128_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_shake128_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
@@ -5,7 +5,7 @@
   "numberOfTests" : 463,
   "header" : [
     "Test vectors of type EcdsaBitcoinVerify are meant for the verification",
-    "of a ECDSA variant used for bitcoin, that add signature non-malleability."
+    "of a ECDSA variant used for Bitcoin, that add signature non-malleability."
   ],
   "notes" : {
     "ArithmeticError" : {
@@ -47,7 +47,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -57,7 +57,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]
@@ -95,8 +95,8 @@
     },
     "SignatureMalleabilityBitcoin" : {
       "bugType" : "SIGNATURE_MALLEABILITY",
-      "description" : "\"BitCoins\"-curves are curves where signature malleability can be a serious issue. An implementation should only accept a signature s where s < n/2. If an implementation is not meant for uses cases that require signature malleability then this implementation should be tested with another set of test vectors.",
-      "effect" : "In bitcoin exchanges, it may be used to make a double deposits or double withdrawals",
+      "description" : "Signature malleability can be a serious issue in Bitcoin. An implementation should only accept a signature s where s < n/2. If an implementation is not meant for use cases that require signature malleability then this implementation should be tested with another set of test vectors.",
+      "effect" : "In Bitcoin exchanges, it may be used to make a double deposits or double withdrawals",
       "links" : [
         "https://en.bitcoin.it/wiki/Transaction_malleability",
         "https://en.bitcoinwiki.org/wiki/Transaction_Malleability"

--- a/testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp256k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256k1_sha3_256_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha3_256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256k1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha3_512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp256k1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256k1_shake128_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_shake128_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp256k1_shake128_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_shake128_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256k1_shake256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_shake256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp256k1_shake256_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_shake256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp256r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256r1_sha3_256_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha3_256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha3_512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp256r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256r1_shake128_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_shake128_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp256r1_shake128_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_shake128_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp256r1_webcrypto_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_webcrypto_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp384r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp384r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha384_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp384r1_sha3_384_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha3_384_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp384r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha3_512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp384r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp384r1_shake256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_shake256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp384r1_shake256_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_shake256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp384r1_webcrypto_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_webcrypto_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp521r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha3_512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp521r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha512_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp521r1_shake256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_shake256_p1363_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/ecdsa_secp521r1_shake256_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_shake256_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -46,7 +46,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",
@@ -56,7 +56,7 @@
     "InvalidTypesInSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449"
       ]

--- a/testvectors_v1/ecdsa_secp521r1_webcrypto_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_webcrypto_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -30,7 +30,7 @@
     "InvalidSignature" : {
       "bugType" : "AUTH_BYPASS",
       "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
-      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
       "cves" : [
         "CVE-2022-21449",
         "CVE-2021-43572",

--- a/testvectors_v1/seed_wrap_test.json
+++ b/testvectors_v1/seed_wrap_test.json
@@ -9,7 +9,7 @@
   "notes" : {
     "CounterOverflow" : {
       "bugType" : "FUNCTIONALITY",
-      "description" : "The test vector contains a value that is long enough so that the round counter becames larger than 256."
+      "description" : "The test vector contains a value that is long enough so that the round counter becomes larger than 256."
     },
     "EmptyKey" : {
       "bugType" : "AUTH_BYPASS",


### PR DESCRIPTION
Some of these came up downstream, https://github.com/bitcoin-core/secp256k1/pull/1686, so just upstreaming the changes.