### PR TITLE
docs: improve signature malleability wording

### DIFF
--- a/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
@@ -95,7 +95,7 @@
     },
     "SignatureMalleabilityBitcoin" : {
       "bugType" : "SIGNATURE_MALLEABILITY",
-      "description" : "Signature malleability can be a serious issue in Bitcoin. An implementation should only accept a signature s where s < n/2. If an implementation is not meant for use cases that require signature malleability then this implementation should be tested with another set of test vectors.",
+      "description" : "Signature malleability can be a serious issue in Bitcoin. An implementation should only accept a signature s where s < n/2. If an implementation is meant for use cases that tolerate signature malleability then this implementation should not be tested with this set of test vectors.",
       "effect" : "In Bitcoin exchanges, it may be used to make a double deposits or double withdrawals",
       "links" : [
         "https://en.bitcoin.it/wiki/Transaction_malleability",


### PR DESCRIPTION
Apologies for the churn on this, but while [reviewing](https://github.com/bitcoin-core/secp256k1/pull/1711#discussion_r2230819323) the downstream PR to integrate #150, I noticed this comment seems incorrect.

I believe it should read something like the following to indicate these test vectors are only for implementations that _do not_ tolerate signature malleability (corroborated by another reviewer [here](https://github.com/bitcoin-core/secp256k1/pull/1711#discussion_r2239970542))  