### PR TITLE
Convert aes_siv_cmac_test to v1 format 

### DIFF
--- a/schemas/daead_test_schema_v1.json
+++ b/schemas/daead_test_schema_v1.json
@@ -1,0 +1,117 @@
+{
+  "type": "object",
+  "definitions": {
+    "DaeadTestGroup": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "DaeadTest"
+          ]
+        },
+        "source": {
+          "$ref": "common.json#/definitions/Source"
+        },
+        "keySize": {
+          "type": "integer",
+          "description": "the keySize in bits"
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DaeadTestVector"
+          }
+        }
+      },
+      "required": ["source"],
+      "additionalProperties": false
+    },
+    "DaeadTestVector": {
+      "type": "object",
+      "properties": {
+        "tcId": {
+          "type": "integer",
+          "description": "Identifier of the test case"
+        },
+        "comment": {
+          "type": "string",
+          "description": "A brief description of the test case"
+        },
+        "key": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the key"
+        },
+        "aad": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "additional authenticated data"
+        },
+        "msg": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the plaintext"
+        },
+        "ct": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the ciphertext including tag"
+        },
+        "result": {
+          "type": "string",
+          "description": "Test result",
+          "enum": [
+            "valid",
+            "invalid",
+            "acceptable"
+          ]
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of flags"
+        }
+      }
+    },
+    "additionalProperties": false
+  },
+  "properties": {
+    "algorithm": {
+      "type": "string",
+      "description": "the primitive tested in the test file"
+    },
+    "generatorVersion": {
+      "type": "string",
+      "description": "DEPRECATED: prefer \"source\" property in test group",
+      "deprecated": true
+    },
+    "header": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "additional documentation"
+    },
+    "notes": {
+      "$ref": "common.json#/definitions/Notes"
+    },
+    "numberOfTests": {
+      "type": "integer",
+      "description": "the number of test vectors in this test"
+    },
+    "schema": {
+      "enum": [
+        "daead_test_schema_v1.json"
+      ]
+    },
+    "testGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DaeadTestGroup"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/testvectors_v1/aes_siv_cmac_test.json
+++ b/testvectors_v1/aes_siv_cmac_test.json
@@ -1,0 +1,4200 @@
+{
+  "algorithm" : "AES-SIV-CMAC",
+  "numberOfTests" : 442,
+  "header" : [
+    "Test vectors of type DaeadTest are intended for verifying",
+    "encryption and decryption of deterministic authenticated encryption",
+    "with additional data."
+  ],
+  "notes" : {
+    "EdgeCaseSiv" : "The SIV of this test vector has an edge case value. One purpose of these test vectors is to detect implementations where integer overflows of the counter is incorrectly implemented. AES-SIV itself prevents such overflow problems by clearing some msbs in the IV."
+  },
+  "schema" : "daead_test_schema.json",
+  "testGroups" : [
+    {
+      "keySize" : 256,
+      "type" : "DaeadTest",
+      "source" : {
+        "name" : "google-wycheproof",
+        "version" : "0.8r12"
+      },
+      "tests" : [
+        {
+          "tcId" : 1,
+          "comment" : "RFC 5297",
+          "key" : "fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+          "aad" : "101112131415161718191a1b1c1d1e1f2021222324252627",
+          "msg" : "112233445566778899aabbccddee",
+          "ct" : "85632d07c6e8f37f950acd320a2ecc9340c02b9690c4dc04daef7f6afe5c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 2,
+          "comment" : "empty message",
+          "key" : "2b27e429fb6c02678e589ccc4437c5adfb44b331ab6d21ea321727e6ec03d354",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "b2b2354e3724dcdaa85ecf029b49a90c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 3,
+          "comment" : "empty message",
+          "key" : "e40992eb4f649e5d49134652aecc24bafa6b45ce8dd9e9d371ede7d5de84fa72",
+          "aad" : "8268c5194a71aed0fc1dafe3",
+          "msg" : "",
+          "ct" : "92bc07ee200fbd488b7f70a10da26a21",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 4,
+          "comment" : "empty message",
+          "key" : "99037935e620da1d67faf1e26d5a0e2c5ac2eae5eec7cbb7b7a613056f6719e3",
+          "aad" : "24ab40e7966c5bfe8a5d2b0a6a9765",
+          "msg" : "",
+          "ct" : "f44934d6f5ba77122f198599cd0e5e52",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 5,
+          "comment" : "empty message",
+          "key" : "7bf9e536b66a215c22233fe2daaa743a898b9acb9f7802de70b40e3d6e43ef97",
+          "aad" : "9ffff196befb5ffba01afa9235418d57",
+          "msg" : "",
+          "ct" : "c11ab0ae193018d2c9c7985aec3f8a5b",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 6,
+          "comment" : "empty message",
+          "key" : "ea7081db53ce49559f9fd2b53e00f91b68c2bdba946961da1a5bc70918297a43",
+          "aad" : "a9efd155159b533f2b649b2e5fbf87e6a2c11ee8",
+          "msg" : "",
+          "ct" : "cf52a3c9e2d3d99a66f74135f39e28bb",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 7,
+          "comment" : "empty message",
+          "key" : "1e225cafb90339bba1b24076d4206c3e79c355805d851682bc818baa4f5a7779",
+          "aad" : "896dcdb367f3c76d60093dc5ae09bc4f30e5cb88e3434e6eb0f0700ac752cd97",
+          "msg" : "",
+          "ct" : "8f603b65e767ef178b4dd11db6c114c1",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 8,
+          "comment" : "message size divisible by block size",
+          "key" : "612e837843ceae7f61d49625faa7e7494f9253e20cb3adcea686512b043936cd",
+          "aad" : "865d39ae9b5e9ff8d6308e00208745bc",
+          "msg" : "cc37fae15f745a2f40e2c8b192f2b38d",
+          "ct" : "c79c86cd7509e60a16ca8cec6bcaa1c58fbd6099718991fe775bf5a659d30a24",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 9,
+          "comment" : "message size divisible by block size",
+          "key" : "96e1e4896fb2cd05f133a6a100bc5609a7ac3ca6d81721e922dadd69ad07a892",
+          "aad" : "8ee21f1a5e2b3f8b8f2064e5cecac81d",
+          "msg" : "91a17e4dfcc3166a1add26ff0e7c12056e8a654f28a6de24f4ba739ceb5b5b18",
+          "ct" : "849195031e8927a1af4f64cbdd8048461c03598bfba441312776a4e8ac959bee44c521801287a2fd95e2329b1c694441",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 10,
+          "comment" : "message size divisible by block size",
+          "key" : "649e373e681ef52e3c10ac265484750932a9918f28fb824f7cb50adab39781fe",
+          "aad" : "3a8363f51bce891eba7bcc0aa4311e10",
+          "msg" : "39b447bd3a01983c1cb761b456d69000948ceb870562a536126a0d18a8e7e49b16de8fe672f13d0808d8b7d957899917",
+          "ct" : "9f66765a019277a7a7acb92e80f8300baa724c92560951eb09d855f471fe1b589928e51f7a8a4bbc6cc9f55fabb2eca2ebb4faca14d1ae20cfdc31b9602e9891",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 11,
+          "comment" : "small plaintext size",
+          "key" : "298962335a075e9eacb7a7627beafa4ee5a02242423cdfb0b4f106eb61cf5663",
+          "aad" : "4c375fd3c4d45c5cfff16d55",
+          "msg" : "49",
+          "ct" : "f5c8155c7dd7f47c61d980ccd2175beb9b",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 12,
+          "comment" : "small plaintext size",
+          "key" : "ea1a7831e6fd080456507a996b6d71668c2cec43c757539c3b5342fadbe64dc4",
+          "aad" : "599f61c649e7cc5cbbd7a78f",
+          "msg" : "7c0c",
+          "ct" : "130e8de11080a3b27cc1ef1272586c24717c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 13,
+          "comment" : "small plaintext size",
+          "key" : "009e8288da0a3d22aeaa231fbbfde9ed901d22df9f3ab707e15aa2fc390d0679",
+          "aad" : "9a582245b46c6170e3f5ca53",
+          "msg" : "2f5c53",
+          "ct" : "b98902dc89e6811dfba5eafb1561186dc1849e",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 14,
+          "comment" : "small plaintext size",
+          "key" : "b6202ef3dad5a42667f020f0e4bd89d845711da77f98c747eb914de869638bcf",
+          "aad" : "eab41f3417c79bc7262c7b64",
+          "msg" : "41ec7178",
+          "ct" : "cd824717886f3363622937bcd118960a0e2605fe",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 15,
+          "comment" : "small plaintext size",
+          "key" : "fa82aef8c8d6e3cd8f8d053ea6b1b07ca3bc0152506d464926630d6fd83e8a72",
+          "aad" : "e9a4b08a8e2ebbb13f82f870",
+          "msg" : "ebe656a97b",
+          "ct" : "85288834b25f27e96083e2f360d3c7e7486519b4f5",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 16,
+          "comment" : "small plaintext size",
+          "key" : "4ed237ae3d066df766bea923116bf9d2ce6f63d34a4f56ed8631baccabd70647",
+          "aad" : "fca537f50d5fce3cdc994b70",
+          "msg" : "82f0d49b77a5",
+          "ct" : "9acd6ee8a827c2c5d0da7bf7815dbd8511bd8c5a79c1",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 17,
+          "comment" : "small plaintext size",
+          "key" : "56df5d41a110a63acc7b7c045be9f35a8f2faf16d83fb559268eb8963484f552",
+          "aad" : "95dceafcd426a9bcbe99b842",
+          "msg" : "1d635248014c3b",
+          "ct" : "f7c739f6a0e20e94265ecbbdaec36cd597088967917d47",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 18,
+          "comment" : "small plaintext size",
+          "key" : "2e94a84c78be80cd598366058d4f6cdf8095666dcac7a00ad832d9f33e20d13c",
+          "aad" : "0c784125715b7f9b1067b077",
+          "msg" : "b978587bf028558d",
+          "ct" : "163833ac904d30589cad9a002bd702f5c7809b04693fd8fb",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 19,
+          "comment" : "small plaintext size",
+          "key" : "60bf711a162cf6a1b108d1351f9fd2ee5022a9df3c5e494268226b17518a93b7",
+          "aad" : "53353976f18ae8c8cbc7e066",
+          "msg" : "078a6a3d7d1d312004",
+          "ct" : "87a37e3de3690b11fba089c068e1c1ea17a4d05ecfb0a97631",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 20,
+          "comment" : "small plaintext size",
+          "key" : "5aadf8dd380e4287582155f11165b31dc8ed76946889a2bb8633990fb62fc46f",
+          "aad" : "0baed8c06718697b4e845acb",
+          "msg" : "435e101a1a4416abe5ce",
+          "ct" : "1ee7891afbc92d52282eb3fdada6f886ae613f6d60e5d8c1a3a6",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 21,
+          "comment" : "small plaintext size",
+          "key" : "b099c4a613f5efda82b069d9a76c02a4049c12310e25f272dbd9d155aedd8d52",
+          "aad" : "30699dc6f497215acda15441",
+          "msg" : "ccb3e3e1bbf6c3b03c257b",
+          "ct" : "a78a01331bb6da90967319859434dbfdd2f9b9c68265c190e28ba3",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 22,
+          "comment" : "small plaintext size",
+          "key" : "dd0655b5099c4acb60c8afacede1b6ac04283c4fcdd1fee2f5aaa6d86bf6c025",
+          "aad" : "164400936032de67a4660b87",
+          "msg" : "6c9a0029bfc98973676d4208",
+          "ct" : "1a104a2de459a3aa9f7b501438b120602de27a8d259ae4f58ef50294",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 23,
+          "comment" : "small plaintext size",
+          "key" : "aa6285693fc40a59ebc2bdab16f1e9111ec794ce5ec63b8f89fafe1b7fedfacf",
+          "aad" : "009002fcf132820ad3838938",
+          "msg" : "9e9813cd498166220bd0d49da9",
+          "ct" : "3d8175b843301690089b8aa54136d698ccd3d88a5d02a3a65f2b115b00",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 24,
+          "comment" : "small plaintext size",
+          "key" : "18a4688da2ad1e112ea56ef6da9107e0f1094eeed3f6b868202952d56e0f8239",
+          "aad" : "52dfc32bab8bc1502d18a334",
+          "msg" : "2e7a1b4c808c1cf4e64e8c5ce54f",
+          "ct" : "9fc042a08918741e2b7beab9cd79d7626214d8960091cf305256e549ee36",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 25,
+          "comment" : "small plaintext size",
+          "key" : "95b330aa5fffa6c0e29fd6fa0debdcb9cf6b448820bea24875089ec8ca5a2387",
+          "aad" : "4dbf5c20ce4caeedfefcae1d",
+          "msg" : "c96596ebba6f89761b9d14dfcc8fb4",
+          "ct" : "91a7f5c4585351b8b76d4a4836a3199aa761e5f9ee1cdd84258a6a3696f7e9",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 26,
+          "comment" : "plaintext size > 16",
+          "key" : "b3b7c2c6d3d80918218afcd8bf2a71cf0220e2e8084ead8ba1abfb893ae36d40",
+          "aad" : "a5c2f6cf309f29c25f5ce35d",
+          "msg" : "dbcf98254157727c35f367fe6e15a2d089",
+          "ct" : "96bf5dd0c28dbd6072b70e2b5b72d3eb9f41adc6d5d877e808fbf15ed4117b5007",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 27,
+          "comment" : "plaintext size > 16",
+          "key" : "2700a20ef5c3eb4df123568d0df042c35d32b42437efb1032a6a1fe5359767cc",
+          "aad" : "e40e09fea86442dcf2cd176d",
+          "msg" : "3de21865217c94c4f82208ccd62ad57f13ba1f5e",
+          "ct" : "be366ca76d9afe36c7d017c1221e1be41a594e1d853574c06d235775b71cc0b56a7da631",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 28,
+          "comment" : "plaintext size > 16",
+          "key" : "cc5d599aecbed35bb4e13a2f79586dfe42e6382e8fa8326b674f34716d6376f2",
+          "aad" : "34eafb781863d85649f8c9b0",
+          "msg" : "8a69fb2ab53b995daf2cd43fc316690f71e171ffc5ab84f68bae3c038a9fd7",
+          "ct" : "73fb501f903d90c35039c065563a0b8f274610f05b8d988a193460658d325a255e808847f3faf937e0354a93201ab0",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 29,
+          "comment" : "plaintext size > 16",
+          "key" : "71a7adc7222f471c28f682c12d45feed45556000a986035922924ad154ba5fa5",
+          "aad" : "46a65672d2699267ab27da82",
+          "msg" : "227e714e3efa84e48049142edaa311dab285407f9b628b146f1d6132c2500ca28497fbd6e386679c",
+          "ct" : "b30ec3b9c85402c356728391acf04fcc0d02ba85b6a9e90cf846155d4ab3158952bd1791885370bf23ba26d8d23359637b6e24e8763ed107",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 30,
+          "comment" : "plaintext size > 16",
+          "key" : "83bc39bf7b5faaf0f9223ed2aa761ab32c04993e3fbccd34ee616ffd28ce5766",
+          "aad" : "ed9ec561ecf5e289a1516c9f",
+          "msg" : "f70ef1598f403902dcab4cc23bb1265f34e825b99abc61b26a22b9bbf478c3c1e61e67e98201bc564d022b87b4106aad0c4ca2d30e8927fba5b52a76971ef79a92a1eb6cf4ef87aea6b551567a2c4c41",
+          "ct" : "fafea55bba0680a510ce095d5c8a40a84a76071b8938dcfe99c8c73b049230ac52df7e09769852a6057353a7df7b8d18882ce5369c6bb855f271d88108719a1b5ea5765f549c282639c8bfacc34b5b10991b8fbdae2e42429fb7f0554e0e5611",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 31,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "1d7f9cc81b316c518efcd7927e8f7b88",
+          "ct" : "00000000000000000000000000000000f0dcac3115ddbd3d8ec28822e54088d0",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 32,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "f16d4958e933778c54aabcd6fda1cabc",
+          "ct" : "000000000000000000000000000000001cce79a1e7dfa6e05494e366666e39e4",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 33,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "110d3aa6f558c30977870672804064e0",
+          "ct" : "ffffffffffffffffffffffffffffffff01f74b8e43a262001d8357f95489432e",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 34,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "fd1fef36075ad8d4add16d36036ed5d4",
+          "ct" : "ffffffffffffffffffffffffffffffffede59e1eb1a079ddc7d53cbdd7a7f21a",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 35,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "c83e256ba8baec0938e51a60bd819cc1",
+          "ct" : "ffffffffffffffffffffffff7fffffffd8c454431e404d0052e14beb6948bb0f",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 36,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "242cf0fb5ab8f7d4e2b371243eaf2df5",
+          "ct" : "ffffffffffffffffffffffff7fffffff34d681d3ec4256dd88b720afea660a3b",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 37,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "d8c89e8ece83de437eac13ca7b1ebb2c",
+          "ct" : "ffffffffffffffff7fffffffffffffffc832efa678797f4a14a84241afd79ce2",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 38,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "34da4b1e3c81c59ea4fa788ef8300a18",
+          "ct" : "ffffffffffffffff7fffffffffffffff24203a368a7b6497cefe29052cf92dd6",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 39,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "b076687f33460af32b7f0edc3304bfff",
+          "ct" : "fffffffffffffffffffffffffffffffee2149531223f5703d3cce887d0dfe544",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 40,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "5c64bdefc144112ef1296598b02a0ecb",
+          "ct" : "fffffffffffffffffffffffffffffffe0e0640a1d03d4cde099a83c353f15470",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 41,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "656a1c3efeb7d2589bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 42,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "45c0cc09b8cc0c37f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 43,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "61e80297b0ba41c54eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 44,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "10ecf972c00209652ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 45,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "666a1c3efeb7d2589bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 46,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "46c0cc09b8cc0c37f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 47,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "62e80297b0ba41c54eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 48,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "13ecf972c00209652ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 49,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e46a1c3efeb7d2589bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 50,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "c4c0cc09b8cc0c37f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 51,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e0e80297b0ba41c54eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 52,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "91ecf972c00209652ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 53,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646b1c3efeb7d2589bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 54,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c1cc09b8cc0c37f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 55,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e90297b0ba41c54eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 56,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11edf972c00209652ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 57,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1cbefeb7d2589bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 58,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc89b8cc0c37f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 59,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80217b0ba41c54eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 60,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf9f2c00209652ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 61,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3effb7d2589bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 62,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b9cc0c37f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 63,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b1ba41c54eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 64,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c10209652ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 65,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efcb7d2589bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 66,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09bacc0c37f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 67,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b2ba41c54eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 68,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c20209652ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 69,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2d89bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 70,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0cb7f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 71,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41454eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 72,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209e52ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 73,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589afdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 74,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f9626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 75,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54fda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 76,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652fa6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 77,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2581bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 78,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c3778626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 79,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c5ceda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 80,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c0020965aea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 81,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bddd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 82,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8426b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 83,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54efa58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 84,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652e86ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 85,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bfdd1892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 86,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8626a36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 87,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54eda59c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 88,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652ea6ee4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 89,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bfdd0892dc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 90,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8626b36dbb95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 91,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54eda58c469502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 92,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652ea6ef4a3a46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 93,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bfdd0892ec86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 94,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8626b36d8b95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 95,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54eda58c46a502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 96,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652ea6ef4a3946ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 97,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bfdd089acc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 98,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8626b365ab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 99,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54eda58c4e8502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 100,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652ea6ef4abb46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 101,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bfdd0892cc86922",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 102,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8626b36dab95df22aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 103,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54eda58c468502b33da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 104,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652ea6ef4a3b46ea2259e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 105,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bfdd0892cc86921",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 106,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8626b36dab95df12aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 107,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54eda58c468502b30da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 108,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652ea6ef4a3b46ea2159e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 109,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bfdd0892cc86963",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 110,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8626b36dab95db32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 111,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54eda58c468502b72da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 112,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652ea6ef4a3b46ea6359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 113,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2589bfdd0892cc869a3",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 114,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0c37f8626b36dab95d732aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 115,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41c54eda58c468502bb2da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 116,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209652ea6ef4a3b46eaa359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 117,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "656a1c3efeb7d2589afdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 118,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "45c0cc09b8cc0c37f9626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 119,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "61e80297b0ba41c54fda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 120,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "10ecf972c00209652fa6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 121,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1cbefeb7d2d89bfdd0892cc86923",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 122,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc89b8cc0cb7f8626b36dab95df32aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 123,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80217b0ba41454eda58c468502b32da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 124,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf9f2c00209e52ea6ef4a3b46ea2359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 125,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "646a1c3efeb7d2d89bfdd0892cc869a3",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 126,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "44c0cc09b8cc0cb7f8626b36dab95d732aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 127,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "60e80297b0ba41454eda58c468502bb2da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 128,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "11ecf972c00209e52ea6ef4a3b46eaa359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 129,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "9b95e3c101482da764022f76d33796dc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 130,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "bb3f33f64733f3c8079d94c92546a20c2aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 131,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "9f17fd684f45be3ab125a73b97afd4cdda4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 132,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "ee13068d3ffdf69ad15910b5c4b915dc59e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 133,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "00000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 134,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "000000000000000000000000000000002aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 135,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "00000000000000000000000000000000da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 136,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "0000000000000000000000000000000059e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 137,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 138,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "ffffffffffffffffffffffffffffffff2aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 139,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "ffffffffffffffffffffffffffffffffda4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 140,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "ffffffffffffffffffffffffffffffff59e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 141,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e4ea9cbe7e3752d81b7d5009ac48e9a3",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 142,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "c4404c89384c8cb778e2ebb65a39dd732aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 143,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e0688217303ac145ce5ad844e8d0abb2da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 144,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "916c79f2408289e5ae266fcabbc66aa359e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 145,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "656b1d3fffb6d3599afcd1882dc96822",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 146,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "45c1cd08b9cd0d36f9636a37dbb85cf22aa03ceafa0e45e6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 147,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "61e90396b1bb40c44fdb59c569512a33da4e0efa57352f1a114e4b3f0cb234c6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 148,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "10edf873c10308642fa7ee4b3a47eb2259e6faebd6af7063c8660362866f1b2af53a989e",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "keySize" : 384,
+      "type" : "DaeadTest",
+      "source" : {
+        "name" : "google-wycheproof",
+        "version" : "0.8r12"
+      },
+      "tests" : [
+        {
+          "tcId" : 149,
+          "comment" : "empty message",
+          "key" : "d3d58a2f21e62f5095542e618168ef040922ab7d80b3840055eb9caf5726a8d4a7f071dc40ddb320effc094211735090",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "59e0a9a04cdb1d9d7bee6be8bb06fd61",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 150,
+          "comment" : "empty message",
+          "key" : "ad0f7862386c35fee128ae7ff18db084a0f457fcfc7fe1c5370b145f7fa645a97ba3eb4f90e18941b18e8d89494ec796",
+          "aad" : "b402ae880487cfaa9314549b",
+          "msg" : "",
+          "ct" : "b50be5e46a3912dcacff27115e209e24",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 151,
+          "comment" : "empty message",
+          "key" : "278e770ca600bb23f5d8725bfd0cfc05b91057e79c890a697d41e9ff687c6a14ea48fb228d7f95ab4a93c5ba9d966262",
+          "aad" : "3f33c781ea57ec1c298f402cbbd27e",
+          "msg" : "",
+          "ct" : "2aec07db61e8e403fa04659921ccaf65",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 152,
+          "comment" : "empty message",
+          "key" : "5ad985b9bcb461f9115937b6bde7073fbed9e8bf32245afe5836e8c2f67b3999266ba0d8d9eba6fa978c47ea9ef4690a",
+          "aad" : "bd2aa07a70aca69c4621d91a6686f42a",
+          "msg" : "",
+          "ct" : "863161c67e86648340fc5eab9fb728a7",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 153,
+          "comment" : "empty message",
+          "key" : "b65c2a4f88f733142cc66ed9aff47e77f3a6339d30e030290d34be40dfa7b33e37bc2f48ea8617f4e7d60c28c0c01a0d",
+          "aad" : "9ce588daa79d6825305a97572d27674a9602bfeb",
+          "msg" : "",
+          "ct" : "4c9cb52e91ee8fd784e9901b2bbfd07e",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 154,
+          "comment" : "empty message",
+          "key" : "4cd9d4d729792e6a599bd59c330ae8a4df4077225c9c633cb59190f3a5d1150fdc38a7fbc687516f82d6354e57281c1a",
+          "aad" : "960dbaaff375101529f193a5b7adc2cd95a36b7222df7e9f6fbf3110e16462a1",
+          "msg" : "",
+          "ct" : "fffc486f0299703902926186e43932d0",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 155,
+          "comment" : "message size divisible by block size",
+          "key" : "ca9db62214c3afab385b9086f1cb90d17195d495ef47642dbad06f4e7d0bab136c77885029ad442b30c34c8b5290e7d0",
+          "aad" : "d4dbfdce11f1147e29dd062ea3bbbd17",
+          "msg" : "ded5a13d759903ecd36cb238527776c6",
+          "ct" : "a4e08bdd8ab8cbef46e0fdb8a7ca1097a8f963e45e554a5882496270f9fd6de8",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 156,
+          "comment" : "message size divisible by block size",
+          "key" : "c4bb58d73a61eeef0ec23490dc3c3a3e140244c9be88209658cc5654a996db2372c2212ffdc260bbdb92a520c86f96d8",
+          "aad" : "2e4b50221284bc07d7e30b1a6621676d",
+          "msg" : "d0535403fed2c1dec9f858eebd688afe4d0010b2823275d1bacfd564c074415f",
+          "ct" : "0131705a9a6c645f13fe4679bd03daac234bc11db1f0941be0788c1c14bbf95ef1dbfbdf5af786a5a5a3a7d4f35fd169",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 157,
+          "comment" : "message size divisible by block size",
+          "key" : "9eae72a3964bdf14adef8616aa5441577b7bbc324652516b4c29a7b0f3bfa719be49e3d2ae6297588ada652eb45b0a00",
+          "aad" : "999a35705530c2f6a7f2427d6b258836",
+          "msg" : "cd9bfe9821b1a5895737a827b41e0ee271ab2687128bb87f173709b73bf18c7c25822f32282895ca8935db00a1d171db",
+          "ct" : "d237a9dd9ea0f70ebc5526fd5e414f318c8a016bc6ecbcb3de5f0aff9330259e67b4984f13fb7e904ae8ac91d8e35faf41ad860bc9423d2ef596c13e15025cdf",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 158,
+          "comment" : "small plaintext size",
+          "key" : "ba783a715ff6ee6d71e3a4a7adb6356687db12cc2954807099f97471c951c7f0c33571d3334d111c4ea33a12365c0061",
+          "aad" : "06b2cd261a3508a7bfd1c049",
+          "msg" : "7e",
+          "ct" : "002abeac978f66d934b9ed06f215c4951d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 159,
+          "comment" : "small plaintext size",
+          "key" : "b5ba35a597be37f8f8168a40e9f47b96077ceced6ac0968a4e5ffabc402199267bcd4f740640c6877441c63e8015d86c",
+          "aad" : "90f605a2cf3ff6e79d6ad4b9",
+          "msg" : "5bff",
+          "ct" : "ae43eb59494a5fe7a7cac8d5d20f7d40177f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 160,
+          "comment" : "small plaintext size",
+          "key" : "17a44937a1f8b8029a7f64137eaa2d7de950b49b0ef2d83994151c7b9dde2e87c5aa3debfa0ad9f028260c6dc2fc7e01",
+          "aad" : "80235b12c840e3fd50dc62fd",
+          "msg" : "8b2a68",
+          "ct" : "6b8c54cd6d99f5470a2461aef614012cee7341",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 161,
+          "comment" : "small plaintext size",
+          "key" : "bff684f086ef3314211ba782a2e7e75a60a9a3df9fc505057f54e2b264fbe2e5eae299879fccd26ca39d1e33b883966e",
+          "aad" : "43634a3668f78c0b00597166",
+          "msg" : "41a1241d",
+          "ct" : "ad0d302a322ca73b5514d8cfd6d40478fc60aee6",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 162,
+          "comment" : "small plaintext size",
+          "key" : "379c425581ca8094e47d1ee49fe9a5dd3dd8d68c6c85f8b4cb56849e99698ee73332c8b0cc6da0627c95f2de9ddd0871",
+          "aad" : "26306f1d6a4316522a928715",
+          "msg" : "22faba3076",
+          "ct" : "717e9e25286ac7eb4d5aa50e613046c4296f693bf4",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 163,
+          "comment" : "small plaintext size",
+          "key" : "0f11a54e9f03071828944e39a3f5a5538c4c94122e757aa7062afdb90d5e8b4aeb41e681818a149831ab7b25e2ca3b96",
+          "aad" : "8ff666163c2af99f3e653b38",
+          "msg" : "2ef90d77c725",
+          "ct" : "c11178fb46a4334df8044ca1746ddd129ca6185d21e1",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 164,
+          "comment" : "small plaintext size",
+          "key" : "e959e0c14f3e0d8dd44162d27f4c333a337332550167731949c6732b23a5dbd9aa3dd801b66543755474f44774e5d823",
+          "aad" : "e5cb907e8df42f0e568e588a",
+          "msg" : "8f1dbfb8c9dd6a",
+          "ct" : "533fa1781af3a3679e5779c9c7c727fa5a1d20d7a89f6c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 165,
+          "comment" : "small plaintext size",
+          "key" : "fe6412c43463c22b98992f8c319b662718255d12277ce62e56ba258ccc7a4694121e6912ed745b4a6e12ff9d38c86ef2",
+          "aad" : "825d771373d6e019043dd2a0",
+          "msg" : "3da09c275906835f",
+          "ct" : "0528c021158609e07d3c71fd363365a644ca61b932c161ba",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 166,
+          "comment" : "small plaintext size",
+          "key" : "71002b321b1e924a45d97302a08f2361af1d2093faf661f04ab47ecca9f5ec9a35be3ccff8a4aed1ff658d195c05aed7",
+          "aad" : "987604cee29b9ee32f26f332",
+          "msg" : "cf1e93a067ed6b4f26",
+          "ct" : "4f4d3533c0a6d2302cc3ce547ca78f1d6dce6f333cca0fe889",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 167,
+          "comment" : "small plaintext size",
+          "key" : "dff1d025a8b62dfbe8fd7d0480e572f1c5e125c1ab4c148e37ff9a8ec5d8a4cf35bc304445be3bc45ed37f92e032af14",
+          "aad" : "80b9534f1e83598235c85690",
+          "msg" : "b81cc3a382a1ad29c1dd",
+          "ct" : "c4c97f0c3530981bcade42a174a65038d8925ed8a5decee8a7c6",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 168,
+          "comment" : "small plaintext size",
+          "key" : "dae6920703b80500b4197269faf5d74de8e610415e194b423080ebaf6d99873dc307dc4f6d9f32ad0ebad8ad7852690c",
+          "aad" : "1b7a5ce2ff405b019125910b",
+          "msg" : "962c7c7ca5bdfcbcb3eba4",
+          "ct" : "2d60ae19a38f400e0ed78b65db3df852f41f0d1e22c917b42e7c5a",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 169,
+          "comment" : "small plaintext size",
+          "key" : "e69ea366fd385e0ed8b9cbb01700654fa28add8e56b7ea683e1fd718511ab0fb22dcd710c530e00fb66f4584fa21e9e6",
+          "aad" : "b55d19772f2776772c04078a",
+          "msg" : "3c32cafeedcce54108e39588",
+          "ct" : "b97290f5f225d05b40704c53ee8fdfcffd972185aa96d4db4b8ddb16",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 170,
+          "comment" : "small plaintext size",
+          "key" : "b60b83856f56cdf89027460a76993fdbde0f2ab01e9dde2fa7c27ef47155ec7caba892b27fd9a31e8923bfc44794cd71",
+          "aad" : "b60c69a4befed39eac27790b",
+          "msg" : "550d0e8b8373a27e4072a5b76c",
+          "ct" : "0afe675b5b92febddc6bd6d450715ad4da97711bfbf3465da408517401",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 171,
+          "comment" : "small plaintext size",
+          "key" : "859698a852a131a3804838f3d012d6088e135b6db160b2ac68e6dfa6ec330dc0d682e406c87c15b9a74affe441749495",
+          "aad" : "29d834bc7bdd2a3e95ae8308",
+          "msg" : "c969bd4b5acf1f7b500f8f21f3c9",
+          "ct" : "92e143e457be47a18ca6827811320ce9c70a1b4e0ef64cf3658b25cd8f51",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 172,
+          "comment" : "small plaintext size",
+          "key" : "ebe1c273ba54b877b937e9906c4063e188efd57bd3a32be825369380f1b9f6b8b6a0c2ab1390e589f6101c5ffb7460c7",
+          "aad" : "c3f0f5c438de5fd85b7a21af",
+          "msg" : "e8d7ac78d2805bfd656634d19b5834",
+          "ct" : "2eea0115c34a461d4de5de4a41b9654b8aa87b4cc944c05057f5b306942a0f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 173,
+          "comment" : "plaintext size > 16",
+          "key" : "80d50fafb3ede5ddbb5058827303a098bf213e47dcff12ea5338a2a0f914d84bff58c8c69c3b151d6dc380fd8f3e4178",
+          "aad" : "b49b12ba140fa8d794a31738",
+          "msg" : "340612da2d2dbbd25d7fa05c775a6ecfa8",
+          "ct" : "adc724b7fabbad1036ded152b968e557a4a1b3f5014f42f84a21ca45727f4b4339",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 174,
+          "comment" : "plaintext size > 16",
+          "key" : "5f6bfe19987d5bf6471dd9e436094f7fe33f8acca3b8a41e277861e202bd7262fc2b0bd3df9b35fa2fc3c579620f00eb",
+          "aad" : "b96c8682cd3ce676b0d79865",
+          "msg" : "1485126d0476bb4b86d087d1892632b53cb4f8a2",
+          "ct" : "8fd1214e80782d7c14007d037feb1ab181fdcb20985887b5ee8d4acf5589924be644947d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 175,
+          "comment" : "plaintext size > 16",
+          "key" : "9ea37352e41b57d61ed837b2ace481870d2413d92bf00f30dbb8fe8d250b3cebd0f64d714cf61a0533d02d372284c6c3",
+          "aad" : "0f1eb4eee461615bc0be8474",
+          "msg" : "80d977965a880bc6bb5e1cc92f234771adb61e7ae7198844623c6b1d1b54ec",
+          "ct" : "0da4c7885ffc4125878efe1d14eb5f64740bcaed915088806c89fb2efdde2a5b0d89aeef6a2324ba2626b42113ee27",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 176,
+          "comment" : "plaintext size > 16",
+          "key" : "25b0b404bb1f78446d0e5cde012ee5832cb403398a3e66e9b5a244b59d8994ee10184a5776f3578faab830e865f8133c",
+          "aad" : "7fe497bacf30af3a85662aa1",
+          "msg" : "b1b197cd7ff68b62e274f5d1046f42f9817163f0a105a0fb7736fa9e5e8f76944a22282af480ee79",
+          "ct" : "b44039f1e5ba808ca055aea6bc2d819d388e3c271cd97c046061e57223bbc2a17aa9b368d5cf281de46f48b34d179c16cc9e9d4600a87af4",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 177,
+          "comment" : "plaintext size > 16",
+          "key" : "7e225cf2004a28a091986f131fd43ed111c0693e63433ffc9dad9029c535096397636e13296eb62143162643b13c7546",
+          "aad" : "01685c58b14805d636541179",
+          "msg" : "81c8a10fcd668100dc762125e03627ac4e68d34c72568be438a7a068c27e2f12e2f17823e41fdd13e53616c622d4f320a38f97c2edead9800ed1091c303f10d172a284284d86708e53dedc82f6a7366b",
+          "ct" : "aa3d2cd732974b733597a369d47a680132dd5a944431231e6f77122d40ae70c5d032cc7d62208f428e6a931c7da6e88364d5ce1a4d9403436740b9e714a2c3b239febe6a6a7b42f78894442c912e6a9c22ea9548ef85540ca76d7c6df42b6534",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 178,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "05ae1ded78b927e7bf5560571e177760",
+          "ct" : "0000000000000000000000000000000081460aba44a680fc6c776c00a1e94b6b",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 179,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "11a7fae3b1b8297b31bdea77a8d6d67c",
+          "ct" : "00000000000000000000000000000000954fedb48da78e60e29fe6201728ea77",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 180,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3de1fd2ff8d5260005edbf9b59b6cf06",
+          "ct" : "ffffffffffffffffffffffffffffffffe8a56dbae884e990cc0df180d5e456ba",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 181,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "29e81a2131d4289c8b0535bbef776e1a",
+          "ct" : "fffffffffffffffffffffffffffffffffcac8ab42185e70c42e57ba06325f7a6",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 182,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "b3c75b1d29b3d5d09501c429c3b8faf2",
+          "ct" : "ffffffffffffffffffffffff7fffffff6683cb8839e21a405ce18a324fea634e",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 183,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "a7cebc13e0b2db4c1be94e0975795bee",
+          "ct" : "ffffffffffffffffffffffff7fffffff728a2c86f0e314dcd2090012f92bc252",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 184,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "6a142a8909ed51e7b2d77fd071f230df",
+          "ct" : "ffffffffffffffff7fffffffffffffffbf50ba1c19bc9e777b3731cbfda0a963",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 185,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "7e1dcd87c0ec5f7b3c3ff5f0c73391c3",
+          "ct" : "ffffffffffffffff7fffffffffffffffab595d12d0bd90ebf5dfbbeb4b61087f",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 186,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "e7202abbfe6fcffa7887a7ef06840040",
+          "ct" : "fffffffffffffffffffffffffffffffea0d032efc9533bf7bb8ac7af5c9c7cdc",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 187,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "f329cdb5376ec166f66f2dcfb045a15c",
+          "ct" : "fffffffffffffffffffffffffffffffeb4d9d5e10052356b35624d8fea5dddc0",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 188,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e94dda18e98cc8139cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 189,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a359304879d74e14fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 190,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e98ecb00ac9a462cdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 191,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c259760003211319acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 192,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "ea4dda18e98cc8139cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 193,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a059304879d74e14fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 194,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "ea8ecb00ac9a462cdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 195,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c159760003211319acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 196,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "684dda18e98cc8139cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 197,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "2259304879d74e14fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 198,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "688ecb00ac9a462cdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 199,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "4359760003211319acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 200,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84cda18e98cc8139cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 201,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a258304879d74e14fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 202,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88fcb00ac9a462cdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 203,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c358760003211319acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 204,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda98e98cc8139cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 205,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a25930c879d74e14fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 206,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb80ac9a462cdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 207,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359768003211319acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 208,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e88cc8139cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 209,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304878d74e14fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 210,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ad9a462cdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 211,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760002211319acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 212,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18eb8cc8139cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 213,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a25930487bd74e14fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 214,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ae9a462cdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 215,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760001211319acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 216,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8939cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 217,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e94fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 218,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a46acdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 219,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211399acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 220,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139dbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 221,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fcf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 222,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdde6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 223,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319add9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 224,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8131cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 225,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e147df520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 226,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462c5ce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 227,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c3597600032113192cd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 228,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139c9dfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 229,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdd520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 230,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdcc6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 231,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acf9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 232,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139cbdfc2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 233,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdf521588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 234,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdce6252b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 235,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acd9d3d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 236,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139cbdfd2270d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 237,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdf520588c3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 238,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdce6242b1a4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 239,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acd9d2d8fb2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 240,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139cbdfd2273d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 241,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdf520588f3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 242,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdce6242b194951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 243,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acd9d2d8f82608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 244,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139cbdfd22f1d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 245,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdf520580d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 246,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdce6242b9b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 247,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acd9d2d87a2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 248,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139cbdfd2271d8bae1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 249,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdf520588d3888f17ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 250,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdce6242b1b4951e5738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 251,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acd9d2d8fa2608458b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 252,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139cbdfd2271d8bae2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 253,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdf520588d3888f27ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 254,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdce6242b1b4951e6738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 255,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acd9d2d8fa2608468b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 256,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139cbdfd2271d8baa0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 257,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdf520588d3888b07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 258,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdce6242b1b4951a4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 259,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acd9d2d8fa2608048b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 260,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8139cbdfd2271d8ba60",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 261,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e14fdf520588d3888707ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 262,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a462cdce6242b1b495164738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 263,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211319acd9d2d8fa2608c48b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 264,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e94dda18e98cc8139dbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 265,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a359304879d74e14fcf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 266,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e98ecb00ac9a462cdde6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 267,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c259760003211319add9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 268,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda98e98cc8939cbdfd2271d8bae0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 269,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a25930c879d74e94fdf520588d3888f07ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 270,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb80ac9a46acdce6242b1b4951e4738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 271,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359768003211399acd9d2d8fa2608448b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 272,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e84dda18e98cc8939cbdfd2271d8ba60",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 273,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a259304879d74e94fdf520588d3888707ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 274,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e88ecb00ac9a46acdce6242b1b495164738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 275,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c359760003211399acd9d2d8fa2608c48b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 276,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "17b225e7167337ec634202dd8e27451f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 277,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "5da6cfb78628b1eb020adfa772c7770f7ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 278,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "177134ff5365b9d32319dbd4e4b6ae1b738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 279,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "3ca689fffcdeece653262d2705d9f7bb8b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 280,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "00000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 281,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "000000000000000000000000000000007ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 282,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "00000000000000000000000000000000738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 283,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "000000000000000000000000000000008b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 284,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 285,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "ffffffffffffffffffffffffffffffff7ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 286,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "ffffffffffffffffffffffffffffffff738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 287,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "ffffffffffffffffffffffffffffffff8b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 288,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "68cd5a98690c48931c3d7da2f1583a60",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 289,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "22d9b0c8f957ce947d75a0d80db808707ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 290,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "680e4b802c1ac6ac5c66a4ab9bc9d164738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 291,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "43d9f68083a193992c5952587aa688c48b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 292,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "e94cdb19e88dc9129dbcfc2370d9bbe1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 293,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a358314978d64f15fcf421598c3989f17ab3dd3c6c31a386",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 294,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "e98fca01ad9b472ddde7252a1a4850e5738b595aebf6ee3e7be424bfb51bfdee",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 295,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "c258770102201218add8d3d9fb2709458b0b5df8332150ff0877d85471d540c4cff1e183",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "keySize" : 512,
+      "type" : "DaeadTest",
+      "source" : {
+        "name" : "google-wycheproof",
+        "version" : "0.8r12"
+      },
+      "tests" : [
+        {
+          "tcId" : 296,
+          "comment" : "empty message",
+          "key" : "bc7635c1fd566aa8357fd103714bfaee1c9e5b3c578b3980401a981030254a54b1756a8c96e600b7252fd0aab12f39d115d256b3f3e7c2c41a7fece72ba7c3c4",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "44b1c6fe8a8c07dee5377b161f283c31",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 297,
+          "comment" : "empty message",
+          "key" : "aff6388fdd2908e0c3b610e3dcd410c8146a268d6befd5c45ffdd23508b5b311cc3a9d8f838f456436b289018682151dd57d8d65d1a823c06eca8ab8ee01da01",
+          "aad" : "d0bb2949a411e22d32964526",
+          "msg" : "",
+          "ct" : "e288d802a0e56ed7544a2e5775459389",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 298,
+          "comment" : "empty message",
+          "key" : "484261ebf7e1fb66e0bcafe8f4ccf9c5accc908fdb23eb7c5254d614072f26e106b34501d13c1dad1f14648c6a142132dd7f2f1268dd6b70fbcde2fe98f03245",
+          "aad" : "1d5ce9288627a12f8f5d809167a3b2",
+          "msg" : "",
+          "ct" : "f8083e55307932d971bfc2a8913c1951",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 299,
+          "comment" : "empty message",
+          "key" : "0b6aaf05f9b5221e539940cd83cb29d2bcc7a0aa472d8fc67bedd0108869394e33c9f233d4b2cc9c6a59e8ce9cd268a0f3f2857e08fe1eb329ef347dace1557d",
+          "aad" : "76aade95964f074c693886f245fa57f9",
+          "msg" : "",
+          "ct" : "f1ad6ea998a2a438acaf90bad0cb9f9f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 300,
+          "comment" : "empty message",
+          "key" : "d47ab6d51f99f4249da56c93d1f09e856231f3fed777b303111ad31079270839e4bc4b5d8623162d4738d70803934a75f457fdbf4a277b828cb6e2753e88702a",
+          "aad" : "41257da6108bedbb150d4e290b6b9a76d11092c6",
+          "msg" : "",
+          "ct" : "a8d27944a84317098eed170631f4c867",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 301,
+          "comment" : "empty message",
+          "key" : "eef6bcf16ef7ae17326a33f22d1406ec1bd3f866505f4b2e4fe8b45bd62ccbd85032a9899facf2db0c93a2345cb8892afb74db549781211dd8881a8c8e25c171",
+          "aad" : "e941d15fadebaf4671e0e3d6d835f87bfb1cc7028f149930daa69c3de446c423",
+          "msg" : "",
+          "ct" : "b754ecb55c1e124de0c8a973d033bd7f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 302,
+          "comment" : "message size divisible by block size",
+          "key" : "c25cafc6018b98dfbb79a40ec89c575a4f88c4116489bba27707479800c0130235334a45dbe8d8dae3da8dcb45bbe5dce031b0f68ded544fda7eca30d6749442",
+          "aad" : "deeb0ccf3aef47a296ed1ca8f4ae5907",
+          "msg" : "beec61030fa3d670337196beade6aeaa",
+          "ct" : "5865208eab9163db85cab9f96d846234a2626aae22f5c17c9aad4b501f4416e4",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 303,
+          "comment" : "message size divisible by block size",
+          "key" : "27faf97fb303aa4f2f364edd23997f4c77b8e51ebb8293c59dfb1d24f0fb629f6c820fc2d91bf48f0035eeec347e37ec4fb0cb36102bcdc5a248c47a2f97eab9",
+          "aad" : "cc94f64e14df90265f7f12a8a0386d0a",
+          "msg" : "6b1db0f5a43376885002dc98bd556f1dac9b66b66213a9fa6069df995a123384",
+          "ct" : "d0016d675b49f11ea873707412d45709b7703a028a0cfc312cf61cbe22b91e3cf20b7d4c9308ee15f18b4eba00889284",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 304,
+          "comment" : "message size divisible by block size",
+          "key" : "97bfd0f3e9bb8167bbb55f4cdc14529d8307c0ec2c3fe8bc88522d05c1261ba460c9cb4116f630edd74d413ec417324c6e29b566fb2dd3df18e07b53b1f9f83b",
+          "aad" : "1cda342c166ea208df5c56bcf995a59b",
+          "msg" : "48ef10ccb1978b53ae73167abe1cc538fa80da3f5df93e3d5c4e9a9ad1f213504f22a694b98a35ad67620af9d8a29fc7",
+          "ct" : "d55c5d0af0260dc1123adb5d7869201f8ccee46deb66dd695c593cde1d7645c72796e42a1733b6705753631b9b626991ddbd28473ce75cfdc4c14d20e66f212d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 305,
+          "comment" : "small plaintext size",
+          "key" : "e2c5662bb18fbb411d0304e4241db073fe60a4704fee290073513038a22b4cd542580b2b4edbc37e3de01c0cb61abcad46986cdc491ce9e5ae5af223ff58b953",
+          "aad" : "fab912dec29a34aabfaef176",
+          "msg" : "0d",
+          "ct" : "1c6969ecb15741a9959b7a8492250e391a",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 306,
+          "comment" : "small plaintext size",
+          "key" : "3ab062dbdd38b951a9fb0d8bb185959a93dab3496b850a3062b93003036c8bd2aabbf37d5d3f6a399d4cedefb70c1b8a7b45639fe118c10e39f36fa58618a84d",
+          "aad" : "e8605f13db8c482d48bdba2d",
+          "msg" : "5c6f",
+          "ct" : "fddea9ac778b978a968033ce52ec61162588",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 307,
+          "comment" : "small plaintext size",
+          "key" : "9e575cd8991b32f06fbaf55ad79eb74822349e07fa77c409848c86820011569f26dcb49afaea19a52a96b27e67f780ac7a00da9a3054d1678d60417cf34996b1",
+          "aad" : "7f89a3f648c1c7c23edbd5ca",
+          "msg" : "35ac33",
+          "ct" : "3834fbedc3502227e3c91a861f2e3195fbb344",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 308,
+          "comment" : "small plaintext size",
+          "key" : "6d43cfc930a1e0051f607d0c4a76ad5bec77d9f98bbd9ae5e56a1d65fcf1bf68c7780f727bfe690497bae478afbc4ebf7a89943ee146f72d352940794ff202f4",
+          "aad" : "c2b75c998f4cac28b4b69dfb",
+          "msg" : "1d25f833",
+          "ct" : "0d1e1981da44a7d9eda60e48e7ae4f8505d8ba98",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 309,
+          "comment" : "small plaintext size",
+          "key" : "673cea582bf3982ce3fba5304de8fe46e316d6804749d6db58b7ab7d64bd4e0af641997975234f8b918cca3247d67cfeac9230d15ed28f8071a85e84fa9ef211",
+          "aad" : "f5042d5a5b68b262274974a8",
+          "msg" : "9e99912c7b",
+          "ct" : "655ef7f09f4cff47b427e9df7fcc642664715ad14c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 310,
+          "comment" : "small plaintext size",
+          "key" : "8f13f2bf02d72360d9958eb8aa90634ae48331e7dfdbf16fc51c7238ae9f9d50d4495d196676ef5259b64a616305ffaae517c587d4e7afba40e4a2c5b0989182",
+          "aad" : "755f50cfdfc849654ad98cc7",
+          "msg" : "ac598720b96e",
+          "ct" : "adee2a373a7f6bbaf4f00e5f3f93435a09091b5221ae",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 311,
+          "comment" : "small plaintext size",
+          "key" : "67b3ab00075a0e3d07f3fe73fabea5d0373206a0aafa9397981924ddaf2cb283c66af61166815dffbe8fafa688b793fd259fad4a1f75a259342e58814448a4b4",
+          "aad" : "f8799bc732cbf6a39ae2268e",
+          "msg" : "8f6b2b21a6dc73",
+          "ct" : "ff6173a70dee05ddbde75a960f84523e01b30adcac5275",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 312,
+          "comment" : "small plaintext size",
+          "key" : "a661c6a90fd40d8a734873d66afd4477c5041cdc2b31a3cd0ac3604cac4f74411219e544615b56e17f5774b5085129f6dd69893bb7216b539cf42b79f0068278",
+          "aad" : "7a5dbdbf803b2593d3e17097",
+          "msg" : "deb2c7c6204496e5",
+          "ct" : "2f8b7583773ae03ba7b3952453c81431780bfcc9d7df9a43",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 313,
+          "comment" : "small plaintext size",
+          "key" : "a40b1cc110e1aa28ab86f714abd6d313016989a1c8cfcb62063e2c396ca12a246de3b9bd82994e5f1cb1323f78a9a0ed02fe841976a659423603d91ccf71d58e",
+          "aad" : "e482e942ce26d244d4962acf",
+          "msg" : "122d1ba394afad1fe3",
+          "ct" : "8185d14ee87cc891bb9bcf3fafde4ed246599626211fe04d23",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 314,
+          "comment" : "small plaintext size",
+          "key" : "8af0e57998dd68b0f45b58e708405d0ad8269397249295fd336096e065db2bb1e4110d5507c04d73c150f6e7d87ced029ab38661f201ec77874e43953373b38a",
+          "aad" : "89f95250fb66b2cda70b8854",
+          "msg" : "9cab7bde926307386505",
+          "ct" : "c4deca5c53bcfa6208b337474212418541e44d0fbf2de7b48c6f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 315,
+          "comment" : "small plaintext size",
+          "key" : "6e063240d83d4a90e44e56e631fefe9f6c7c7d56518eff3a902ddd5ca9b837a2044b3727571d1ca56a68abfd997da945e4d14f71dc86b0149a19a93d1e5fec85",
+          "aad" : "5c3661f4047454bac445f1ac",
+          "msg" : "08eb0a196e8f3cb6428b0a",
+          "ct" : "67673064fc540ae128232ba87ba2e9bbe7d3569dd419bcc52796ec",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 316,
+          "comment" : "small plaintext size",
+          "key" : "9593f0d6679e8e18b43cb4d26a7ea9da9d6037fd5a82db0b091a682b6547a77298e4fd1d1481f3603d0b1e7e6dcf27200105af0f844f2aaacd98540ab2b6c8a8",
+          "aad" : "7b3f9591076e32a21766e2bb",
+          "msg" : "0628d19cc94c4b4f3d703e1f",
+          "ct" : "56e6fd5a7f449a8e6bafa38f945c70cf8a534179b3b1f26266fb6b56",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 317,
+          "comment" : "small plaintext size",
+          "key" : "77f7dd662a8f0aaf7f19c6614584e4acf5c774d19e10d2070eaa977e9c6ba21ba82f0bc84939cf70283dcac9c645b7423ca0cc94bac827ea378f1ca0c9da0eee",
+          "aad" : "a3c4e387bfc005402acd20bb",
+          "msg" : "a171376f2a66dbdf17f32961e8",
+          "ct" : "4e7b642dcc3cbd935d4cda8193982ef7240fa47f951ec8b3fd37204a73",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 318,
+          "comment" : "small plaintext size",
+          "key" : "8916d0342001561922e674b0cc51c05a935e5dc45a6d6284f34a4c5c79e92062dc3091217584607e9cf9056aa495ca4cd53fd3d4c6a94c4b384007e62174506b",
+          "aad" : "890dcea871da1caff4766d32",
+          "msg" : "6ad348470891d1babb13f3bf0e8c",
+          "ct" : "fbb68324b8c5b3e55ebc1feb4b98761521f4aac7eb7b6c0fb0505a08457b",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 319,
+          "comment" : "small plaintext size",
+          "key" : "2a93a0c37797bee0c344b9ceed1a609813d8c5ee686d260f3aa6fc2f66dc59f400479d1dfe04e89e6df608a3f699ff1cb4e9bf24a78fb2dfddaa0011a2e40208",
+          "aad" : "6ae54f41ac52baf2f89abe8e",
+          "msg" : "3fc3bf53bb485c9edcb1d25adb4ca0",
+          "ct" : "2d344a54038a857f47e0c77eb0834538aaf01e61a8ac82c0012f9dac6f15ef",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 320,
+          "comment" : "plaintext size > 16",
+          "key" : "139383f3f82dc78e0b380027f9e5fcd2ed23716404be5c554452e4dc73d237026594491820c6b8297185cc1fa84f49a5c7d7cd05c5de090ff1c3397bc2740437",
+          "aad" : "d39da73ffc03ad0a9213ffc7",
+          "msg" : "48604944a80fadf50d55b87727934458c8",
+          "ct" : "a9cf73951cb39823777f35c96c845169476e2ec2317cb6b8dd8b6172fdceabff9d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 321,
+          "comment" : "plaintext size > 16",
+          "key" : "eac96a89b8e0c928a85c91396346efe8287730595064554cd13574f8b340f541c5f0bb55e654e51b05e21ba007942cabab5ee1020922f0dd002196a39d7fda1d",
+          "aad" : "29d614f908593f6a5ab03cea",
+          "msg" : "0c22e4875dcd23de89a6d32f2082dd40e1848fc2",
+          "ct" : "bce886623d11320d22dfdc1defb04d17bd001d9370a3d8c83aabe4494d16ca75ce534f7c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 322,
+          "comment" : "plaintext size > 16",
+          "key" : "c0f4bede68c6ed5ad14918e2ddeced692dfd5419c04204d5b96f4ca47078b07028c6fb87b1b490d875f070bbe4d790f65e5df19947f02c9d3a4e493b542d0291",
+          "aad" : "b411e4d2facca67ea4a9f2a1",
+          "msg" : "2f358d4534559ac99dd71798b7925705d6f013f6b848ffe01cc86cef09d88f",
+          "ct" : "d27ae26dfe02e3eedf544e1b452cb0f0c9303a4e4819318315ae08839bcce558e4741817ec08dae406bbfc09f59aa9",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 323,
+          "comment" : "plaintext size > 16",
+          "key" : "cd8689f821817f59bfaa755131f2565161c7f4489f89b657ac9fa127a9768535a702d001b9b99cc11c3976467b1b45865ff417dc256ebb5079b7f1b3e08307b5",
+          "aad" : "b3edffbb89b373fe04da244b",
+          "msg" : "ebcfb2ffb681cc5dfa0c5c524c1b1cc87cc6b2bfa35dc36d15e80505118b84a072a78a157b4d1837",
+          "ct" : "1ac78aae2ede04eb47924d8f9f99fe75deb61bf693da7f3a2147c05f6d29d17392356fe00f82b24cdbce774fd864561548f33dd3192d806f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 324,
+          "comment" : "plaintext size > 16",
+          "key" : "72a76714e0171e8213de624f00e273bc900050e69d25c454cc42b61e8b3fbc92d4942e1ae14421e164046c1479a7b9c9f4b50b382cb62dfeaa210b98dec7d937",
+          "aad" : "6a8aaf2c84003e0e6f409658",
+          "msg" : "92d8f4dc7d41e8b180d66e8994022db79249cdc76fd7f3ea12d9925b51925250cd75a15fcfd78ea85c57fe6196f8d7545086f99ea796a0ea69170db9944200435d9d3d551943892400ce787f703c1105",
+          "ct" : "69f720f36b0da86ec8cc0f46d62835dcb35ac23f5b891152d861c4e0f0018f19d272ee8b12d83300bfd46aeec0124d5d23b3cb849c1cab1fdf64b70947ebf79f5442e209076dfa9a3f36ab0a6d3cf4a75ddfcdc21837743b20885db4c803ac27",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 325,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "8dbfee9580e7e2bc66100a674497f4e1",
+          "ct" : "000000000000000000000000000000007ef8aa7e4dd49d9cfa09e9cb574fd90d",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 326,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "bfa1733d07afa03cb3f2eeb81bbde037",
+          "ct" : "000000000000000000000000000000004ce637d6ca9cdf1c2feb0d140865cddb",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 327,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "72543a9a07a3c18a280060653432c05c",
+          "ct" : "ffffffffffffffffffffffffffffffff3db09cc48f2780859351901d1014ae06",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 328,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "404aa73280eb830afde284ba6b18d48a",
+          "ct" : "ffffffffffffffffffffffffffffffff0fae016c086fc20546b374c24f3ebad0",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 329,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "ff4d7cdeb8f3c4e37a05a91ee26e2a84",
+          "ct" : "ffffffffffffffffffffffff7fffffffb0a9da80307785ecc1545966c64844de",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 330,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "cd53e1763fbb8663afe74dc1bd443e52",
+          "ct" : "ffffffffffffffffffffffff7fffffff82b74728b73fc76c14b6bdb999625008",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 331,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "6eb52fc95a5185a3bd2a30d3058414ab",
+          "ct" : "ffffffffffffffff7fffffffffffffff21518997d2d5c4ac067bc0ab21a27af1",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 332,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "5cabb261dd19c72368c8d40c5aae007d",
+          "ct" : "ffffffffffffffff7fffffffffffffff134f143f559d862cd39924747e886e27",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 333,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "114cc36e58faceb2e6a2344a679ea4c3",
+          "ct" : "fffffffffffffffffffffffffffffffe2f849650d6e89e2668e990219195719c",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 334,
+          "comment" : "edge case SIV",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "23525ec6dfb28c323340d09538b4b015",
+          "ct" : "fffffffffffffffffffffffffffffffe1d9a0bf851a0dca6bd0b74fecebf654a",
+          "result" : "valid",
+          "flags" : [
+            "EdgeCaseSiv"
+          ]
+        },
+        {
+          "tcId" : 335,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ef5b8ef53fc365606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 336,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "202e4a8f8b4c66788f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 337,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "05b4e8166f28082987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 338,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "315d6cf8eeb36a37849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 339,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6df5b8ef53fc365606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 340,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "232e4a8f8b4c66788f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 341,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "06b4e8166f28082987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 342,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "325d6cf8eeb36a37849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 343,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "eff5b8ef53fc365606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 344,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a12e4a8f8b4c66788f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 345,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "84b4e8166f28082987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 346,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "b05d6cf8eeb36a37849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 347,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff4b8ef53fc365606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 348,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212f4a8f8b4c66788f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 349,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b5e8166f28082987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 350,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305c6cf8eeb36a37849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 351,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b86f53fc365606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 352,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a0f8b4c66788f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 353,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8966f28082987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 354,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6c78eeb36a37849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 355,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef52fc365606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 356,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8a4c66788f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 357,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166e28082987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 358,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8efb36a37849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 359,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef51fc365606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 360,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f894c66788f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 361,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166d28082987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 362,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8ecb36a37849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 363,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc36d606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 364,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66f88f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 365,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f2808a987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 366,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36ab7849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 367,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365607cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 368,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788e3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 369,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082986a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 370,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37859710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 371,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365686cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 372,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66780f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 373,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082907a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 374,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37049710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 375,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606ed3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 376,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f1af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 377,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987832cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 378,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a3784b710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 379,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606cd3fa047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 380,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f3af330fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 381,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987a32ddaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 382,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37849711e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 383,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606cd3ea046374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 384,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f3af230fa1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 385,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987a32cdaf43deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 386,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37849710e7d0f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 387,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606cd3ea045374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 388,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f3af230f91c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 389,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987a32cdaf73deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 390,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37849710e7d3f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 391,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606cd3ea0c7374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 392,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f3af2307b1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 393,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987a32cda753deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 394,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37849710e751f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 395,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606cd3ea047374884",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 396,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f3af230fb1c3adb5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 397,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987a32cdaf53deb60211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 398,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37849710e7d1f72941adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 399,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606cd3ea047374887",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 400,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f3af230fb1c3ad85ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 401,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987a32cdaf53deb63211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 402,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37849710e7d1f72942adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 403,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606cd3ea0473748c5",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 404,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f3af230fb1c3a9a5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 405,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987a32cdaf53deb21211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 406,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37849710e7d1f72900adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 407,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc365606cd3ea047374805",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 408,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66788f3af230fb1c3a5a5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 409,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f28082987a32cdaf53debe1211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 410,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36a37849710e7d1f729c0adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 411,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ef5b8ef53fc365607cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 412,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "202e4a8f8b4c66788e3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 413,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "05b4e8166f28082986a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 414,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "315d6cf8eeb36a37859710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 415,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b86f53fc36d606cd3ea047374885",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 416,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a0f8b4c66f88f3af230fb1c3ada5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 417,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8966f2808a987a32cdaf53deb61211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 418,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6c78eeb36ab7849710e7d1f72940adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 419,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ff5b8ef53fc36d606cd3ea047374805",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 420,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "212e4a8f8b4c66f88f3af230fb1c3a5a5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 421,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "04b4e8166f2808a987a32cdaf53debe1211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 422,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "305d6cf8eeb36ab7849710e7d1f729c0adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 423,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "900a4710ac03c9a9f932c15fb8c8b77a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 424,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "ded1b57074b3998770c50dcf04e3c5255ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 425,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "fb4b17e990d7f7d6785cd3250ac2149e211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 426,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "cfa29307114c95c87b68ef182e08d6bfadfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 427,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "00000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 428,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "000000000000000000000000000000005ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 429,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "00000000000000000000000000000000211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 430,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "00000000000000000000000000000000adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 431,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 432,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "ffffffffffffffffffffffffffffffff5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 433,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "ffffffffffffffffffffffffffffffff211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 434,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "ffffffffffffffffffffffffffffffffadfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 435,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "ef75386fd37cb6d6864dbe20c7b7c805",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 436,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "a1aeca0f0bcce6f80fba72b07b9cba5a5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 437,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "84346896efa888a90723ac5a75bd6be1211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 438,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "b0ddec786e33eab7041790675177a9c0adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 439,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "",
+          "ct" : "6ef4b9ee52fd375707cc3fa146364984",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 440,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "3031323334353637",
+          "ct" : "202f4b8e8a4d67798e3bf331fa1d3bdb5ead70c7f066d4df",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 441,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f",
+          "ct" : "05b5e9176e29092886a22ddbf43cea60211dffad7562c4b924bb79fed73d9ce2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 442,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+          "aad" : "",
+          "msg" : "303132333435363738393a3b3c3d3e3f40414243",
+          "ct" : "315c6df9efb26b36859611e6d0f62841adfd10a7615d6515b999dbfc5a10f3ae9df5f19a",
+          "result" : "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/testvectors_v1/aes_siv_cmac_test.json
+++ b/testvectors_v1/aes_siv_cmac_test.json
@@ -7,9 +7,12 @@
     "with additional data."
   ],
   "notes" : {
-    "EdgeCaseSiv" : "The SIV of this test vector has an edge case value. One purpose of these test vectors is to detect implementations where integer overflows of the counter is incorrectly implemented. AES-SIV itself prevents such overflow problems by clearing some msbs in the IV."
+    "EdgeCaseSiv" : {
+      "bugType" : "MISSING_STEP",
+      "description" : "The SIV of this test vector has an edge case value. One purpose of these test vectors is to detect implementations where integer overflows of the counter is incorrectly implemented. AES-SIV itself prevents such overflow problems by clearing some msbs in the IV."
+    }
   },
-  "schema" : "daead_test_schema.json",
+  "schema" : "daead_test_schema_v1.json",
   "testGroups" : [
     {
       "keySize" : 256,


### PR DESCRIPTION
This is v0 coverage ported to v1 to augment existing coverage. Unlike the `aead_test_schema_v1` schema, and `aead_aes_siv_cmac_test.json` vectors the `daead_test_schema_v1` schema and `aes_siv_cmac_test.json` vectors do not provide separated iv/tag data.

Updates https://github.com/C2SP/wycheproof/issues/151