### PR TITLE
Add ECDSA tests with non-minimally encoded DER tags

### DIFF
--- a/testvectors/ecdsa_brainpoolP224r1_sha224_test.json
+++ b/testvectors/ecdsa_brainpoolP224r1_sha224_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 359,
+  "numberOfTests" : 362,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4585,6 +4585,56 @@
           "flags" : [
             "GroupIsomorphism"
           ]
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "brainpoolP224r1",
+        "keySize" : 224,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04572eab7376d052dfc40923db25342ea9cbfce4b8581e104a4c8f37c94a700ec5dc05a481b2b695320c6f1ad2dd8628633cdb75a91245c265",
+        "wx" : "572eab7376d052dfc40923db25342ea9cbfce4b8581e104a4c8f37c9",
+        "wy" : "4a700ec5dc05a481b2b695320c6f1ad2dd8628633cdb75a91245c265"
+      },
+      "keyDer" : "3052301406072a8648ce3d020106092b2403030208010105033a0004572eab7376d052dfc40923db25342ea9cbfce4b8581e104a4c8f37c94a700ec5dc05a481b2b695320c6f1ad2dd8628633cdb75a91245c265",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABFcuq3N20FLfxAkj2yU0LqnL/OS4\nWB4QSkyPN8lKcA7F3AWkgbK2lTIMbxrS3YYoYzzbdakSRcJl\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-224",
+      "tests" : [
+        {
+          "tcId" : 360,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f103d021d00cb68ac9765c7641785df237e9951e1429581879af2631460048961d3021c139c78243a6e36e124d5f5e14b4cb8754abdf20ff1a501d5666a428f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 361,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e1f021d00cb68ac9765c7641785df237e9951e1429581879af2631460048961d3021c139c78243a6e36e124d5f5e14b4cb8754abdf20ff1a501d5666a428f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 362,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e021d00cb68ac9765c7641785df237e9951e1429581879af2631460048961d31f021c139c78243a6e36e124d5f5e14b4cb8754abdf20ff1a501d5666a428f",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_brainpoolP256r1_sha256_test.json
+++ b/testvectors/ecdsa_brainpoolP256r1_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 389,
+  "numberOfTests" : 392,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4854,6 +4854,56 @@
           "flags" : [
             "GroupIsomorphism"
           ]
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "brainpoolP256r1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04019a2d9637743a63ddaefdbca0ee229a163b809b9b145e5313bbeb8defeab9d6548caf89bf5ba49499404145651234336401b9b2843a579ed152e090f11b9e59",
+        "wx" : "019a2d9637743a63ddaefdbca0ee229a163b809b9b145e5313bbeb8defeab9d6",
+        "wy" : "548caf89bf5ba49499404145651234336401b9b2843a579ed152e090f11b9e59"
+      },
+      "keyDer" : "305a301406072a8648ce3d020106092b240303020801010703420004019a2d9637743a63ddaefdbca0ee229a163b809b9b145e5313bbeb8defeab9d6548caf89bf5ba49499404145651234336401b9b2843a579ed152e090f11b9e59",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABAGaLZY3dDpj3a79vKDuIpoWO4Cb\nmxReUxO7643v6rnWVIyvib9bpJSZQEFFZRI0M2QBubKEOlee0VLgkPEbnlk=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 390,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f104402200a5f8c70ba2d0842d5d0f841f160ad15195769a8159bfe692634d73d469d111f0220426e857aad3ff7aa96e4d200c03b45f1846a36d089ee3917768ca1a0d6d4da6e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 391,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30451f02200a5f8c70ba2d0842d5d0f841f160ad15195769a8159bfe692634d73d469d111f0220426e857aad3ff7aa96e4d200c03b45f1846a36d089ee3917768ca1a0d6d4da6e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 392,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502200a5f8c70ba2d0842d5d0f841f160ad15195769a8159bfe692634d73d469d111f1f0220426e857aad3ff7aa96e4d200c03b45f1846a36d089ee3917768ca1a0d6d4da6e",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_brainpoolP320r1_sha384_test.json
+++ b/testvectors/ecdsa_brainpoolP320r1_sha384_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 393,
+  "numberOfTests" : 396,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4718,6 +4718,56 @@
           "sig" : "305502282417eb10a538921621066608243fd6574de84ef1281520f01ebe0444b46a607ab9eda8f3721779a60229008f1e2ea294028baeb738181e128c86ad55cb1945436cf69e090c2f6159f6f22011d731733b4433ba",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "brainpoolP320r1",
+        "keySize" : 320,
+        "type" : "EcPublicKey",
+        "uncompressed" : "040fcc8860cb26e262ca8b4ecb9c52f78d82a10a1d30dd0c8ecd7584ce80dbb75c488a062b643755001f27e676c26cd3488c1ef4ec3edd88cf8af78daf9036724b57e66da02cf7c676a53664becdfedc3b",
+        "wx" : "0fcc8860cb26e262ca8b4ecb9c52f78d82a10a1d30dd0c8ecd7584ce80dbb75c488a062b64375500",
+        "wy" : "1f27e676c26cd3488c1ef4ec3edd88cf8af78daf9036724b57e66da02cf7c676a53664becdfedc3b"
+      },
+      "keyDer" : "306a301406072a8648ce3d020106092b2403030208010109035200040fcc8860cb26e262ca8b4ecb9c52f78d82a10a1d30dd0c8ecd7584ce80dbb75c488a062b643755001f27e676c26cd3488c1ef4ec3edd88cf8af78daf9036724b57e66da02cf7c676a53664becdfedc3b",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABA/MiGDLJuJiyotOy5xS942CoQod\nMN0Mjs11hM6A27dcSIoGK2Q3VQAfJ+Z2wmzTSIwe9Ow+3YjPiveNr5A2cktX5m2g\nLPfGdqU2ZL7N/tw7\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 394,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f105602290085b1bc586bf5407f9c8ec3765fe02bd19380998c45892ccd5081a1bd8872a26cdaf403e6dbf34a6e022900833d6661b0576d61a80ffe4d3271c43b2a56c14b3bd90305923ccdcf7b3d988c07ebb1c4cc67381c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 395,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30571f02290085b1bc586bf5407f9c8ec3765fe02bd19380998c45892ccd5081a1bd8872a26cdaf403e6dbf34a6e022900833d6661b0576d61a80ffe4d3271c43b2a56c14b3bd90305923ccdcf7b3d988c07ebb1c4cc67381c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 396,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "305702290085b1bc586bf5407f9c8ec3765fe02bd19380998c45892ccd5081a1bd8872a26cdaf403e6dbf34a6e1f022900833d6661b0576d61a80ffe4d3271c43b2a56c14b3bd90305923ccdcf7b3d988c07ebb1c4cc67381c",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_brainpoolP384r1_sha384_test.json
+++ b/testvectors/ecdsa_brainpoolP384r1_sha384_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 420,
+  "numberOfTests" : 423,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5128,6 +5128,56 @@
           "flags" : [
             "GroupIsomorphism"
           ]
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "brainpoolP384r1",
+        "keySize" : 384,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04192ed5ce547d2336911d3f6cecba227f08df077f6242a9147a914e854e6e32d325fd23ccc42921dc4a7e4c2eb71defd3631e69079ba982e7a1cad0a39eff47fc6d6e3a280d081286b624886ba1f3069671ec1a29986d84fb79736d2799e6fc21",
+        "wx" : "192ed5ce547d2336911d3f6cecba227f08df077f6242a9147a914e854e6e32d325fd23ccc42921dc4a7e4c2eb71defd3",
+        "wy" : "631e69079ba982e7a1cad0a39eff47fc6d6e3a280d081286b624886ba1f3069671ec1a29986d84fb79736d2799e6fc21"
+      },
+      "keyDer" : "307a301406072a8648ce3d020106092b240303020801010b03620004192ed5ce547d2336911d3f6cecba227f08df077f6242a9147a914e854e6e32d325fd23ccc42921dc4a7e4c2eb71defd3631e69079ba982e7a1cad0a39eff47fc6d6e3a280d081286b624886ba1f3069671ec1a29986d84fb79736d2799e6fc21",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABBku1c5UfSM2kR0/bOy6In8I3wd/\nYkKpFHqRToVObjLTJf0jzMQpIdxKfkwutx3v02MeaQebqYLnocrQo57/R/xtbjoo\nDQgShrYkiGuh8waWcewaKZhthPt5c20nmeb8IQ==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 421,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f106502300e8e114a1c351405560bf8d47b166bfe957087a8003b353433b6144f7ee7d6f79c8dd14ef229fa7a2f2782bf33708b9102310083aa7ba485dc060df9922f9ccc5da29adb75d44671d18bad0636d2e09c5e2f95e892a79b9fd3b37e1f798b157b567a24",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 422,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30661f02300e8e114a1c351405560bf8d47b166bfe957087a8003b353433b6144f7ee7d6f79c8dd14ef229fa7a2f2782bf33708b9102310083aa7ba485dc060df9922f9ccc5da29adb75d44671d18bad0636d2e09c5e2f95e892a79b9fd3b37e1f798b157b567a24",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 423,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306602300e8e114a1c351405560bf8d47b166bfe957087a8003b353433b6144f7ee7d6f79c8dd14ef229fa7a2f2782bf33708b911f02310083aa7ba485dc060df9922f9ccc5da29adb75d44671d18bad0636d2e09c5e2f95e892a79b9fd3b37e1f798b157b567a24",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_brainpoolP512r1_sha512_test.json
+++ b/testvectors/ecdsa_brainpoolP512r1_sha512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 462,
+  "numberOfTests" : 465,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5496,6 +5496,56 @@
           "flags" : [
             "GroupIsomorphism"
           ]
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "brainpoolP512r1",
+        "keySize" : 512,
+        "type" : "EcPublicKey",
+        "uncompressed" : "0467cea1bedf84cbdcba69a05bb2ce3a2d1c9d911d236c480929a16ad697b45a6ca127079fe8d7868671e28ef33bdf9319e2e51c84b190ac5c91b51baf0a980ba500a7e79006194b5378f65cbe625ef2c47c64e56040d873b995b5b1ebaa4a6ce971da164391ff619af3bcfc71c5e1ad27ee0e859c2943e2de8ef7c43d3c976e9b",
+        "wx" : "67cea1bedf84cbdcba69a05bb2ce3a2d1c9d911d236c480929a16ad697b45a6ca127079fe8d7868671e28ef33bdf9319e2e51c84b190ac5c91b51baf0a980ba5",
+        "wy" : "00a7e79006194b5378f65cbe625ef2c47c64e56040d873b995b5b1ebaa4a6ce971da164391ff619af3bcfc71c5e1ad27ee0e859c2943e2de8ef7c43d3c976e9b"
+      },
+      "keyDer" : "30819b301406072a8648ce3d020106092b240303020801010d038182000467cea1bedf84cbdcba69a05bb2ce3a2d1c9d911d236c480929a16ad697b45a6ca127079fe8d7868671e28ef33bdf9319e2e51c84b190ac5c91b51baf0a980ba500a7e79006194b5378f65cbe625ef2c47c64e56040d873b995b5b1ebaa4a6ce971da164391ff619af3bcfc71c5e1ad27ee0e859c2943e2de8ef7c43d3c976e9b",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEZ86hvt+Ey9y6aaBbss46LRyd\nkR0jbEgJKaFq1pe0WmyhJwef6NeGhnHijvM735MZ4uUchLGQrFyRtRuvCpgLpQCn\n55AGGUtTePZcvmJe8sR8ZOVgQNhzuZW1seuqSmzpcdoWQ5H/YZrzvPxxxeGtJ+4O\nhZwpQ+LejvfEPTyXbps=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 463,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f10818402400bd2593447cc6c02caf99d60418dd42e9a194c910e6755ed0c7059acac656b04ccfe1e8348462ee43066823aee2fed7ca012e9890dfb69866d7ae88b6506f9c7024044b42304e693796618d090dbcb2a2551c3cb78534611e61fd9d1a5c0938b5b8ec6ed53d2d28999eabbd8e7792d167fcf582492403a6a0f7cc94c73a28fb76b71",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 464,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081851f02400bd2593447cc6c02caf99d60418dd42e9a194c910e6755ed0c7059acac656b04ccfe1e8348462ee43066823aee2fed7ca012e9890dfb69866d7ae88b6506f9c7024044b42304e693796618d090dbcb2a2551c3cb78534611e61fd9d1a5c0938b5b8ec6ed53d2d28999eabbd8e7792d167fcf582492403a6a0f7cc94c73a28fb76b71",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 465,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818502400bd2593447cc6c02caf99d60418dd42e9a194c910e6755ed0c7059acac656b04ccfe1e8348462ee43066823aee2fed7ca012e9890dfb69866d7ae88b6506f9c71f024044b42304e693796618d090dbcb2a2551c3cb78534611e61fd9d1a5c0938b5b8ec6ed53d2d28999eabbd8e7792d167fcf582492403a6a0f7cc94c73a28fb76b71",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp160k1_sha256_test.json
+++ b/testvectors/ecdsa_secp160k1_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 365,
+  "numberOfTests" : 368,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4414,6 +4414,56 @@
           "sig" : "302e021500f036a3151449a8f854c12c6fd55bd9fb02ee67af021500c3bc5227188b85b9b9c33fa7c5088f8e8e02de86",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp160k1",
+        "keySize" : 160,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04be74d8dd1d5654265384f74227ab0f8534b5a4fe2ab8e5bfeff929794d8dd9c2e3be40e6cf49ad49",
+        "wx" : "00be74d8dd1d5654265384f74227ab0f8534b5a4fe",
+        "wy" : "2ab8e5bfeff929794d8dd9c2e3be40e6cf49ad49"
+      },
+      "keyDer" : "303e301006072a8648ce3d020106052b81040009032a0004be74d8dd1d5654265384f74227ab0f8534b5a4fe2ab8e5bfeff929794d8dd9c2e3be40e6cf49ad49",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEvnTY3R1WVCZThPdCJ6sPhTS1pP4quOW/\n7/kpeU2N2cLjvkDmz0mtSQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 366,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f102e021500a89cf5aa14f3e5d8a02f7021c6d0291e7154df23021500e0348c201105978ee3ab9c565cf9a63261a58173",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 367,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302f1f021500a89cf5aa14f3e5d8a02f7021c6d0291e7154df23021500e0348c201105978ee3ab9c565cf9a63261a58173",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 368,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302f021500a89cf5aa14f3e5d8a02f7021c6d0291e7154df231f021500e0348c201105978ee3ab9c565cf9a63261a58173",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp160r1_sha256_test.json
+++ b/testvectors/ecdsa_secp160r1_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 368,
+  "numberOfTests" : 371,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4498,6 +4498,56 @@
           "sig" : "302d02144f71014057dde59269ba089c49082dab3ffa9af30215008d1abb842b2f932a04c2dd19a2f2109a57c88c32",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp160r1",
+        "keySize" : 160,
+        "type" : "EcPublicKey",
+        "uncompressed" : "0450cd6584a80522992ecc20c20280c358c15e5085e0a12cbbb20fbec12ce194c0f90b72331db90fce",
+        "wx" : "50cd6584a80522992ecc20c20280c358c15e5085",
+        "wy" : "00e0a12cbbb20fbec12ce194c0f90b72331db90fce"
+      },
+      "keyDer" : "303e301006072a8648ce3d020106052b81040008032a000450cd6584a80522992ecc20c20280c358c15e5085e0a12cbbb20fbec12ce194c0f90b72331db90fce",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEUM1lhKgFIpkuzCDCAoDDWMFeUIXgoSy7\nsg++wSzhlMD5C3IzHbkPzg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 369,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f102e021500c0d64c9119a1ef31b0b2a60b24a93580b2ff29e5021500a064880a1352852176abfa15c2787c05d84f5e8d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 370,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302f1f021500c0d64c9119a1ef31b0b2a60b24a93580b2ff29e5021500a064880a1352852176abfa15c2787c05d84f5e8d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 371,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302f021500c0d64c9119a1ef31b0b2a60b24a93580b2ff29e51f021500a064880a1352852176abfa15c2787c05d84f5e8d",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp160r2_sha256_test.json
+++ b/testvectors/ecdsa_secp160r2_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 368,
+  "numberOfTests" : 371,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4475,6 +4475,56 @@
           "sig" : "302d02144f71a123bf7c4983f5707c17ce4782c833e833f0021500dcfb123cf5470f21375e62ba4054ffd9a836908c",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp160r2",
+        "keySize" : 160,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04e4d9ffe5ec17db4997519d0ae4219c47d8104498b1ac39296f239bb18008b6711545873c9fade258",
+        "wx" : "00e4d9ffe5ec17db4997519d0ae4219c47d8104498",
+        "wy" : "00b1ac39296f239bb18008b6711545873c9fade258"
+      },
+      "keyDer" : "303e301006072a8648ce3d020106052b8104001e032a0004e4d9ffe5ec17db4997519d0ae4219c47d8104498b1ac39296f239bb18008b6711545873c9fade258",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAE5Nn/5ewX20mXUZ0K5CGcR9gQRJixrDkp\nbyObsYAItnEVRYc8n63iWA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 369,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f102d02140af8cf160e6cdee66be28cc2e341d85210f931d0021500c85b8de817a9a998acf135a918c146c7ebde2b3e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 370,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302e1f02140af8cf160e6cdee66be28cc2e341d85210f931d0021500c85b8de817a9a998acf135a918c146c7ebde2b3e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 371,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302e02140af8cf160e6cdee66be28cc2e341d85210f931d01f021500c85b8de817a9a998acf135a918c146c7ebde2b3e",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp192k1_sha256_test.json
+++ b/testvectors/ecdsa_secp192k1_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 367,
+  "numberOfTests" : 370,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4470,6 +4470,56 @@
           "sig" : "3035021828d91785c005c416c436222a06578939d12c9ead1cfcd63c021900828921b3e632424caa08ce947d2ef43a3b9ccb89f5a74820",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp192k1",
+        "keySize" : 192,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04657a69e8020565f6bb0a6254d24e06805c75b6f1ad819d8c490866832f75cb6fbb7427eee4d89a767fdd5065000300f9",
+        "wx" : "657a69e8020565f6bb0a6254d24e06805c75b6f1ad819d8c",
+        "wy" : "490866832f75cb6fbb7427eee4d89a767fdd5065000300f9"
+      },
+      "keyDer" : "3046301006072a8648ce3d020106052b8104001f03320004657a69e8020565f6bb0a6254d24e06805c75b6f1ad819d8c490866832f75cb6fbb7427eee4d89a767fdd5065000300f9",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAEZXpp6AIFZfa7CmJU0k4GgFx1tvGtgZ2M\nSQhmgy91y2+7dCfu5Niadn/dUGUAAwD5\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 368,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f1036021900d781b83e5846f00406b23fd03959a9a050ff008a07b0a8140219009ecb5311ba692e0d41d5d7654d0c8c4ea7f71eb92b2e4996",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 369,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30371f021900d781b83e5846f00406b23fd03959a9a050ff008a07b0a8140219009ecb5311ba692e0d41d5d7654d0c8c4ea7f71eb92b2e4996",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 370,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3037021900d781b83e5846f00406b23fd03959a9a050ff008a07b0a8141f0219009ecb5311ba692e0d41d5d7654d0c8c4ea7f71eb92b2e4996",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp192r1_sha256_test.json
+++ b/testvectors/ecdsa_secp192r1_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 369,
+  "numberOfTests" : 372,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4526,6 +4526,56 @@
           "sig" : "303502190091cd55bb1984e9d793f9a17bd516aa7aa597569d2962225002183996aa1d58df66bddd4aaf70964775198137c819c9e6b88e",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp192r1",
+        "keySize" : 192,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04cd35a0b18eeb8fcd87ff019780012828745f046e785deba28150de1be6cb4376523006beff30ff09b4049125ced29723",
+        "wx" : "00cd35a0b18eeb8fcd87ff019780012828745f046e785deba2",
+        "wy" : "008150de1be6cb4376523006beff30ff09b4049125ced29723"
+      },
+      "keyDer" : "3049301306072a8648ce3d020106082a8648ce3d03010103320004cd35a0b18eeb8fcd87ff019780012828745f046e785deba28150de1be6cb4376523006beff30ff09b4049125ced29723",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEzTWgsY7rj82H/wGXgAEoKHRfBG54\nXeuigVDeG+bLQ3ZSMAa+/zD/CbQEkSXO0pcj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 370,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f10340218184abdfc6df2ed2d0c9c7067af5552c0238ca4aa7f8f8a030218508423e042b52945e2198ae8b4a97d3810961d886c6ce1e4",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 371,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30351f0218184abdfc6df2ed2d0c9c7067af5552c0238ca4aa7f8f8a030218508423e042b52945e2198ae8b4a97d3810961d886c6ce1e4",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 372,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30350218184abdfc6df2ed2d0c9c7067af5552c0238ca4aa7f8f8a031f0218508423e042b52945e2198ae8b4a97d3810961d886c6ce1e4",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp224r1_sha224_test.json
+++ b/testvectors/ecdsa_secp224r1_sha224_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 356,
+  "numberOfTests" : 359,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4502,6 +4502,56 @@
           "sig" : "303d021d00a4de0d931ddab90e667ebc0ad800ce49e971c60543abdc46cefff926021c550816170bd87593b9fb8ad5ed9ab4ddb12403ff6fe032252833bac4",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+        "wx" : "00eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7",
+        "wy" : "00eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5"
+      },
+      "keyDer" : "304e301006072a8648ce3d020106052b81040021033a0004eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE6tqTvhCyRJ4ei7WDBdUgCAE8VxB8GiCj\nF6bLp+ymcjQMA9HS4JZjKGaR31UGn6JUkMndn5wLsrU=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-224",
+      "tests" : [
+        {
+          "tcId" : 357,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f103c021c70049af31f8348673d56cece2b27e587a402f2a48f0b21a7911a480a021c2840bf24f6f66be287066b7cbf38788e1b7770b18fd1aa6a26d7c6dc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 358,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303d1f021c70049af31f8348673d56cece2b27e587a402f2a48f0b21a7911a480a021c2840bf24f6f66be287066b7cbf38788e1b7770b18fd1aa6a26d7c6dc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 359,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303d021c70049af31f8348673d56cece2b27e587a402f2a48f0b21a7911a480a1f021c2840bf24f6f66be287066b7cbf38788e1b7770b18fd1aa6a26d7c6dc",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp224r1_sha256_test.json
+++ b/testvectors/ecdsa_secp224r1_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 385,
+  "numberOfTests" : 388,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4731,6 +4731,56 @@
           "sig" : "303c021c1526eb2f657ebea9af4ca184b975c02372c88e24e835f3f5774c0e12021c1f1ecce38ee52372cb201907794de17b6d6c1afa13c316c51cb07bc7",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+        "wx" : "00eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7",
+        "wy" : "00eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5"
+      },
+      "keyDer" : "304e301006072a8648ce3d020106052b81040021033a0004eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE6tqTvhCyRJ4ei7WDBdUgCAE8VxB8GiCj\nF6bLp+ymcjQMA9HS4JZjKGaR31UGn6JUkMndn5wLsrU=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 386,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f103d021c3ade5c0624a5677ed7b6450d9420bbe028d499c23be9ef9d8b8a8a04021d009e82950ebe102f37ff3645cc7d3c1bab8864e5e03a5011eeba8150bc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 387,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e1f021c3ade5c0624a5677ed7b6450d9420bbe028d499c23be9ef9d8b8a8a04021d009e82950ebe102f37ff3645cc7d3c1bab8864e5e03a5011eeba8150bc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 388,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e021c3ade5c0624a5677ed7b6450d9420bbe028d499c23be9ef9d8b8a8a041f021d009e82950ebe102f37ff3645cc7d3c1bab8864e5e03a5011eeba8150bc",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp224r1_sha3_224_test.json
+++ b/testvectors/ecdsa_secp224r1_sha3_224_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 384,
+  "numberOfTests" : 387,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4728,6 +4728,56 @@
           "sig" : "303d021c2eb5db8a9e1c82ed4ce643c953c9f11c3de264ef92d7607c91dbce76021d00b6a97c943aa7a62b5783786356f7b75b36b88356eb62d5a3d15a7029",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+        "wx" : "00eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7",
+        "wy" : "00eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5"
+      },
+      "keyDer" : "304e301006072a8648ce3d020106052b81040021033a0004eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE6tqTvhCyRJ4ei7WDBdUgCAE8VxB8GiCj\nF6bLp+ymcjQMA9HS4JZjKGaR31UGn6JUkMndn5wLsrU=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-224",
+      "tests" : [
+        {
+          "tcId" : 385,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f103d021d00bdeb8edbcb30885c65bcb58d6ea2d4fe740d29c4c205d6ac15845376021c56c80970d9a308a9f639ed199ac088f93ba9afd04c53f48e4fa88d3a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 386,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e1f021d00bdeb8edbcb30885c65bcb58d6ea2d4fe740d29c4c205d6ac15845376021c56c80970d9a308a9f639ed199ac088f93ba9afd04c53f48e4fa88d3a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 387,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e021d00bdeb8edbcb30885c65bcb58d6ea2d4fe740d29c4c205d6ac158453761f021c56c80970d9a308a9f639ed199ac088f93ba9afd04c53f48e4fa88d3a",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp224r1_sha3_256_test.json
+++ b/testvectors/ecdsa_secp224r1_sha3_256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 393,
+  "numberOfTests" : 396,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4800,6 +4800,56 @@
           "sig" : "303e021d00e472e504ef4b293b7f4a6cc99ba33a702f35593f49cb284137776b44021d00c1efe440463fde3b604d48319e0ddb93261ae608d009942a01933241",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+        "wx" : "00eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7",
+        "wy" : "00eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5"
+      },
+      "keyDer" : "304e301006072a8648ce3d020106052b81040021033a0004eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE6tqTvhCyRJ4ei7WDBdUgCAE8VxB8GiCj\nF6bLp+ymcjQMA9HS4JZjKGaR31UGn6JUkMndn5wLsrU=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-256",
+      "tests" : [
+        {
+          "tcId" : 394,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f103d021d008ed6690a135a8f918c0598c2d2ffcd120bc36966c9897d160e763264021c2f396442932cb80e2cca3381ebf0d975f33f6d7b77da96aefba1216a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 395,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e1f021d008ed6690a135a8f918c0598c2d2ffcd120bc36966c9897d160e763264021c2f396442932cb80e2cca3381ebf0d975f33f6d7b77da96aefba1216a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 396,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e021d008ed6690a135a8f918c0598c2d2ffcd120bc36966c9897d160e7632641f021c2f396442932cb80e2cca3381ebf0d975f33f6d7b77da96aefba1216a",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp224r1_sha3_512_test.json
+++ b/testvectors/ecdsa_secp224r1_sha3_512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 458,
+  "numberOfTests" : 461,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5320,6 +5320,56 @@
           "sig" : "303e021d00b66a579ea2dca40e3a48074567af7daad34fd784e3ed097d1b39569c021d0094a2b72c713c109153863ebb71a8cc80f57094d811c13fa269e14a42",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+        "wx" : "00eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7",
+        "wy" : "00eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5"
+      },
+      "keyDer" : "304e301006072a8648ce3d020106052b81040021033a0004eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE6tqTvhCyRJ4ei7WDBdUgCAE8VxB8GiCj\nF6bLp+ymcjQMA9HS4JZjKGaR31UGn6JUkMndn5wLsrU=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 459,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f103d021d00fba71f1257bc26e0a99d33024c40e63ad266915389bca804cdaa5264021c352507aabd0f9bc223e1ac97a4ccb33b9de8ad3df447037367aa413b",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 460,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e1f021d00fba71f1257bc26e0a99d33024c40e63ad266915389bca804cdaa5264021c352507aabd0f9bc223e1ac97a4ccb33b9de8ad3df447037367aa413b",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 461,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303e021d00fba71f1257bc26e0a99d33024c40e63ad266915389bca804cdaa52641f021c352507aabd0f9bc223e1ac97a4ccb33b9de8ad3df447037367aa413b",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp224r1_sha512_test.json
+++ b/testvectors/ecdsa_secp224r1_sha512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 454,
+  "numberOfTests" : 457,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5286,6 +5286,56 @@
           "sig" : "303d021c0eb9dc5d67bb0d4009544f8654977907dfe770e7fae4571d31d7b4fa021d00ab5cda53e868bff5198be4be3681b186cb0c1396d272c71f093f8b12",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+        "wx" : "00eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7",
+        "wy" : "00eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5"
+      },
+      "keyDer" : "304e301006072a8648ce3d020106052b81040021033a0004eada93be10b2449e1e8bb58305d52008013c57107c1a20a317a6cba7eca672340c03d1d2e09663286691df55069fa25490c9dd9f9c0bb2b5",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE6tqTvhCyRJ4ei7WDBdUgCAE8VxB8GiCj\nF6bLp+ymcjQMA9HS4JZjKGaR31UGn6JUkMndn5wLsrU=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 455,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f103c021c691c723dd6a7f5d11b8c8e8bd0825c9fab0b99ee2b25f3658fdf92ab021c394766fb67a65fe0af6c154f7cbd285ea180b4c6150cdafafb0f6f0f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 456,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303d1f021c691c723dd6a7f5d11b8c8e8bd0825c9fab0b99ee2b25f3658fdf92ab021c394766fb67a65fe0af6c154f7cbd285ea180b4c6150cdafafb0f6f0f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 457,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303d021c691c723dd6a7f5d11b8c8e8bd0825c9fab0b99ee2b25f3658fdf92ab1f021c394766fb67a65fe0af6c154f7cbd285ea180b4c6150cdafafb0f6f0f",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp256k1_sha256_test.json
+++ b/testvectors/ecdsa_secp256k1_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 380,
+  "numberOfTests" : 383,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4774,6 +4774,56 @@
           "sig" : "3046022100edf03cf63f658883289a1a593d1007895b9f236d27c9c1f1313089aaed6b16ae022100e5b22903f7eb23adc2e01057e39b0408d495f694c83f306f1216c9bf87506074",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx" : "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy" : "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "keyDer" : "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 381,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f1046022100813ef79ccefa9a56f7ba805f0e478584fe5f0dd5f567bc09b5123ccbc9832365022100900e75ad233fcc908509dbff5922647db37c21f4afd3203ae8dc4ae7794b0f87",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 382,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30471f022100813ef79ccefa9a56f7ba805f0e478584fe5f0dd5f567bc09b5123ccbc9832365022100900e75ad233fcc908509dbff5922647db37c21f4afd3203ae8dc4ae7794b0f87",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 383,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047022100813ef79ccefa9a56f7ba805f0e478584fe5f0dd5f567bc09b5123ccbc98323651f022100900e75ad233fcc908509dbff5922647db37c21f4afd3203ae8dc4ae7794b0f87",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp256k1_sha3_256_test.json
+++ b/testvectors/ecdsa_secp256k1_sha3_256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 388,
+  "numberOfTests" : 391,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4838,6 +4838,56 @@
           "sig" : "30450221009d9cdb94e5e9a66bf8eedfdf9f1af43713bb05d880dec89aec21631958970de60220732932649bea35f11dfe0926618e4f091c1b264ca128a9eef14e6d94d7c9f207",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx" : "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy" : "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "keyDer" : "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-256",
+      "tests" : [
+        {
+          "tcId" : 389,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f1046022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022100bbdbc26e1099b2713ada34df9cfa8edaf905a4a6d2a1f449f05de03df8c2a696",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 390,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30471f022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022100bbdbc26e1099b2713ada34df9cfa8edaf905a4a6d2a1f449f05de03df8c2a696",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 391,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2511f022100bbdbc26e1099b2713ada34df9cfa8edaf905a4a6d2a1f449f05de03df8c2a696",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp256k1_sha3_512_test.json
+++ b/testvectors/ecdsa_secp256k1_sha3_512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 454,
+  "numberOfTests" : 457,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5366,6 +5366,56 @@
           "sig" : "3045022100921a16ea241e69c9d4f3bde6ba2cc7e10a27c9dfd8b92076d0a4a6d9f8ae0ab3022039b66ee2afd7db1099fee2cd8c69c9f1ea29047efacc1c6e8ee92e5a2244a40b",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx" : "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy" : "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "keyDer" : "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 455,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f104402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022059f100a7e4a774cf8f04577ebd9ab9ab2f09cfc5a6be10ffd0338524e6c26caa",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 456,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30451f02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022059f100a7e4a774cf8f04577ebd9ab9ab2f09cfc5a6be10ffd0338524e6c26caa",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 457,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe61f022059f100a7e4a774cf8f04577ebd9ab9ab2f09cfc5a6be10ffd0338524e6c26caa",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp256k1_sha512_test.json
+++ b/testvectors/ecdsa_secp256k1_sha512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 450,
+  "numberOfTests" : 453,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5334,6 +5334,56 @@
           "sig" : "3046022100dd60d7cf83a08208637212b65d079fb658d8ef1b8438d9c58f4122b0cd14ac49022100f1d762516f4d6c3e6a98dd31dc3869dc7cf35944f33b35c6a17fe632d2b18cd5",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx" : "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy" : "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "keyDer" : "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 451,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f104402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022034d2f1a567d7e647b178552dec35875a2cc61df3ce8ae2c1357ea8c5ff505561",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 452,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30451f02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022034d2f1a567d7e647b178552dec35875a2cc61df3ce8ae2c1357ea8c5ff505561",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 453,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e91f022034d2f1a567d7e647b178552dec35875a2cc61df3ce8ae2c1357ea8c5ff505561",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp256r1_sha256_test.json
+++ b/testvectors/ecdsa_secp256r1_sha256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 387,
+  "numberOfTests" : 390,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4890,6 +4890,56 @@
           "sig" : "3045022070bebe684cdcb5ca72a42f0d873879359bd1781a591809947628d313a3814f67022100aec03aca8f5587a4d535fa31027bbe9cc0e464b1c3577f4c2dcde6b2094798a9",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy" : "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 388,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f104402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 389,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30451f02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 390,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e181f02204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp256r1_sha3_256_test.json
+++ b/testvectors/ecdsa_secp256r1_sha3_256_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 395,
+  "numberOfTests" : 398,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4954,6 +4954,56 @@
           "sig" : "3046022100b686774db39201a9462b96842adbeea16ae6003789bb18214dab9e5a758bf6ef022100ffc6b396293b94c96fcb325fae127608ebfd118a46f715b49b918caafb602a34",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy" : "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-256",
+      "tests" : [
+        {
+          "tcId" : 396,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f10460221008ab9effd6738803fd19b92d2e9fdea1293056b793e29542b3b224af53e10c36e0221009364745a6a2d69f2283698fdfbee7b13de20bc93deb0230a9af3bd9fddf04401",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 397,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30471f0221008ab9effd6738803fd19b92d2e9fdea1293056b793e29542b3b224af53e10c36e0221009364745a6a2d69f2283698fdfbee7b13de20bc93deb0230a9af3bd9fddf04401",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 398,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470221008ab9effd6738803fd19b92d2e9fdea1293056b793e29542b3b224af53e10c36e1f0221009364745a6a2d69f2283698fdfbee7b13de20bc93deb0230a9af3bd9fddf04401",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp256r1_sha3_512_test.json
+++ b/testvectors/ecdsa_secp256r1_sha3_512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 461,
+  "numberOfTests" : 464,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5484,6 +5484,56 @@
           "sig" : "304502207bf225bec33ce7fb4014097e350c1504d3374028cda8f6fbbac4e0fa5319a048022100aaa45d54eba6bb3ce00ce8e63de24dc7ee19069062e8d340663adcac07f097cd",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy" : "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 462,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f1045022100dcbe02d38091fccba712175e1effda765021c6b8f211bc9d41a49377ed57ef2d02201202069b6b5ffadede2fdc290da1badc989ba98a9a491db339bfe478450ef9cc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 463,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30461f022100dcbe02d38091fccba712175e1effda765021c6b8f211bc9d41a49377ed57ef2d02201202069b6b5ffadede2fdc290da1badc989ba98a9a491db339bfe478450ef9cc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 464,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100dcbe02d38091fccba712175e1effda765021c6b8f211bc9d41a49377ed57ef2d1f02201202069b6b5ffadede2fdc290da1badc989ba98a9a491db339bfe478450ef9cc",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp256r1_sha512_test.json
+++ b/testvectors/ecdsa_secp256r1_sha512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 457,
+  "numberOfTests" : 460,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5450,6 +5450,56 @@
           "sig" : "3045022100b38ca4dac6d949be5e5f969860269f0eedff2eb92f45bfc02470300cc96dd52602201c7b22992bb13749cc0c5bc25330a17446e40db734203f9035172725fc70f863",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy" : "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 458,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f104402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002205f85a63a5be977ad714cea16b10035f07cadf7513ae8cca86f35b7692aafd69f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 459,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30451f02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002205f85a63a5be977ad714cea16b10035f07cadf7513ae8cca86f35b7692aafd69f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 460,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c01f02205f85a63a5be977ad714cea16b10035f07cadf7513ae8cca86f35b7692aafd69f",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp384r1_sha384_test.json
+++ b/testvectors/ecdsa_secp384r1_sha384_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 408,
+  "numberOfTests" : 411,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4918,6 +4918,56 @@
           "sig" : "3066023100dd4391ce7557cbd005e3d5d727cd264399dcc3c6501e4547505b6d57b40bbf0a7fac794dcc8d4233159dd0aa40d4e0b9023100a77fa1374fd60aa91600912200fc83c6aa447f8171ecea72ae322df32dccd68951dc5caf6c50380e400e45bf5c0e626b",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+        "wx" : "2da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa",
+        "wy" : "4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f"
+      },
+      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELaV92hCJJ2pUP5/9rAv/DZdsrXHrcoDn\n2b/Z/uS9svIPR/+IgnQ4l3LZjMV1ITiqS20FTWnc8+JexJ34cHFeNIg7GDYZfXb4\nrZYuePZXG7x0B7DWCR+eTYjwFCdEBhdP\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 409,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f1064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702301840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca03995ca30240e09513805bf6209b58ac7aa9cff54eecd82b9f1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 410,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30651f023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702301840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca03995ca30240e09513805bf6209b58ac7aa9cff54eecd82b9f1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 411,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d71f02301840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca03995ca30240e09513805bf6209b58ac7aa9cff54eecd82b9f1",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp384r1_sha3_384_test.json
+++ b/testvectors/ecdsa_secp384r1_sha3_384_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 418,
+  "numberOfTests" : 421,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -4995,6 +4995,56 @@
           "sig" : "30650230024deac92bccdf77a3fe019fb5d35063c9ad9374bf1e7508218b25776815eb95f51c8c253f88991c3073c67ca8bbd5770231008da6b6f9fde42f24536413f8c2d3506171c742b6a0883de116b314d559388b41630aa24c485e090fee5f340c79486164",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+        "wx" : "2da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa",
+        "wy" : "4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f"
+      },
+      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELaV92hCJJ2pUP5/9rAv/DZdsrXHrcoDn\n2b/Z/uS9svIPR/+IgnQ4l3LZjMV1ITiqS20FTWnc8+JexJ34cHFeNIg7GDYZfXb4\nrZYuePZXG7x0B7DWCR+eTYjwFCdEBhdP\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-384",
+      "tests" : [
+        {
+          "tcId" : 419,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f1065023034a42eda6d8a881c6a3369fd89db629c9b61904c86019726ed8db04fc617bda742990a70fcf7dfd92a9e2527dd4db44c023100c0bb0ee1bffc6c7b74609ec20c460ec47f4d068f33d601870778e5e474860d77834d744db219e6abae9c32912907efd2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 420,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30661f023034a42eda6d8a881c6a3369fd89db629c9b61904c86019726ed8db04fc617bda742990a70fcf7dfd92a9e2527dd4db44c023100c0bb0ee1bffc6c7b74609ec20c460ec47f4d068f33d601870778e5e474860d77834d744db219e6abae9c32912907efd2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 421,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023034a42eda6d8a881c6a3369fd89db629c9b61904c86019726ed8db04fc617bda742990a70fcf7dfd92a9e2527dd4db44c1f023100c0bb0ee1bffc6c7b74609ec20c460ec47f4d068f33d601870778e5e474860d77834d744db219e6abae9c32912907efd2",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp384r1_sha3_512_test.json
+++ b/testvectors/ecdsa_secp384r1_sha3_512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 450,
+  "numberOfTests" : 453,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5256,6 +5256,56 @@
           "sig" : "3064023038897bbcf7f806e2c7d32d9376462b0ac097717b984b3acfdb66cba4d20f2ea36f728342c21e6e9aaa517416c2ded86002300790f3b0f4a0c567ac9f58fdb42d1fc77ec08fc347736661cd73dd37993baad45af89a26d4154a6fafd81b4bae060e92",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+        "wx" : "2da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa",
+        "wy" : "4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f"
+      },
+      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELaV92hCJJ2pUP5/9rAv/DZdsrXHrcoDn\n2b/Z/uS9svIPR/+IgnQ4l3LZjMV1ITiqS20FTWnc8+JexJ34cHFeNIg7GDYZfXb4\nrZYuePZXG7x0B7DWCR+eTYjwFCdEBhdP\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 451,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f1065023100fbd23a1b04d2696c9cc86d93c8e8325427802fe7710f65e06a2cadee943f8e0ddf1ac0732ff5305abad42fab72b7ab760230302d08b563b09fbd4bb648f56a35794a12d24f48cefb874eac860c115c043020c92da2a8a55ad7b52aa165bbb90ff909",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 452,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30661f023100fbd23a1b04d2696c9cc86d93c8e8325427802fe7710f65e06a2cadee943f8e0ddf1ac0732ff5305abad42fab72b7ab760230302d08b563b09fbd4bb648f56a35794a12d24f48cefb874eac860c115c043020c92da2a8a55ad7b52aa165bbb90ff909",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 453,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fbd23a1b04d2696c9cc86d93c8e8325427802fe7710f65e06a2cadee943f8e0ddf1ac0732ff5305abad42fab72b7ab761f0230302d08b563b09fbd4bb648f56a35794a12d24f48cefb874eac860c115c043020c92da2a8a55ad7b52aa165bbb90ff909",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp384r1_sha512_test.json
+++ b/testvectors/ecdsa_secp384r1_sha512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 446,
+  "numberOfTests" : 449,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5224,6 +5224,56 @@
           "sig" : "306402306bf6fa7a663802c3382cc5fd02004ec71e5a031e3d9bfc0858fa994e88497a7782308bc265b8237a6bbbdd38658b36fc02303a9d5941a013bf70d99cc3ff255ce85573688dac40344b5db7144b19bf57bb2701e6850a8f819796b67f7d0b6aea7e50",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+        "wx" : "2da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa",
+        "wy" : "4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f"
+      },
+      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELaV92hCJJ2pUP5/9rAv/DZdsrXHrcoDn\n2b/Z/uS9svIPR/+IgnQ4l3LZjMV1ITiqS20FTWnc8+JexJ34cHFeNIg7GDYZfXb4\nrZYuePZXG7x0B7DWCR+eTYjwFCdEBhdP\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 447,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f1065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202307b0a10ee2dd0dd2fab75095af240d095e446faba7a50a19fbb197e4c4250926e30c5303a2c2d34250f17fcf5ab3181a6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 448,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30661f023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202307b0a10ee2dd0dd2fab75095af240d095e446faba7a50a19fbb197e4c4250926e30c5303a2c2d34250f17fcf5ab3181a6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 449,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e21f02307b0a10ee2dd0dd2fab75095af240d095e446faba7a50a19fbb197e4c4250926e30c5303a2c2d34250f17fcf5ab3181a6",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp521r1_sha3_512_test.json
+++ b/testvectors/ecdsa_secp521r1_sha3_512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 449,
+  "numberOfTests" : 452,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5301,6 +5301,56 @@
           "sig" : "3081880242019c5d65ec2257ece62f146d9c61661789151ccce3a045c60a03f2034eec2e84eb54414825529b9e1bc6c19581e3ab827166ff4e4722bc10447bbff9a5758839b82602420191e1bb04a72eac5dec7c021bae1fc37d9bc81e0acdd09ae63464009a01751394a8593084f634c191045a632073aae56eb65d88ac1ac6fb309dcbcf76f22ae652c9",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04005c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508007878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6",
+        "wx" : "5c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508",
+        "wy" : "7878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6"
+      },
+      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508007878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXGRX7AiNUy9IIJOWWuU8zQflVu1Z\n4q+UXNjHqVwcZE+KVqioo813OS3dhh6Kkk2smcaQaQk71SpS+mxWAEoHRQgAeHjW\n1C5LTdHpwGlss+GfYwM8PbTmDUcyWbPr4Hmq8KmG7mF3+CF6eMaLgT9+FJpOVv2V\nYsB/7T2JWULX0QHLg/Y=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 450,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f108188024201ce1817011741fa212bd3c0ef00eb3037c038892358407fcd3e2267bfc02a376ed3a5f26299e4d080be733fe91545eca5cf086bbec5c1077c09f3165b7db496a6b2024201abcd9bbc11d77ae8aacb4dc113aa0d5a53ee51b5e4b189befeed4649f35c97fe595e3ee86ba4c3358e80dd91c4e7db45cfd0fa027f18458c30602d7038515558b8",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 451,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081891f024201ce1817011741fa212bd3c0ef00eb3037c038892358407fcd3e2267bfc02a376ed3a5f26299e4d080be733fe91545eca5cf086bbec5c1077c09f3165b7db496a6b2024201abcd9bbc11d77ae8aacb4dc113aa0d5a53ee51b5e4b189befeed4649f35c97fe595e3ee86ba4c3358e80dd91c4e7db45cfd0fa027f18458c30602d7038515558b8",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 452,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308189024201ce1817011741fa212bd3c0ef00eb3037c038892358407fcd3e2267bfc02a376ed3a5f26299e4d080be733fe91545eca5cf086bbec5c1077c09f3165b7db496a6b21f024201abcd9bbc11d77ae8aacb4dc113aa0d5a53ee51b5e4b189befeed4649f35c97fe595e3ee86ba4c3358e80dd91c4e7db45cfd0fa027f18458c30602d7038515558b8",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_secp521r1_sha512_test.json
+++ b/testvectors/ecdsa_secp521r1_sha512_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 447,
+  "numberOfTests" : 450,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5285,6 +5285,56 @@
           "sig" : "308188024201a2af29c58184ca861e7cd931f39cea064b199eee563f241cd5ecf6ebb2ade728f1be23cf007ebe8ef0c42d99f9f5190f6815446afc3043a820d7daf27e86b83b8a024201a2acd1822eb539383defff8769aad8bacd50cd24ca7aa6670671418110177808c3f4fbe6041b9cb898359ee61e04824adedd62b39fe5791907a20586333bd3c76d",
           "result" : "valid",
           "flags" : []
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "type" : "EcPublicKey",
+        "uncompressed" : "04005c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508007878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6",
+        "wx" : "5c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508",
+        "wy" : "7878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6"
+      },
+      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508007878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXGRX7AiNUy9IIJOWWuU8zQflVu1Z\n4q+UXNjHqVwcZE+KVqioo813OS3dhh6Kkk2smcaQaQk71SpS+mxWAEoHRQgAeHjW\n1C5LTdHpwGlss+GfYwM8PbTmDUcyWbPr4Hmq8KmG7mF3+CF6eMaLgT9+FJpOVv2V\nYsB/7T2JWULX0QHLg/Y=\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 448,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f10818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024201d74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f5a27a24a1aae1e218fdccd8cd7d4990b666d4bf4902b84fdad123f941fe906d948",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 449,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081881f02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024201d74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f5a27a24a1aae1e218fdccd8cd7d4990b666d4bf4902b84fdad123f941fe906d948",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 450,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86451f024201d74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f5a27a24a1aae1e218fdccd8cd7d4990b666d4bf4902b84fdad123f941fe906d948",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors/ecdsa_test.json
+++ b/testvectors/ecdsa_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDSA",
-  "numberOfTests" : 1575,
+  "numberOfTests" : 1578,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -27426,6 +27426,56 @@
           "flags" : [
             "GroupIsomorphism"
           ]
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "key" : {
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "type" : "EcPublicKey",
+        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy" : "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 1576,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3f104402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 1577,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30451f02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 1578,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e181f02204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha224_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha224_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 440,
+  "numberOfTests" : 443,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6434,6 +6434,56 @@
           "msg" : "4d657373616765",
           "sig" : "303c021c625f473ca2d15bb7f12da1235f90adcb69ed4818746cae2e2db26fe6021c4ab817f6f1b9c8c49f681bed1568346f53ecbfacfd52d45e27abcbb0",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP224r1",
+        "keySize" : 224,
+        "uncompressed" : "04b554fc25e9f098eaf1466c35328c97305d0d4aa0e4462e8baf7a8e7ed08fc40eb01dc855577baea9e3070770616f57b17ea9854cad93881a",
+        "wx" : "00b554fc25e9f098eaf1466c35328c97305d0d4aa0e4462e8baf7a8e7e",
+        "wy" : "00d08fc40eb01dc855577baea9e3070770616f57b17ea9854cad93881a"
+      },
+      "publicKeyDer" : "3052301406072a8648ce3d020106092b2403030208010105033a0004b554fc25e9f098eaf1466c35328c97305d0d4aa0e4462e8baf7a8e7ed08fc40eb01dc855577baea9e3070770616f57b17ea9854cad93881a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABLVU/CXp8Jjq8UZsNTKMlzBdDUqg\n5EYui696jn7Qj8QOsB3IVVd7rqnjBwdwYW9XsX6phUytk4ga\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-224",
+      "tests" : [
+        {
+          "tcId" : 441,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103e021d00b982bea80d10816bb450a3faaaed4ed54fb197b3bff95af25d7d3786021d009e6ea2e58713f1304d29debf8559a74a89e018bae28b05556e5482a1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 442,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303f1f021d00b982bea80d10816bb450a3faaaed4ed54fb197b3bff95af25d7d3786021d009e6ea2e58713f1304d29debf8559a74a89e018bae28b05556e5482a1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 443,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303f021d00b982bea80d10816bb450a3faaaed4ed54fb197b3bff95af25d7d37861f021d009e6ea2e58713f1304d29debf8559a74a89e018bae28b05556e5482a1",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha3_224_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha3_224_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 468,
+  "numberOfTests" : 471,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6714,6 +6714,56 @@
           "msg" : "4d657373616765",
           "sig" : "303e021d00cc7a1d1ffe41cead37e3eb4969cc954e38a1e9befa10e9112236c89c021d008fa6e67ab5c9ea4356065b98bc37ac35d8e58a3d68649fedd295f5ad",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP224r1",
+        "keySize" : 224,
+        "uncompressed" : "04b554fc25e9f098eaf1466c35328c97305d0d4aa0e4462e8baf7a8e7ed08fc40eb01dc855577baea9e3070770616f57b17ea9854cad93881a",
+        "wx" : "00b554fc25e9f098eaf1466c35328c97305d0d4aa0e4462e8baf7a8e7e",
+        "wy" : "00d08fc40eb01dc855577baea9e3070770616f57b17ea9854cad93881a"
+      },
+      "publicKeyDer" : "3052301406072a8648ce3d020106092b2403030208010105033a0004b554fc25e9f098eaf1466c35328c97305d0d4aa0e4462e8baf7a8e7ed08fc40eb01dc855577baea9e3070770616f57b17ea9854cad93881a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABLVU/CXp8Jjq8UZsNTKMlzBdDUqg\n5EYui696jn7Qj8QOsB3IVVd7rqnjBwdwYW9XsX6phUytk4ga\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-224",
+      "tests" : [
+        {
+          "tcId" : 469,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103c021c6d8a31020d2c2e7238de3f3799d4b7269cc14901a182596df4494407021c3def9f1839b96523d042081cc2d1f70a40f79d895a375729b99a7548",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 470,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303d1f021c6d8a31020d2c2e7238de3f3799d4b7269cc14901a182596df4494407021c3def9f1839b96523d042081cc2d1f70a40f79d895a375729b99a7548",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 471,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303d021c6d8a31020d2c2e7238de3f3799d4b7269cc14901a182596df44944071f021c3def9f1839b96523d042081cc2d1f70a40f79d895a375729b99a7548",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 472,
+  "numberOfTests" : 475,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6828,6 +6828,56 @@
           "msg" : "4d657373616765",
           "sig" : "304402206b0d70e09ba1642adac06dff9b52e22a3e4aab4180e372665691412241e743a002204d7d30ff8a210de69e3e6d1ecf7175f89f481a4d9ed06beaf7148da47f4af9e9",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP256r1",
+        "keySize" : 256,
+        "uncompressed" : "042676bd1e3fd83f3328d1af941442c036760f09587729419053083eb61d1ed22c2cf769688a5ffd67da1899d243e66bcabe21f9e78335263bf5308b8e41a71b39",
+        "wx" : "2676bd1e3fd83f3328d1af941442c036760f09587729419053083eb61d1ed22c",
+        "wy" : "2cf769688a5ffd67da1899d243e66bcabe21f9e78335263bf5308b8e41a71b39"
+      },
+      "publicKeyDer" : "305a301406072a8648ce3d020106092b2403030208010107034200042676bd1e3fd83f3328d1af941442c036760f09587729419053083eb61d1ed22c2cf769688a5ffd67da1899d243e66bcabe21f9e78335263bf5308b8e41a71b39",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABCZ2vR4/2D8zKNGvlBRCwDZ2DwlY\ndylBkFMIPrYdHtIsLPdpaIpf/WfaGJnSQ+Zryr4h+eeDNSY79TCLjkGnGzk=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 473,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10440220745be1da902d19c76c8f57d4a1f3362b4b20ed7c8de8fc0463d566795f979cea02205916c317a1e325b53735216a0fa37737f08b32245c88084817b468a41f5afee9",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 474,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30451f0220745be1da902d19c76c8f57d4a1f3362b4b20ed7c8de8fc0463d566795f979cea02205916c317a1e325b53735216a0fa37737f08b32245c88084817b468a41f5afee9",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 475,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30450220745be1da902d19c76c8f57d4a1f3362b4b20ed7c8de8fc0463d566795f979cea1f02205916c317a1e325b53735216a0fa37737f08b32245c88084817b468a41f5afee9",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha3_256_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha3_256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 480,
+  "numberOfTests" : 483,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6908,6 +6908,56 @@
           "msg" : "4d657373616765",
           "sig" : "3045022100819979e8dc2f74cb11a9444480ea072402ee4d8618d81d38335a6752e7094eeb022059a6994a157bd8d18856ee4aa878d03524d37db6f3a8d98c82dd6a8dbdd93638",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP256r1",
+        "keySize" : 256,
+        "uncompressed" : "042676bd1e3fd83f3328d1af941442c036760f09587729419053083eb61d1ed22c2cf769688a5ffd67da1899d243e66bcabe21f9e78335263bf5308b8e41a71b39",
+        "wx" : "2676bd1e3fd83f3328d1af941442c036760f09587729419053083eb61d1ed22c",
+        "wy" : "2cf769688a5ffd67da1899d243e66bcabe21f9e78335263bf5308b8e41a71b39"
+      },
+      "publicKeyDer" : "305a301406072a8648ce3d020106092b2403030208010107034200042676bd1e3fd83f3328d1af941442c036760f09587729419053083eb61d1ed22c2cf769688a5ffd67da1899d243e66bcabe21f9e78335263bf5308b8e41a71b39",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABCZ2vR4/2D8zKNGvlBRCwDZ2DwlY\ndylBkFMIPrYdHtIsLPdpaIpf/WfaGJnSQ+Zryr4h+eeDNSY79TCLjkGnGzk=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-256",
+      "tests" : [
+        {
+          "tcId" : 481,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10440221008cb8886a70de6ff2080cd46dca0d7fd99586d561199dc22b49eef2725b3e2c60021f137f519df89193db550373a9a5e70ec0a5db85933e3bddae77cb58bb87fe68",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 482,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30451f0221008cb8886a70de6ff2080cd46dca0d7fd99586d561199dc22b49eef2725b3e2c60021f137f519df89193db550373a9a5e70ec0a5db85933e3bddae77cb58bb87fe68",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 483,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30450221008cb8886a70de6ff2080cd46dca0d7fd99586d561199dc22b49eef2725b3e2c601f021f137f519df89193db550373a9a5e70ec0a5db85933e3bddae77cb58bb87fe68",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 476,
+  "numberOfTests" : 479,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6713,6 +6713,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "3055022900ad0b664f9559e29e46fd4fd390e75abebf14997d17a1a3304c80e451fc8f79bb7cff168e17de6f2202281e320a292c640b636951c80d8bb7200e915daff31a147060742ee21c8fca0cb3a58279e87789f070",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP320r1",
+        "keySize" : 320,
+        "uncompressed" : "0444ab2320c2297b66114428df33fe641956f82033893398af3b49b0023179201c27d26dd65121c06e0c59524c938f19daffc2a9a4679dba7cf1991ced4700592bb75e98cf77dbf6c584c2f72735152921",
+        "wx" : "44ab2320c2297b66114428df33fe641956f82033893398af3b49b0023179201c27d26dd65121c06e",
+        "wy" : "0c59524c938f19daffc2a9a4679dba7cf1991ced4700592bb75e98cf77dbf6c584c2f72735152921"
+      },
+      "publicKeyDer" : "306a301406072a8648ce3d020106092b24030302080101090352000444ab2320c2297b66114428df33fe641956f82033893398af3b49b0023179201c27d26dd65121c06e0c59524c938f19daffc2a9a4679dba7cf1991ced4700592bb75e98cf77dbf6c584c2f72735152921",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABESrIyDCKXtmEUQo3zP+ZBlW+CAz\niTOYrztJsAIxeSAcJ9Jt1lEhwG4MWVJMk48Z2v/CqaRnnbp88Zkc7UcAWSu3XpjP\nd9v2xYTC9yc1FSkh\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 477,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10540229009cf7f0d60cc1fb2d4b3e78d5f83b374e17a4aebccc6e723f1ad35babb2acfb2b75530389189395f802271110c5b8b8e5fa8dc7952a7bf6200bddae6c1d66639a07a4b6046e00bfa7a2bd9d5777b80c3a92",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 478,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30551f0229009cf7f0d60cc1fb2d4b3e78d5f83b374e17a4aebccc6e723f1ad35babb2acfb2b75530389189395f802271110c5b8b8e5fa8dc7952a7bf6200bddae6c1d66639a07a4b6046e00bfa7a2bd9d5777b80c3a92",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 479,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30550229009cf7f0d60cc1fb2d4b3e78d5f83b374e17a4aebccc6e723f1ad35babb2acfb2b75530389189395f81f02271110c5b8b8e5fa8dc7952a7bf6200bddae6c1d66639a07a4b6046e00bfa7a2bd9d5777b80c3a92",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha3_384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha3_384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 486,
+  "numberOfTests" : 489,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6808,6 +6808,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "3055022900ae4a5dbcaf940fc15449b517cbccfde29e70de386a15ee4ac30454e4c1b273d4b8787b0b6567b1a402281e320a292c640b636951c80d8bb7200e915daff31a147060742ee21c8fca0cb3a58279e87789f070",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP320r1",
+        "keySize" : 320,
+        "uncompressed" : "0444ab2320c2297b66114428df33fe641956f82033893398af3b49b0023179201c27d26dd65121c06e0c59524c938f19daffc2a9a4679dba7cf1991ced4700592bb75e98cf77dbf6c584c2f72735152921",
+        "wx" : "44ab2320c2297b66114428df33fe641956f82033893398af3b49b0023179201c27d26dd65121c06e",
+        "wy" : "0c59524c938f19daffc2a9a4679dba7cf1991ced4700592bb75e98cf77dbf6c584c2f72735152921"
+      },
+      "publicKeyDer" : "306a301406072a8648ce3d020106092b24030302080101090352000444ab2320c2297b66114428df33fe641956f82033893398af3b49b0023179201c27d26dd65121c06e0c59524c938f19daffc2a9a4679dba7cf1991ced4700592bb75e98cf77dbf6c584c2f72735152921",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABESrIyDCKXtmEUQo3zP+ZBlW+CAz\niTOYrztJsAIxeSAcJ9Jt1lEhwG4MWVJMk48Z2v/CqaRnnbp88Zkc7UcAWSu3XpjP\nd9v2xYTC9yc1FSkh\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-384",
+      "tests" : [
+        {
+          "tcId" : 487,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f105502281df0b7216839cbb0053b366f923c33026fc24098f018447d0cc6876c1676e07e499d948316cd3a48022900826976dc125cf3e56ec88a6f8f0869fec2170d5ddf322057d7b3408860862d8f30752a46c131cc25",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 488,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30561f02281df0b7216839cbb0053b366f923c33026fc24098f018447d0cc6876c1676e07e499d948316cd3a48022900826976dc125cf3e56ec88a6f8f0869fec2170d5ddf322057d7b3408860862d8f30752a46c131cc25",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 489,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "305602281df0b7216839cbb0053b366f923c33026fc24098f018447d0cc6876c1676e07e499d948316cd3a481f022900826976dc125cf3e56ec88a6f8f0869fec2170d5ddf322057d7b3408860862d8f30752a46c131cc25",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 503,
+  "numberOfTests" : 506,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7161,6 +7161,56 @@
           "msg" : "4d657373616765",
           "sig" : "3065023100818b0fd6ca0978a59cad3fa15e84db2896f39b2aa462f0583834fa4444d153fe61e0c93071ba96c5ffa7193f77b806f302301d2d6144172385f857db4b7e7e863962eacacdec034b4b4a9dd1af272604403f39f45a21948b30976e738e9e98fd9cee",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP384r1",
+        "keySize" : 384,
+        "uncompressed" : "046c9aaba343cb2faf098319cc4d15ea218786f55c8cf0a8b668091170a6422f6c2498945a8164a4b6f27cdd11e800da501be961b37b09804610ce0df40dd8236c75a12d0c8014b163464a4aeba7cb18d20d3222083ec4a941852f24aa3d5d84e3",
+        "wx" : "6c9aaba343cb2faf098319cc4d15ea218786f55c8cf0a8b668091170a6422f6c2498945a8164a4b6f27cdd11e800da50",
+        "wy" : "1be961b37b09804610ce0df40dd8236c75a12d0c8014b163464a4aeba7cb18d20d3222083ec4a941852f24aa3d5d84e3"
+      },
+      "publicKeyDer" : "307a301406072a8648ce3d020106092b240303020801010b036200046c9aaba343cb2faf098319cc4d15ea218786f55c8cf0a8b668091170a6422f6c2498945a8164a4b6f27cdd11e800da501be961b37b09804610ce0df40dd8236c75a12d0c8014b163464a4aeba7cb18d20d3222083ec4a941852f24aa3d5d84e3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABGyaq6NDyy+vCYMZzE0V6iGHhvVc\njPCotmgJEXCmQi9sJJiUWoFkpLbyfN0R6ADaUBvpYbN7CYBGEM4N9A3YI2x1oS0M\ngBSxY0ZKSuunyxjSDTIiCD7EqUGFLySqPV2E4w==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 504,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1064023065fd456814371d60883ffda5f74f36dc2d45886121770e29ed3163754716d12c1cab03a2cb6a6e3376fc96d8727bd1bf02301aa65e57932d05788413219b7ab23e5337f63fb2dcb0f89b4227d284a3fcbdf3c54c021a6c0ca42445bf802213121654",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 505,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30651f023065fd456814371d60883ffda5f74f36dc2d45886121770e29ed3163754716d12c1cab03a2cb6a6e3376fc96d8727bd1bf02301aa65e57932d05788413219b7ab23e5337f63fb2dcb0f89b4227d284a3fcbdf3c54c021a6c0ca42445bf802213121654",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 506,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3065023065fd456814371d60883ffda5f74f36dc2d45886121770e29ed3163754716d12c1cab03a2cb6a6e3376fc96d8727bd1bf1f02301aa65e57932d05788413219b7ab23e5337f63fb2dcb0f89b4227d284a3fcbdf3c54c021a6c0ca42445bf802213121654",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha3_384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha3_384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 513,
+  "numberOfTests" : 516,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7261,6 +7261,56 @@
           "msg" : "4d657373616765",
           "sig" : "306402300764c51cbe588255927756ef3f9e84925486baa4ac7e4dc4f8e0889950690728aa2f748bfbfd7e2f29fc5b9b58a2e4b40230522f73fe54b6efddc2566bb5d020eb8183d88f987219c2df9cb98a33958a2698f0384ce93578b1178233bca0411d4754",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP384r1",
+        "keySize" : 384,
+        "uncompressed" : "046c9aaba343cb2faf098319cc4d15ea218786f55c8cf0a8b668091170a6422f6c2498945a8164a4b6f27cdd11e800da501be961b37b09804610ce0df40dd8236c75a12d0c8014b163464a4aeba7cb18d20d3222083ec4a941852f24aa3d5d84e3",
+        "wx" : "6c9aaba343cb2faf098319cc4d15ea218786f55c8cf0a8b668091170a6422f6c2498945a8164a4b6f27cdd11e800da50",
+        "wy" : "1be961b37b09804610ce0df40dd8236c75a12d0c8014b163464a4aeba7cb18d20d3222083ec4a941852f24aa3d5d84e3"
+      },
+      "publicKeyDer" : "307a301406072a8648ce3d020106092b240303020801010b036200046c9aaba343cb2faf098319cc4d15ea218786f55c8cf0a8b668091170a6422f6c2498945a8164a4b6f27cdd11e800da501be961b37b09804610ce0df40dd8236c75a12d0c8014b163464a4aeba7cb18d20d3222083ec4a941852f24aa3d5d84e3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABGyaq6NDyy+vCYMZzE0V6iGHhvVc\njPCotmgJEXCmQi9sJJiUWoFkpLbyfN0R6ADaUBvpYbN7CYBGEM4N9A3YI2x1oS0M\ngBSxY0ZKSuunyxjSDTIiCD7EqUGFLySqPV2E4w==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-384",
+      "tests" : [
+        {
+          "tcId" : 514,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f106402301daf64b9ed9a7168b5cff72717d48cd81f01ed3c4b53276cd2e4ab2d2f077847202469b233bcada1fa62938b898a65da02304319e8549570ea906c8b3b8f8167b11f3bedfebcf866c181cea8fd96eaa62d0e492b783cb475432d80c070a0be9d66a6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 515,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30651f02301daf64b9ed9a7168b5cff72717d48cd81f01ed3c4b53276cd2e4ab2d2f077847202469b233bcada1fa62938b898a65da02304319e8549570ea906c8b3b8f8167b11f3bedfebcf866c181cea8fd96eaa62d0e492b783cb475432d80c070a0be9d66a6",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 516,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "306502301daf64b9ed9a7168b5cff72717d48cd81f01ed3c4b53276cd2e4ab2d2f077847202469b233bcada1fa62938b898a65da1f02304319e8549570ea906c8b3b8f8167b11f3bedfebcf866c181cea8fd96eaa62d0e492b783cb475432d80c070a0be9d66a6",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha3_512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 550,
+  "numberOfTests" : 553,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7694,6 +7694,56 @@
           "msg" : "4d657373616765",
           "sig" : "30818402406d33308ec4b9c24a16087c9787c638ad940f8573e8a3b43efa34cdf8ebd16bc32bc96738c993004a6ac4041277e80c2182745dad23355c1f3a9084d1e1ffd88502404bdf5d90681327fbcc38d8e15c699e6928b36bae1c19a13879e9224177e013fa1e8794e609065c48ffc5d722c031d643864fc80d6343a9018fc85d5c4bd47e78",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP512r1",
+        "keySize" : 512,
+        "uncompressed" : "041ec7fe2275860c3bc0e4e6e459af7e16985d37adba7351ac357a7c397e07522ea41bcca8e89777fe05b8f0d9dc8c614004fcaf30a97001a5011a159f46fcd5443cbc1ddfc7ac89a1a2f8eef77bf9bba8ade73da2100cb6a371546b495fb5ea885eb631645e79591db659c49266d263d5cbd3403081cb407536efe9a5bec69955",
+        "wx" : "1ec7fe2275860c3bc0e4e6e459af7e16985d37adba7351ac357a7c397e07522ea41bcca8e89777fe05b8f0d9dc8c614004fcaf30a97001a5011a159f46fcd544",
+        "wy" : "3cbc1ddfc7ac89a1a2f8eef77bf9bba8ade73da2100cb6a371546b495fb5ea885eb631645e79591db659c49266d263d5cbd3403081cb407536efe9a5bec69955"
+      },
+      "publicKeyDer" : "30819b301406072a8648ce3d020106092b240303020801010d03818200041ec7fe2275860c3bc0e4e6e459af7e16985d37adba7351ac357a7c397e07522ea41bcca8e89777fe05b8f0d9dc8c614004fcaf30a97001a5011a159f46fcd5443cbc1ddfc7ac89a1a2f8eef77bf9bba8ade73da2100cb6a371546b495fb5ea885eb631645e79591db659c49266d263d5cbd3403081cb407536efe9a5bec69955",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEHsf+InWGDDvA5ObkWa9+Fphd\nN626c1GsNXp8OX4HUi6kG8yo6Jd3/gW48NncjGFABPyvMKlwAaUBGhWfRvzVRDy8\nHd/HrImhovju93v5u6it5z2iEAy2o3FUa0lfteqIXrYxZF55WR22WcSSZtJj1cvT\nQDCBy0B1Nu/ppb7GmVU=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 551,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1081850241008a7e0a277d49c29d3ed8b0dffbff6fb07644f71005a992bed255b2b5a5c10fd931f3b379cd644427a1c3311d863298b75c7cf5413e8ed8ddf11fc74be0b7e0ce024078c5950ad2b4b1b976a643cfc610dcab6bb148c473d4c186904ff30a1da1c68f6f83f6c1db5f7adcdefc1c8de931790779e236f2a504dc8b0b7c6ca4cb163f5c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 552,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3081861f0241008a7e0a277d49c29d3ed8b0dffbff6fb07644f71005a992bed255b2b5a5c10fd931f3b379cd644427a1c3311d863298b75c7cf5413e8ed8ddf11fc74be0b7e0ce024078c5950ad2b4b1b976a643cfc610dcab6bb148c473d4c186904ff30a1da1c68f6f83f6c1db5f7adcdefc1c8de931790779e236f2a504dc8b0b7c6ca4cb163f5c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 553,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3081860241008a7e0a277d49c29d3ed8b0dffbff6fb07644f71005a992bed255b2b5a5c10fd931f3b379cd644427a1c3311d863298b75c7cf5413e8ed8ddf11fc74be0b7e0ce1f024078c5950ad2b4b1b976a643cfc610dcab6bb148c473d4c186904ff30a1da1c68f6f83f6c1db5f7adcdefc1c8de931790779e236f2a504dc8b0b7c6ca4cb163f5c",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 546,
+  "numberOfTests" : 549,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7649,6 +7649,56 @@
           "msg" : "4d657373616765",
           "sig" : "308185024019524b15cf4ecb400b938ef5f752b86ec8f07c5903da5dba9c91ab7965b1223a8e262bef8cca8973ed98797f37a35e1c5999cf203e610ef773c6aa2786bba06402410098cf7526f5a24a0e2f22f909f8190b13130451b15dd6774bdea9d929342d924bc7eba1df89919c1b9aee8d09203606d10cebff89904cb7e71a82d8972d755306",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "brainpoolP512r1",
+        "keySize" : 512,
+        "uncompressed" : "041ec7fe2275860c3bc0e4e6e459af7e16985d37adba7351ac357a7c397e07522ea41bcca8e89777fe05b8f0d9dc8c614004fcaf30a97001a5011a159f46fcd5443cbc1ddfc7ac89a1a2f8eef77bf9bba8ade73da2100cb6a371546b495fb5ea885eb631645e79591db659c49266d263d5cbd3403081cb407536efe9a5bec69955",
+        "wx" : "1ec7fe2275860c3bc0e4e6e459af7e16985d37adba7351ac357a7c397e07522ea41bcca8e89777fe05b8f0d9dc8c614004fcaf30a97001a5011a159f46fcd544",
+        "wy" : "3cbc1ddfc7ac89a1a2f8eef77bf9bba8ade73da2100cb6a371546b495fb5ea885eb631645e79591db659c49266d263d5cbd3403081cb407536efe9a5bec69955"
+      },
+      "publicKeyDer" : "30819b301406072a8648ce3d020106092b240303020801010d03818200041ec7fe2275860c3bc0e4e6e459af7e16985d37adba7351ac357a7c397e07522ea41bcca8e89777fe05b8f0d9dc8c614004fcaf30a97001a5011a159f46fcd5443cbc1ddfc7ac89a1a2f8eef77bf9bba8ade73da2100cb6a371546b495fb5ea885eb631645e79591db659c49266d263d5cbd3403081cb407536efe9a5bec69955",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEHsf+InWGDDvA5ObkWa9+Fphd\nN626c1GsNXp8OX4HUi6kG8yo6Jd3/gW48NncjGFABPyvMKlwAaUBGhWfRvzVRDy8\nHd/HrImhovju93v5u6it5z2iEAy2o3FUa0lfteqIXrYxZF55WR22WcSSZtJj1cvT\nQDCBy0B1Nu/ppb7GmVU=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 547,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10818502410089edf75e6e986305d8181386c16db44ba0d7ff40f4335569754a481f5cd48c6211a63de7bdaa485e9fa79858a4eabf111fed2959f031de2a132ba709412683a902407a8c08564f51534128bb52fe36dffaae89079011256ef8069e64d64c5610d3e611c0ba8b19027388fccc212523b22c44e85a789e16cb1bbd3240c86b43480fde",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 548,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3081861f02410089edf75e6e986305d8181386c16db44ba0d7ff40f4335569754a481f5cd48c6211a63de7bdaa485e9fa79858a4eabf111fed2959f031de2a132ba709412683a902407a8c08564f51534128bb52fe36dffaae89079011256ef8069e64d64c5610d3e611c0ba8b19027388fccc212523b22c44e85a789e16cb1bbd3240c86b43480fde",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 549,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30818602410089edf75e6e986305d8181386c16db44ba0d7ff40f4335569754a481f5cd48c6211a63de7bdaa485e9fa79858a4eabf111fed2959f031de2a132ba709412683a91f02407a8c08564f51534128bb52fe36dffaae89079011256ef8069e64d64c5610d3e611c0ba8b19027388fccc212523b22c44e85a789e16cb1bbd3240c86b43480fde",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160k1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 437,
+  "numberOfTests" : 440,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6201,6 +6201,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "302d021500894b5a17a0c6db3c257cae09057a136f93bf9de0021424924924924924924924d1484c691883d3ba1a19",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp160k1",
+        "keySize" : 160,
+        "uncompressed" : "048c8b7f800bc9c5588b4970e7559eca926fa38e7b6c5d8223426e1cf8d2a2791ab710a14305048ad3",
+        "wx" : "008c8b7f800bc9c5588b4970e7559eca926fa38e7b",
+        "wy" : "6c5d8223426e1cf8d2a2791ab710a14305048ad3"
+      },
+      "publicKeyDer" : "303e301006072a8648ce3d020106052b81040009032a00048c8b7f800bc9c5588b4970e7559eca926fa38e7b6c5d8223426e1cf8d2a2791ab710a14305048ad3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEjIt/gAvJxViLSXDnVZ7Kkm+jjntsXYIj\nQm4c+NKieRq3EKFDBQSK0w==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 438,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f102c02142e3567b523f24421cf59dc80925775b148eb5380021438aa38f17c131f0128af4dcafe01e68305414586",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 439,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "302d1f02142e3567b523f24421cf59dc80925775b148eb5380021438aa38f17c131f0128af4dcafe01e68305414586",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 440,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "302d02142e3567b523f24421cf59dc80925775b148eb53801f021438aa38f17c131f0128af4dcafe01e68305414586",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_secp160r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 440,
+  "numberOfTests" : 443,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6292,6 +6292,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "302d021500894b5a17a0c6db3c257d25a6ca0a19e1947c7528021424924924924924924924d9d3914ecfd51cec297a",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp160r1",
+        "keySize" : 160,
+        "uncompressed" : "04b0046a56f874d30ea2ba7ac1a935fd9d754ee6417b9a54d275806819ec30b15618f5625115241f46",
+        "wx" : "00b0046a56f874d30ea2ba7ac1a935fd9d754ee641",
+        "wy" : "7b9a54d275806819ec30b15618f5625115241f46"
+      },
+      "publicKeyDer" : "303e301006072a8648ce3d020106052b81040008032a0004b0046a56f874d30ea2ba7ac1a935fd9d754ee6417b9a54d275806819ec30b15618f5625115241f46",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEsARqVvh00w6iunrBqTX9nXVO5kF7mlTS\ndYBoGewwsVYY9WJRFSQfRg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 441,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f102c021449c9656cd8cbee4456548d63a7fc480791909c4202146ff78980793ee086a2e66e01a490bdfc03f2d302",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 442,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "302d1f021449c9656cd8cbee4456548d63a7fc480791909c4202146ff78980793ee086a2e66e01a490bdfc03f2d302",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 443,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "302d021449c9656cd8cbee4456548d63a7fc480791909c421f02146ff78980793ee086a2e66e01a490bdfc03f2d302",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_secp160r2_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160r2_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 440,
+  "numberOfTests" : 443,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6266,6 +6266,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "302d021500894b5a17a0c6db3c2579a652a6c80c6be6d5735002142492492492492492492499dfd7eeaa4cb517170f",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp160r2",
+        "keySize" : 160,
+        "uncompressed" : "0446f1a7493b131f3c6032e9612b8e1bd3d1a3104ce3cef3c8020c277ba45bc93a9a364f07eba8302c",
+        "wx" : "46f1a7493b131f3c6032e9612b8e1bd3d1a3104c",
+        "wy" : "00e3cef3c8020c277ba45bc93a9a364f07eba8302c"
+      },
+      "publicKeyDer" : "303e301006072a8648ce3d020106052b8104001e032a000446f1a7493b131f3c6032e9612b8e1bd3d1a3104ce3cef3c8020c277ba45bc93a9a364f07eba8302c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAERvGnSTsTHzxgMulhK44b09GjEEzjzvPI\nAgwne6RbyTqaNk8H66gwLA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 441,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f102d02142b5ebaf4211158c687625922bd903253892cf834021500aed36914690e0d99637b92439539a13bd8e6d800",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 442,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "302e1f02142b5ebaf4211158c687625922bd903253892cf834021500aed36914690e0d99637b92439539a13bd8e6d800",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 443,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "302e02142b5ebaf4211158c687625922bd903253892cf8341f021500aed36914690e0d99637b92439539a13bd8e6d800",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_secp192k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp192k1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 439,
+  "numberOfTests" : 442,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6240,6 +6240,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "3034021844a5ad0bd0636d9e12bc9e0892d05a340f325ea749b7f1050218249249249249249249249248e0fe24034b582ea17e68ffa6",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp192k1",
+        "keySize" : 192,
+        "uncompressed" : "0404a4e7bedc7d8137aade86c1a4d223ad704e63dad4717c493efc196def1cad9823c91f6b8be2611164b93cca4bb2c559",
+        "wx" : "04a4e7bedc7d8137aade86c1a4d223ad704e63dad4717c49",
+        "wy" : "3efc196def1cad9823c91f6b8be2611164b93cca4bb2c559"
+      },
+      "publicKeyDer" : "3046301006072a8648ce3d020106052b8104001f0332000404a4e7bedc7d8137aade86c1a4d223ad704e63dad4717c493efc196def1cad9823c91f6b8be2611164b93cca4bb2c559",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAEBKTnvtx9gTeq3obBpNIjrXBOY9rUcXxJ\nPvwZbe8crZgjyR9ri+JhEWS5PMpLssVZ\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 440,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103402185ca564801c724e9027e6d39f006ec3f63bd8d3829fdd785002186eaec4b21473db322e9924f12d2a260467c0ed58882e7134",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 441,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30351f02185ca564801c724e9027e6d39f006ec3f63bd8d3829fdd785002186eaec4b21473db322e9924f12d2a260467c0ed58882e7134",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 442,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303502185ca564801c724e9027e6d39f006ec3f63bd8d3829fdd78501f02186eaec4b21473db322e9924f12d2a260467c0ed58882e7134",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_secp192r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp192r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 441,
+  "numberOfTests" : 444,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6300,6 +6300,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "3034021844a5ad0bd0636d9e12bc9e0a05bc56531434e1ee89ab1ba9021824924924924924924924924915fb4807b9c64162878bbc99",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp192r1",
+        "keySize" : 192,
+        "uncompressed" : "042a551b5a39771e436de636d6259ba6afb1afa5d4d897ccf8bca9a6ea5d92d656c4ba4f2dd85c9d86d0e2445fd5db8692",
+        "wx" : "2a551b5a39771e436de636d6259ba6afb1afa5d4d897ccf8",
+        "wy" : "00bca9a6ea5d92d656c4ba4f2dd85c9d86d0e2445fd5db8692"
+      },
+      "publicKeyDer" : "3049301306072a8648ce3d020106082a8648ce3d030101033200042a551b5a39771e436de636d6259ba6afb1afa5d4d897ccf8bca9a6ea5d92d656c4ba4f2dd85c9d86d0e2445fd5db8692",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEKlUbWjl3HkNt5jbWJZumr7GvpdTY\nl8z4vKmm6l2S1lbEuk8t2FydhtDiRF/V24aS\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 442,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1035021900e71a129d6448d62998efe3978fc988213eca13b5566717a402183d126426794e418914e5670c75a197fbd93b91d55c16abde",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 443,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30361f021900e71a129d6448d62998efe3978fc988213eca13b5566717a402183d126426794e418914e5670c75a197fbd93b91d55c16abde",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 444,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3036021900e71a129d6448d62998efe3978fc988213eca13b5566717a41f02183d126426794e418914e5670c75a197fbd93b91d55c16abde",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_secp224k1_sha224_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha224_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 408,
+  "numberOfTests" : 411,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -5909,6 +5909,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "303d021d008ac44bff876cbf7e2842eec13b66c2f9c91aa751816a192009529fcb021c24924924924924924924924924928d45d4fd3280af46f3a27ea9196c",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224k1",
+        "keySize" : 224,
+        "uncompressed" : "042ef983fa542b64472e2bc405d9eedd861acc9a7f814fad8275ce6b9a3459ba4ab52164883bd29eb6ac7e6d22ac7d302c053dc39684928ef9",
+        "wx" : "2ef983fa542b64472e2bc405d9eedd861acc9a7f814fad8275ce6b9a",
+        "wy" : "3459ba4ab52164883bd29eb6ac7e6d22ac7d302c053dc39684928ef9"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040020033a00042ef983fa542b64472e2bc405d9eedd861acc9a7f814fad8275ce6b9a3459ba4ab52164883bd29eb6ac7e6d22ac7d302c053dc39684928ef9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAELvmD+lQrZEcuK8QF2e7dhhrMmn+BT62C\ndc5rmjRZukq1IWSIO9Ketqx+bSKsfTAsBT3DloSSjvk=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-224",
+      "tests" : [
+        {
+          "tcId" : 409,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103e021d00e6a214ba602a2a371a7db42c92ad3d63da09c84992dcb5e4036dafb1021d00fd4c323943614d244d76064ad3620bca3fdaa4d0db53b93b07d18575",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 410,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303f1f021d00e6a214ba602a2a371a7db42c92ad3d63da09c84992dcb5e4036dafb1021d00fd4c323943614d244d76064ad3620bca3fdaa4d0db53b93b07d18575",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 411,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303f021d00e6a214ba602a2a371a7db42c92ad3d63da09c84992dcb5e4036dafb11f021d00fd4c323943614d244d76064ad3620bca3fdaa4d0db53b93b07d18575",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_secp224k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 438,
+  "numberOfTests" : 441,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6213,6 +6213,56 @@
           ],
           "msg" : "313233343030",
           "sig" : "303d021d00894b5a17a0c6db3c25793c14d7be760ba56af3833f9339d2ddf72ff1021c24924924924924924924924924928d45d4fd3280af46f3a27ea9196c",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224k1",
+        "keySize" : 224,
+        "uncompressed" : "042ef983fa542b64472e2bc405d9eedd861acc9a7f814fad8275ce6b9a3459ba4ab52164883bd29eb6ac7e6d22ac7d302c053dc39684928ef9",
+        "wx" : "2ef983fa542b64472e2bc405d9eedd861acc9a7f814fad8275ce6b9a",
+        "wy" : "3459ba4ab52164883bd29eb6ac7e6d22ac7d302c053dc39684928ef9"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040020033a00042ef983fa542b64472e2bc405d9eedd861acc9a7f814fad8275ce6b9a3459ba4ab52164883bd29eb6ac7e6d22ac7d302c053dc39684928ef9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAELvmD+lQrZEcuK8QF2e7dhhrMmn+BT62C\ndc5rmjRZukq1IWSIO9Ketqx+bSKsfTAsBT3DloSSjvk=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 439,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103d021c464bb0fb437b06922073e124528486e500b1394a05e86b0bf58aa70b021d00f2819cdd8f311adae3930586d1fb883ae071cc8d60435904ffb9d872",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 440,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e1f021c464bb0fb437b06922073e124528486e500b1394a05e86b0bf58aa70b021d00f2819cdd8f311adae3930586d1fb883ae071cc8d60435904ffb9d872",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 441,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e021c464bb0fb437b06922073e124528486e500b1394a05e86b0bf58aa70b1f021d00f2819cdd8f311adae3930586d1fb883ae071cc8d60435904ffb9d872",
           "result" : "invalid"
         }
       ]

--- a/testvectors_v1/ecdsa_secp224r1_sha224_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha224_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 439,
+  "numberOfTests" : 442,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6424,6 +6424,56 @@
           "msg" : "4d657373616765",
           "sig" : "303d021d00a4de0d931ddab90e667ebc0ad800ce49e971c60543abdc46cefff926021c550816170bd87593b9fb8ad5ed9ab4ddb12403ff6fe032252833bac4",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "uncompressed" : "044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+        "wx" : "4c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466",
+        "wy" : "00ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040021033a00044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAETCRmcGWKHUH113vOJGy+OGrCKEjiabnU\nzWfEZt3ZRxU9ObLUJTOkYN7yaIBAjK8t091I/oiM0XY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-224",
+      "tests" : [
+        {
+          "tcId" : 440,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103d021c2770403d42b7b45e553308d1f6a480640b61cac0ae36665d6f14d34e021d0085506b0404265ededf9a89fc7c9c7a55c16c5b0d781f774de8f46fa1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 441,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e1f021c2770403d42b7b45e553308d1f6a480640b61cac0ae36665d6f14d34e021d0085506b0404265ededf9a89fc7c9c7a55c16c5b0d781f774de8f46fa1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 442,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e021c2770403d42b7b45e553308d1f6a480640b61cac0ae36665d6f14d34e1f021d0085506b0404265ededf9a89fc7c9c7a55c16c5b0d781f774de8f46fa1",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 468,
+  "numberOfTests" : 471,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6713,6 +6713,56 @@
           "msg" : "4d657373616765",
           "sig" : "303c021c1526eb2f657ebea9af4ca184b975c02372c88e24e835f3f5774c0e12021c1f1ecce38ee52372cb201907794de17b6d6c1afa13c316c51cb07bc7",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "uncompressed" : "044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+        "wx" : "4c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466",
+        "wy" : "00ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040021033a00044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAETCRmcGWKHUH113vOJGy+OGrCKEjiabnU\nzWfEZt3ZRxU9ObLUJTOkYN7yaIBAjK8t091I/oiM0XY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 469,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103d021c0364e7d96832614a80216e730c353534d4bffd2c26649c0b4b0e2628021d008f40064b412fe38c5ba9cf664e6172ed48e6e79f0fe5e31a54985dfc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 470,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e1f021c0364e7d96832614a80216e730c353534d4bffd2c26649c0b4b0e2628021d008f40064b412fe38c5ba9cf664e6172ed48e6e79f0fe5e31a54985dfc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 471,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e021c0364e7d96832614a80216e730c353534d4bffd2c26649c0b4b0e26281f021d008f40064b412fe38c5ba9cf664e6172ed48e6e79f0fe5e31a54985dfc",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha3_224_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha3_224_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 467,
+  "numberOfTests" : 470,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6704,6 +6704,56 @@
           "msg" : "4d657373616765",
           "sig" : "303d021c2eb5db8a9e1c82ed4ce643c953c9f11c3de264ef92d7607c91dbce76021d00b6a97c943aa7a62b5783786356f7b75b36b88356eb62d5a3d15a7029",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "uncompressed" : "044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+        "wx" : "4c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466",
+        "wy" : "00ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040021033a00044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAETCRmcGWKHUH113vOJGy+OGrCKEjiabnU\nzWfEZt3ZRxU9ObLUJTOkYN7yaIBAjK8t091I/oiM0XY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-224",
+      "tests" : [
+        {
+          "tcId" : 468,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103c021c474b086cf4754c270d20f88be569b7d7b6eb6e55de6ce21382160e81021c60692fdb35b4cb824a2729fb175f709d06bc9f4e8bbb4b1058c53788",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 469,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303d1f021c474b086cf4754c270d20f88be569b7d7b6eb6e55de6ce21382160e81021c60692fdb35b4cb824a2729fb175f709d06bc9f4e8bbb4b1058c53788",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 470,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303d021c474b086cf4754c270d20f88be569b7d7b6eb6e55de6ce21382160e811f021c60692fdb35b4cb824a2729fb175f709d06bc9f4e8bbb4b1058c53788",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha3_256_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha3_256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 476,
+  "numberOfTests" : 479,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6798,6 +6798,56 @@
           "msg" : "4d657373616765",
           "sig" : "303e021d00e472e504ef4b293b7f4a6cc99ba33a702f35593f49cb284137776b44021d00c1efe440463fde3b604d48319e0ddb93261ae608d009942a01933241",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "uncompressed" : "044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+        "wx" : "4c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466",
+        "wy" : "00ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040021033a00044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAETCRmcGWKHUH113vOJGy+OGrCKEjiabnU\nzWfEZt3ZRxU9ObLUJTOkYN7yaIBAjK8t091I/oiM0XY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-256",
+      "tests" : [
+        {
+          "tcId" : 477,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103c021c2a8e4fc8c813be0459fe6fd5a449fcd27118121180f37f96857498fb021c487fabaabee79f667da6505c5c171d299732d37784fd73775dfd3db3",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 478,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303d1f021c2a8e4fc8c813be0459fe6fd5a449fcd27118121180f37f96857498fb021c487fabaabee79f667da6505c5c171d299732d37784fd73775dfd3db3",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 479,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303d021c2a8e4fc8c813be0459fe6fd5a449fcd27118121180f37f96857498fb1f021c487fabaabee79f667da6505c5c171d299732d37784fd73775dfd3db3",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha3_512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 541,
+  "numberOfTests" : 544,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7448,6 +7448,56 @@
           "msg" : "4d657373616765",
           "sig" : "303e021d00b66a579ea2dca40e3a48074567af7daad34fd784e3ed097d1b39569c021d0094a2b72c713c109153863ebb71a8cc80f57094d811c13fa269e14a42",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "uncompressed" : "044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+        "wx" : "4c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466",
+        "wy" : "00ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040021033a00044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAETCRmcGWKHUH113vOJGy+OGrCKEjiabnU\nzWfEZt3ZRxU9ObLUJTOkYN7yaIBAjK8t091I/oiM0XY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 542,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103d021d008de3b662a51308a2dc0651a2f50bb3475376e90bb8418256cd791bcb021c0910c5c50a32a24aad84da25559dbf077e5337f3c3f626fb15d376dc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 543,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e1f021d008de3b662a51308a2dc0651a2f50bb3475376e90bb8418256cd791bcb021c0910c5c50a32a24aad84da25559dbf077e5337f3c3f626fb15d376dc",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 544,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e021d008de3b662a51308a2dc0651a2f50bb3475376e90bb8418256cd791bcb1f021c0910c5c50a32a24aad84da25559dbf077e5337f3c3f626fb15d376dc",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 537,
+  "numberOfTests" : 540,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7408,6 +7408,56 @@
           "msg" : "4d657373616765",
           "sig" : "303d021c0eb9dc5d67bb0d4009544f8654977907dfe770e7fae4571d31d7b4fa021d00ab5cda53e868bff5198be4be3681b186cb0c1396d272c71f093f8b12",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "uncompressed" : "044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+        "wx" : "4c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466",
+        "wy" : "00ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040021033a00044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAETCRmcGWKHUH113vOJGy+OGrCKEjiabnU\nzWfEZt3ZRxU9ObLUJTOkYN7yaIBAjK8t091I/oiM0XY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 538,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103e021d00f72915d6d916014279616186869a01228fcd9f1b4078353018b399ab021d00b67f2b91eeeb910381f5b461a4a39c642aea4792013d4eb63da1832b",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 539,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303f1f021d00f72915d6d916014279616186869a01228fcd9f1b4078353018b399ab021d00b67f2b91eeeb910381f5b461a4a39c642aea4792013d4eb63da1832b",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 540,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303f021d00f72915d6d916014279616186869a01228fcd9f1b4078353018b399ab1f021d00b67f2b91eeeb910381f5b461a4a39c642aea4792013d4eb63da1832b",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_shake128_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_shake128_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 474,
+  "numberOfTests" : 477,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6778,6 +6778,56 @@
           "msg" : "4d657373616765",
           "sig" : "303d021d00b21b7db16470f793e3d8bef011abf4b7489d5b8b23381fa48570e3a4021c1460f760ed02cb0818b1acf0db90ad0088fe748d75a4e4826260cd07",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp224r1",
+        "keySize" : 224,
+        "uncompressed" : "044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+        "wx" : "4c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466",
+        "wy" : "00ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176"
+      },
+      "publicKeyDer" : "304e301006072a8648ce3d020106052b81040021033a00044c246670658a1d41f5d77bce246cbe386ac22848e269b9d4cd67c466ddd947153d39b2d42533a460def26880408caf2dd3dd48fe888cd176",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAETCRmcGWKHUH113vOJGy+OGrCKEjiabnU\nzWfEZt3ZRxU9ObLUJTOkYN7yaIBAjK8t091I/oiM0XY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHAKE128",
+      "tests" : [
+        {
+          "tcId" : 475,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f103d021c43e621f2c7bccc08c4c8ff40dbaaa664fe05fa0fabf0435cb6374a18021d00ceb806fbdeafdfba5d6de2718c1220b2ab6d58d1d92d6c2f27bbe94b",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 476,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e1f021c43e621f2c7bccc08c4c8ff40dbaaa664fe05fa0fabf0435cb6374a18021d00ceb806fbdeafdfba5d6de2718c1220b2ab6d58d1d92d6c2f27bbe94b",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 477,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "303e021c43e621f2c7bccc08c4c8ff40dbaaa664fe05fa0fabf0435cb6374a181f021d00ceb806fbdeafdfba5d6de2718c1220b2ab6d58d1d92d6c2f27bbe94b",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 463,
+  "numberOfTests" : 466,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6744,6 +6744,56 @@
           "msg" : "4d657373616765",
           "sig" : "3046022100edf03cf63f658883289a1a593d1007895b9f236d27c9c1f1313089aaed6b16ae022100e5b22903f7eb23adc2e01057e39b0408d495f694c83f306f1216c9bf87506074",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "uncompressed" : "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx" : "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy" : "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer" : "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 464,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1046022100f80ae4f96cdbc9d853f83d47aae225bf407d51c56b7776cd67d0dc195d99a9dc022100b303e26be1f73465315221f0b331528807a1a9b6eb068ede6eebeaaa49af8a36",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 465,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30471f022100f80ae4f96cdbc9d853f83d47aae225bf407d51c56b7776cd67d0dc195d99a9dc022100b303e26be1f73465315221f0b331528807a1a9b6eb068ede6eebeaaa49af8a36",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 466,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3047022100f80ae4f96cdbc9d853f83d47aae225bf407d51c56b7776cd67d0dc195d99a9dc1f022100b303e26be1f73465315221f0b331528807a1a9b6eb068ede6eebeaaa49af8a36",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha3_256_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha3_256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 471,
+  "numberOfTests" : 474,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6824,6 +6824,56 @@
           "msg" : "4d657373616765",
           "sig" : "30450221009d9cdb94e5e9a66bf8eedfdf9f1af43713bb05d880dec89aec21631958970de60220732932649bea35f11dfe0926618e4f091c1b264ca128a9eef14e6d94d7c9f207",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "uncompressed" : "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx" : "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy" : "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer" : "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-256",
+      "tests" : [
+        {
+          "tcId" : 472,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1046022100fc0f737a79d525eefe3c940c162173cc6fd9a6d5cc5017754026c4113d0f15cc022100894d6fb59cc79199b89cf12b556ba49f8623b66da8c11a55e267e3318497688c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 473,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30471f022100fc0f737a79d525eefe3c940c162173cc6fd9a6d5cc5017754026c4113d0f15cc022100894d6fb59cc79199b89cf12b556ba49f8623b66da8c11a55e267e3318497688c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 474,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3047022100fc0f737a79d525eefe3c940c162173cc6fd9a6d5cc5017754026c4113d0f15cc1f022100894d6fb59cc79199b89cf12b556ba49f8623b66da8c11a55e267e3318497688c",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha3_512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 537,
+  "numberOfTests" : 540,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7488,6 +7488,56 @@
           "msg" : "4d657373616765",
           "sig" : "3045022100921a16ea241e69c9d4f3bde6ba2cc7e10a27c9dfd8b92076d0a4a6d9f8ae0ab3022039b66ee2afd7db1099fee2cd8c69c9f1ea29047efacc1c6e8ee92e5a2244a40b",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "uncompressed" : "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx" : "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy" : "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer" : "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 538,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1044022022bb0000e9648a0ee659f9b6a9ab6513dc90ab968ec49d3953f64c82bddc852002204aa0dfd047b0786e118231eff7e86311487ec9d1bc84aaef1f736f4178c288f9",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 539,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30451f022022bb0000e9648a0ee659f9b6a9ab6513dc90ab968ec49d3953f64c82bddc852002204aa0dfd047b0786e118231eff7e86311487ec9d1bc84aaef1f736f4178c288f9",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 540,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3045022022bb0000e9648a0ee659f9b6a9ab6513dc90ab968ec49d3953f64c82bddc85201f02204aa0dfd047b0786e118231eff7e86311487ec9d1bc84aaef1f736f4178c288f9",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 533,
+  "numberOfTests" : 536,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7448,6 +7448,56 @@
           "msg" : "4d657373616765",
           "sig" : "3046022100dd60d7cf83a08208637212b65d079fb658d8ef1b8438d9c58f4122b0cd14ac49022100f1d762516f4d6c3e6a98dd31dc3869dc7cf35944f33b35c6a17fe632d2b18cd5",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "uncompressed" : "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx" : "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy" : "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer" : "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 534,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f104502206632473c909425b6fa37095398e2538daab8552440320f9fe190dba8f672796b022100a8c3aacce9ffe4bc17c0530738f1386f9d9579f029ff3a7791b16e98422265e3",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 535,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30461f02206632473c909425b6fa37095398e2538daab8552440320f9fe190dba8f672796b022100a8c3aacce9ffe4bc17c0530738f1386f9d9579f029ff3a7791b16e98422265e3",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 536,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "304602206632473c909425b6fa37095398e2538daab8552440320f9fe190dba8f672796b1f022100a8c3aacce9ffe4bc17c0530738f1386f9d9579f029ff3a7791b16e98422265e3",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_shake128_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_shake128_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 469,
+  "numberOfTests" : 472,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6804,6 +6804,56 @@
           "msg" : "4d657373616765",
           "sig" : "3045022050d5cd3ba1be23ad74f4eef7213024678999c2e0f2953c193c90f14615b620cd022100bf89d4a87902f306cb4a8b7c5fc0cb65c4593eab0d7df88d557cbbb4d764d3cc",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "uncompressed" : "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx" : "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy" : "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer" : "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHAKE128",
+      "tests" : [
+        {
+          "tcId" : 470,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10450220606e2e02683631c5fb803e8c92a594e4c444ffe2b83066029f62d637330dfc1f022100ea9f5b6c399a99bdbbc5a6ddc3cffde178f08f52774e47cc83a9d7bd19ec16ef",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 471,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30461f0220606e2e02683631c5fb803e8c92a594e4c444ffe2b83066029f62d637330dfc1f022100ea9f5b6c399a99bdbbc5a6ddc3cffde178f08f52774e47cc83a9d7bd19ec16ef",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 472,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30460220606e2e02683631c5fb803e8c92a594e4c444ffe2b83066029f62d637330dfc1f1f022100ea9f5b6c399a99bdbbc5a6ddc3cffde178f08f52774e47cc83a9d7bd19ec16ef",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_shake256_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_shake256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 539,
+  "numberOfTests" : 542,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7508,6 +7508,56 @@
           "msg" : "4d657373616765",
           "sig" : "3044022057a0f29be404873953639f069f5b4b0149a241f5da85df21eac9dd58995be0af02202813f7d8bbe6f1d7f3f7dca63670393fd1709496253af1243493536a64eccd6f",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256k1",
+        "keySize" : 256,
+        "uncompressed" : "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx" : "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy" : "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer" : "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHAKE256",
+      "tests" : [
+        {
+          "tcId" : 540,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10440220628b14cbf72917074fa426d416fa5c48f06478530212ad30ae2e9010b8c6fdec0220388acfa3ec598bfaf6688d476ee0cef3e8bf39eb316fcc1aa543d281990d187c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 541,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30451f0220628b14cbf72917074fa426d416fa5c48f06478530212ad30ae2e9010b8c6fdec0220388acfa3ec598bfaf6688d476ee0cef3e8bf39eb316fcc1aa543d281990d187c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 542,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30450220628b14cbf72917074fa426d416fa5c48f06478530212ad30ae2e9010b8c6fdec1f0220388acfa3ec598bfaf6688d476ee0cef3e8bf39eb316fcc1aa543d281990d187c",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 471,
+  "numberOfTests" : 474,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6906,6 +6906,56 @@
           "msg" : "4d657373616765",
           "sig" : "3045022070bebe684cdcb5ca72a42f0d873879359bd1781a591809947628d313a3814f67022100aec03aca8f5587a4d535fa31027bbe9cc0e464b1c3577f4c2dcde6b2094798a9",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx" : "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy" : "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 472,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1045022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 473,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30461f022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 474,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3046022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a1f02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_sha3_256_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha3_256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 479,
+  "numberOfTests" : 482,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6986,6 +6986,56 @@
           "msg" : "4d657373616765",
           "sig" : "3046022100b686774db39201a9462b96842adbeea16ae6003789bb18214dab9e5a758bf6ef022100ffc6b396293b94c96fcb325fae127608ebfd118a46f715b49b918caafb602a34",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx" : "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy" : "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-256",
+      "tests" : [
+        {
+          "tcId" : 480,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1044022063f01899b4b0bfe9dc9929fd4526919b981acda781044ee3d2c337bf5fc748300220591381bdf1b1a9b01020b87314a128d06e4833342bf232779f61480739613927",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 481,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30451f022063f01899b4b0bfe9dc9929fd4526919b981acda781044ee3d2c337bf5fc748300220591381bdf1b1a9b01020b87314a128d06e4833342bf232779f61480739613927",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 482,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3045022063f01899b4b0bfe9dc9929fd4526919b981acda781044ee3d2c337bf5fc748301f0220591381bdf1b1a9b01020b87314a128d06e4833342bf232779f61480739613927",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha3_512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 545,
+  "numberOfTests" : 548,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7650,6 +7650,56 @@
           "msg" : "4d657373616765",
           "sig" : "304502207bf225bec33ce7fb4014097e350c1504d3374028cda8f6fbbac4e0fa5319a048022100aaa45d54eba6bb3ce00ce8e63de24dc7ee19069062e8d340663adcac07f097cd",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx" : "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy" : "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 546,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1046022100ddb577670d5a9b93666df2af7f9baadd8256fca0c81deb2d5cd7301a4b39105f022100a2bcd9f6228a0aa0a4f066aa674b9b08da252b02a77fd1b2f7a2d85929e8b491",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 547,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30471f022100ddb577670d5a9b93666df2af7f9baadd8256fca0c81deb2d5cd7301a4b39105f022100a2bcd9f6228a0aa0a4f066aa674b9b08da252b02a77fd1b2f7a2d85929e8b491",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 548,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3047022100ddb577670d5a9b93666df2af7f9baadd8256fca0c81deb2d5cd7301a4b39105f1f022100a2bcd9f6228a0aa0a4f066aa674b9b08da252b02a77fd1b2f7a2d85929e8b491",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 541,
+  "numberOfTests" : 544,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7610,6 +7610,56 @@
           "msg" : "4d657373616765",
           "sig" : "3045022100b38ca4dac6d949be5e5f969860269f0eedff2eb92f45bfc02470300cc96dd52602201c7b22992bb13749cc0c5bc25330a17446e40db734203f9035172725fc70f863",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx" : "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy" : "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 542,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10440220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 543,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30451f0220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 544,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30450220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f1f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_shake128_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_shake128_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 477,
+  "numberOfTests" : 480,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6966,6 +6966,56 @@
           "msg" : "4d657373616765",
           "sig" : "3046022100c2647c6784b38cc7050b6f85b4c96ba98f8bcaa4c2d77061470e2e49647d0c6d022100e9ba6ff9ed3c26bb4614a5d5d74fbd8d567ed15f02005d704fe861e8ef5f88f9",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx" : "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy" : "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHAKE128",
+      "tests" : [
+        {
+          "tcId" : 478,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1044022032c6866d51c43759bee8ad160e64ef98ee6bf68a2a199caa32ebe0064ca7bc12022012751dc03a925c2e3568bf9190e41da8e6d90a3bf7943c62ff00c2278b47a853",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 479,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30451f022032c6866d51c43759bee8ad160e64ef98ee6bf68a2a199caa32ebe0064ca7bc12022012751dc03a925c2e3568bf9190e41da8e6d90a3bf7943c62ff00c2278b47a853",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 480,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3045022032c6866d51c43759bee8ad160e64ef98ee6bf68a2a199caa32ebe0064ca7bc121f022012751dc03a925c2e3568bf9190e41da8e6d90a3bf7943c62ff00c2278b47a853",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 459,
+  "numberOfTests" : 462,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6624,6 +6624,56 @@
           "msg" : "4d657373616765",
           "sig" : "3066023100b57d6915f6ef8bc76246fe073372ac289fbd9c1b9451e261aeccb927dfbc39419fe51aa936afc3e5ae6d18b99fa7a863023100dacf1c1c7a6ec67e4a6a4b2d7c0fdad0a9e8e92f65a2bdd3b42548aae9853128fd36291d492ca1b51990b3b62fae3860",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
+        "wy" : "009a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 460,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1065023100d670d637fcb2da85a22f74ac92939ee2ee5e7d1bb8d6d0afd6f1ef0f883a43872ba285430d4df43f93784e1cd6e6f63702303774da5d699f6bd62b329376e3b6d3612abc67cb945a109d506d3fde45f4c33893c4428250ef6ccfd6e417400344eabb",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 461,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30661f023100d670d637fcb2da85a22f74ac92939ee2ee5e7d1bb8d6d0afd6f1ef0f883a43872ba285430d4df43f93784e1cd6e6f63702303774da5d699f6bd62b329376e3b6d3612abc67cb945a109d506d3fde45f4c33893c4428250ef6ccfd6e417400344eabb",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 462,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3066023100d670d637fcb2da85a22f74ac92939ee2ee5e7d1bb8d6d0afd6f1ef0f883a43872ba285430d4df43f93784e1cd6e6f6371f02303774da5d699f6bd62b329376e3b6d3612abc67cb945a109d506d3fde45f4c33893c4428250ef6ccfd6e417400344eabb",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 491,
+  "numberOfTests" : 494,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6944,6 +6944,56 @@
           "msg" : "4d657373616765",
           "sig" : "3066023100dd4391ce7557cbd005e3d5d727cd264399dcc3c6501e4547505b6d57b40bbf0a7fac794dcc8d4233159dd0aa40d4e0b9023100a77fa1374fd60aa91600912200fc83c6aa447f8171ecea72ae322df32dccd68951dc5caf6c50380e400e45bf5c0e626b",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
+        "wy" : "009a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 492,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1064023032401249714e9091f05a5e109d5c1216fdc05e98614261aa0dbd9e9cd4415dee29238afbd3b103c1e40ee5c9144aee0f02304326756fb2c4fd726360dd6479b5849478c7a9d054a833a58c1631c33b63c3441336ddf2c7fe0ed129aae6d4ddfeb753",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 493,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30651f023032401249714e9091f05a5e109d5c1216fdc05e98614261aa0dbd9e9cd4415dee29238afbd3b103c1e40ee5c9144aee0f02304326756fb2c4fd726360dd6479b5849478c7a9d054a833a58c1631c33b63c3441336ddf2c7fe0ed129aae6d4ddfeb753",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 494,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3065023032401249714e9091f05a5e109d5c1216fdc05e98614261aa0dbd9e9cd4415dee29238afbd3b103c1e40ee5c9144aee0f1f02304326756fb2c4fd726360dd6479b5849478c7a9d054a833a58c1631c33b63c3441336ddf2c7fe0ed129aae6d4ddfeb753",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha3_384_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha3_384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 501,
+  "numberOfTests" : 504,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7039,6 +7039,56 @@
           "msg" : "4d657373616765",
           "sig" : "30650230024deac92bccdf77a3fe019fb5d35063c9ad9374bf1e7508218b25776815eb95f51c8c253f88991c3073c67ca8bbd5770231008da6b6f9fde42f24536413f8c2d3506171c742b6a0883de116b314d559388b41630aa24c485e090fee5f340c79486164",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
+        "wy" : "009a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-384",
+      "tests" : [
+        {
+          "tcId" : 502,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10660231009da5c054a9eddabf4753559edd5a862cdf57adc0c2717a6949a43d80cfccd02b14ec06113ccf08081be43552391cfb1602310088bb307e9a04f923c70013db3ca716d21b313dde0cd6849435bf3b192d5266589a00b34e9c4c626b1055e7a38ef10853",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 503,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30671f0231009da5c054a9eddabf4753559edd5a862cdf57adc0c2717a6949a43d80cfccd02b14ec06113ccf08081be43552391cfb1602310088bb307e9a04f923c70013db3ca716d21b313dde0cd6849435bf3b192d5266589a00b34e9c4c626b1055e7a38ef10853",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 504,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30670231009da5c054a9eddabf4753559edd5a862cdf57adc0c2717a6949a43d80cfccd02b14ec06113ccf08081be43552391cfb161f02310088bb307e9a04f923c70013db3ca716d21b313dde0cd6849435bf3b192d5266589a00b34e9c4c626b1055e7a38ef10853",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha3_512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 533,
+  "numberOfTests" : 536,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7368,6 +7368,56 @@
           "msg" : "4d657373616765",
           "sig" : "3064023038897bbcf7f806e2c7d32d9376462b0ac097717b984b3acfdb66cba4d20f2ea36f728342c21e6e9aaa517416c2ded86002300790f3b0f4a0c567ac9f58fdb42d1fc77ec08fc347736661cd73dd37993baad45af89a26d4154a6fafd81b4bae060e92",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
+        "wy" : "009a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 534,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10650231009404b3ea09d8e0777f2f492c3f15736ff0e63e22389c676f9a1463b8d8153bbce5e522ee992cbd8d5e3f9378d33969fa023041593e5eb1eef51f034ee2e6384d17f5f466089bf064567571839bab3ec4cfb1a1b8533011e7cc3f9e337865385f86f1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 535,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30661f0231009404b3ea09d8e0777f2f492c3f15736ff0e63e22389c676f9a1463b8d8153bbce5e522ee992cbd8d5e3f9378d33969fa023041593e5eb1eef51f034ee2e6384d17f5f466089bf064567571839bab3ec4cfb1a1b8533011e7cc3f9e337865385f86f1",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 536,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30660231009404b3ea09d8e0777f2f492c3f15736ff0e63e22389c676f9a1463b8d8153bbce5e522ee992cbd8d5e3f9378d33969fa1f023041593e5eb1eef51f034ee2e6384d17f5f466089bf064567571839bab3ec4cfb1a1b8533011e7cc3f9e337865385f86f1",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 529,
+  "numberOfTests" : 532,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7328,6 +7328,56 @@
           "msg" : "4d657373616765",
           "sig" : "306402306bf6fa7a663802c3382cc5fd02004ec71e5a031e3d9bfc0858fa994e88497a7782308bc265b8237a6bbbdd38658b36fc02303a9d5941a013bf70d99cc3ff255ce85573688dac40344b5db7144b19bf57bb2701e6850a8f819796b67f7d0b6aea7e50",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
+        "wy" : "009a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 530,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f106402302290c886bbad8f53089583d543a269a727665626d6b94a3796324c62d08988f66f6011e845811a03589e92abe1f17faf023066e2cb4380997f4e7f85022541adb22d24d1196be68a3db888b03eb3d2d40b0d9a3a6a00a1a4782ee0a00e8410ba2d86",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 531,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30651f02302290c886bbad8f53089583d543a269a727665626d6b94a3796324c62d08988f66f6011e845811a03589e92abe1f17faf023066e2cb4380997f4e7f85022541adb22d24d1196be68a3db888b03eb3d2d40b0d9a3a6a00a1a4782ee0a00e8410ba2d86",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 532,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "306502302290c886bbad8f53089583d543a269a727665626d6b94a3796324c62d08988f66f6011e845811a03589e92abe1f17faf1f023066e2cb4380997f4e7f85022541adb22d24d1196be68a3db888b03eb3d2d40b0d9a3a6a00a1a4782ee0a00e8410ba2d86",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_shake256_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_shake256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 535,
+  "numberOfTests" : 538,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7388,6 +7388,56 @@
           "msg" : "4d657373616765",
           "sig" : "3066023100f67bcd0933cd126e4505ab3750fdb2cfd4b63676c6ae3aa72ccb0d7d0672a5f95ec57367965c81aa04e1f9082e74a054023100d606711435e4298c14721eb53ad459922c59642bd30823056c20b50f853ea286321d3e7f54b0418d25e5fb319be05c35",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
+        "wy" : "009a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHAKE256",
+      "tests" : [
+        {
+          "tcId" : 536,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f1065023100e34cd1b22762afffffd88f15e27fab39a5f37a183007e75d5acb9e9f457640df00f0bc88d57f71b284d507efae6368c9023044eca3a9b2a156924a94d28c1df3909981baedbc68bbad3764439081d5b550a389ea1ac6b2b627730a97ec42a25b55c8",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 537,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30661f023100e34cd1b22762afffffd88f15e27fab39a5f37a183007e75d5acb9e9f457640df00f0bc88d57f71b284d507efae6368c9023044eca3a9b2a156924a94d28c1df3909981baedbc68bbad3764439081d5b550a389ea1ac6b2b627730a97ec42a25b55c8",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 538,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3066023100e34cd1b22762afffffd88f15e27fab39a5f37a183007e75d5acb9e9f457640df00f0bc88d57f71b284d507efae6368c91f023044eca3a9b2a156924a94d28c1df3909981baedbc68bbad3764439081d5b550a389ea1ac6b2b627730a97ec42a25b55c8",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp521r1_sha3_512_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha3_512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 531,
+  "numberOfTests" : 534,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7399,6 +7399,56 @@
           "msg" : "4d657373616765",
           "sig" : "3081880242019c5d65ec2257ece62f146d9c61661789151ccce3a045c60a03f2034eec2e84eb54414825529b9e1bc6c19581e3ab827166ff4e4722bc10447bbff9a5758839b82602420191e1bb04a72eac5dec7c021bae1fc37d9bc81e0acdd09ae63464009a01751394a8593084f634c191045a632073aae56eb65d88ac1ac6fb309dcbcf76f22ae652c9",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
+        "wx" : "012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8",
+        "wy" : "012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBKpCL/Ftw4XvfrnQpSZSAi/KkLatZ\nr4sFI6Am1kCio9bTRFILYhd+LPoznKQvsIg+xCWQT72igzo7WwqaAIETZdgBIzPV\nMvj46xpiPDeKNpRlEZK72oM+O417j5Cyv8mwRfilXhtqX+FRLEAMS8nIb9fGmdZC\n9c7pu4J8iwq8DaAc7x4=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA3-512",
+      "tests" : [
+        {
+          "tcId" : 532,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f108188024201eee90ae46276f5a4d085d97da8d3d73e3aa41e809aeef225fa7e1780128f43ddb99afd82aff727e7dacfa0f59b1023350741fead9de533527aa6ef6a3a3a285a6a024200b27e5ab4845f86ed525fac4e9e8500e56dd5a5161c02f0513393f4381a67ee307ef6516405445e931e6aaa3d7d3f969c6dd5f2044362304d112fa78c1956fe845c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 533,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3081891f024201eee90ae46276f5a4d085d97da8d3d73e3aa41e809aeef225fa7e1780128f43ddb99afd82aff727e7dacfa0f59b1023350741fead9de533527aa6ef6a3a3a285a6a024200b27e5ab4845f86ed525fac4e9e8500e56dd5a5161c02f0513393f4381a67ee307ef6516405445e931e6aaa3d7d3f969c6dd5f2044362304d112fa78c1956fe845c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 534,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "308189024201eee90ae46276f5a4d085d97da8d3d73e3aa41e809aeef225fa7e1780128f43ddb99afd82aff727e7dacfa0f59b1023350741fead9de533527aa6ef6a3a3a285a6a1f024200b27e5ab4845f86ed525fac4e9e8500e56dd5a5161c02f0513393f4381a67ee307ef6516405445e931e6aaa3d7d3f969c6dd5f2044362304d112fa78c1956fe845c",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp521r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 529,
+  "numberOfTests" : 532,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7379,6 +7379,56 @@
           "msg" : "4d657373616765",
           "sig" : "308188024201a2af29c58184ca861e7cd931f39cea064b199eee563f241cd5ecf6ebb2ade728f1be23cf007ebe8ef0c42d99f9f5190f6815446afc3043a820d7daf27e86b83b8a024201a2acd1822eb539383defff8769aad8bacd50cd24ca7aa6670671418110177808c3f4fbe6041b9cb898359ee61e04824adedd62b39fe5791907a20586333bd3c76d",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
+        "wx" : "012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8",
+        "wy" : "012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBKpCL/Ftw4XvfrnQpSZSAi/KkLatZ\nr4sFI6Am1kCio9bTRFILYhd+LPoznKQvsIg+xCWQT72igzo7WwqaAIETZdgBIzPV\nMvj46xpiPDeKNpRlEZK72oM+O417j5Cyv8mwRfilXhtqX+FRLEAMS8nIb9fGmdZC\n9c7pu4J8iwq8DaAc7x4=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 530,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f108188024201625d6115092a8e2ee21b9f8a425aa73814dec8b2335e86150ab4229f5a3421d2e6256d632c7a4365a1ee01dd2a936921bbb4551a512d1d4b5a56c314e4a02534c5024201b792d23f2649862595451055777bda1b02dc6cc8fef23231e44b921b16155cd42257441d75a790371e91819f0a9b1fd0ebd02c90b5b774527746ed9bfe743dbe2f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 531,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3081891f024201625d6115092a8e2ee21b9f8a425aa73814dec8b2335e86150ab4229f5a3421d2e6256d632c7a4365a1ee01dd2a936921bbb4551a512d1d4b5a56c314e4a02534c5024201b792d23f2649862595451055777bda1b02dc6cc8fef23231e44b921b16155cd42257441d75a790371e91819f0a9b1fd0ebd02c90b5b774527746ed9bfe743dbe2f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 532,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "308189024201625d6115092a8e2ee21b9f8a425aa73814dec8b2335e86150ab4229f5a3421d2e6256d632c7a4365a1ee01dd2a936921bbb4551a512d1d4b5a56c314e4a02534c51f024201b792d23f2649862595451055777bda1b02dc6cc8fef23231e44b921b16155cd42257441d75a790371e91819f0a9b1fd0ebd02c90b5b774527746ed9bfe743dbe2f",
+          "result" : "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp521r1_shake256_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_shake256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm" : "ECDSA",
   "schema" : "ecdsa_verify_schema_v1.json",
-  "numberOfTests" : 533,
+  "numberOfTests" : 536,
   "header" : [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7424,6 +7424,56 @@
           "msg" : "4d657373616765",
           "sig" : "30818502400545b0665b7e15cc755ee5ba1ce237052c2d29e507ddcca767c5871b0558eade44ec782f206d7915d311a0bff18b182e0b9fbb49658469d08f28f2d6f11a402d024144a2977be42bf0008898e68325d4f71d33746781752ceafb823d02ef4c367b668bb58b8310a1fc5a4a5a105e49d364a4ba8160ac4e6e208fd9dfaeca92a823afad",
           "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "source" : {
+        "name" : "github/davidben",
+        "version" : "0.1"
+      },
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
+        "wx" : "012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8",
+        "wy" : "012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBKpCL/Ftw4XvfrnQpSZSAi/KkLatZ\nr4sFI6Am1kCio9bTRFILYhd+LPoznKQvsIg+xCWQT72igzo7WwqaAIETZdgBIzPV\nMvj46xpiPDeKNpRlEZK72oM+O417j5Cyv8mwRfilXhtqX+FRLEAMS8nIb9fGmdZC\n9c7pu4J8iwq8DaAc7x4=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHAKE256",
+      "tests" : [
+        {
+          "tcId" : 534,
+          "comment" : "signature with non-minimal SEQUENCE tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3f10818702417d9bd71f51be1eeadebc83955b1a5e85a51a58f0f0ba654a209160fcb09f4b0aca8e163b798d231add5ab30c4dcfec85b35dc0bd2fb04e28d570aafee0513fe52e02420157f64e6ed8404357ce39781af26428c773c8b4c5337f1fea631ed32107d1cc70498506f827957938151f58c47811b616a9c308791897bc4ad0fffe18ec9456493a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 535,
+          "comment" : "signature with non-minimal INTEGER tag on r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "3081881f02417d9bd71f51be1eeadebc83955b1a5e85a51a58f0f0ba654a209160fcb09f4b0aca8e163b798d231add5ab30c4dcfec85b35dc0bd2fb04e28d570aafee0513fe52e02420157f64e6ed8404357ce39781af26428c773c8b4c5337f1fea631ed32107d1cc70498506f827957938151f58c47811b616a9c308791897bc4ad0fffe18ec9456493a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 536,
+          "comment" : "signature with non-minimal INTEGER tag on s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "",
+          "sig" : "30818802417d9bd71f51be1eeadebc83955b1a5e85a51a58f0f0ba654a209160fcb09f4b0aca8e163b798d231add5ab30c4dcfec85b35dc0bd2fb04e28d570aafee0513fe52e1f02420157f64e6ed8404357ce39781af26428c773c8b4c5337f1fea631ed32107d1cc70498506f827957938151f58c47811b616a9c308791897bc4ad0fffe18ec9456493a",
+          "result" : "invalid"
         }
       ]
     }


### PR DESCRIPTION
DER tags are typically one byte, but when the tag number exceeds 30, they are encoded in a multi-byte tag form. The tag number bits of the first byte is set to all ones (i.e. 31) and then the actual tag number is encoded in the big-endian base128 encoding. (See X.690 (02/2021) 8.1.2.4.)

This encoding is only for larger tag numbers, so these should be rejected by an ECDSA signature verifier. This case was missing from the original Wycheproof tests.

Although this is a general DER issue, it makes sense to test this specifically in ECDSA test vectors because ECDSA is deep in the crypto layer of libraries, and so it is not uncommon for this to be implemented with slightly different parsers than the rest of the system.

These tests are tagged InvalidEncoding and not BerEncodedSignature because non-minimal integers is forbidden in BER too. X.690 (02/2021) 8.1.2 says that, for even BER, the single-octet encoding is the encoding for tags 0 to 30 and the multi-octet encoding is only for 31 and up.

I've added the tests to both testvectors and testvectors_v1 since it was easy, though hopefully that situation will settle out soon.

The tests were generated by the following script:
<details>
<summary>make_bad_tags.py</summary>

```
import json
import sys

SEQUENCE = 0x30
INTEGER = 0x02

def parse_elem(inp):
    # Parse a tiny subset of DER.
    tag, inp = inp[0], inp[1:]
    assert tag & 0x1f != 0x1f
    l, inp = inp[0], inp[1:]
    if l > 0x80:
        assert l == 0x81
        l, inp = inp[0], inp[1:]
        assert l >= 0x80
    body, inp = inp[:l], inp[l:]
    return tag, body, inp

def parse_sig(sig):
    tag, sig, rest = parse_elem(sig)
    assert tag == SEQUENCE
    assert len(rest) == 0
    tag, r, sig = parse_elem(sig)
    assert tag == INTEGER
    tag, s, sig = parse_elem(sig)
    assert tag == INTEGER
    assert len(sig) == 0
    return r, s

def encode_der(tag, body, long_tag = False):
    ret = bytearray()
    if long_tag:
        ret.append(tag | 0x1f)
        ret.append(tag & 0x1f)
    else:
        ret.append(tag)
    if len(body) < 0x80:
        ret.append(len(body))
    else:
        assert len(body) <= 0xff
        ret.append(0x81)
        ret.append(len(body))
    ret.extend(body)
    return bytes(ret)

for arg in sys.argv[1:]:
    with open(arg) as f:
        data = json.load(f)

    group = data["testGroups"][0]
    if group["type"] != "EcdsaVerify":
        print(f"{arg} is not an EcdsaVerify file. Skipping.")
        continue

    test = group["tests"][0]
    if test["result"] != "valid":
        raise ValueError("could not find sample signature")
    msg = bytes.fromhex(test["msg"])
    sig = bytes.fromhex(test["sig"])
    r, s = parse_sig(sig)

    bad_seq = encode_der(SEQUENCE, encode_der(INTEGER, r) + encode_der(INTEGER, s), long_tag=True)
    bad_r = encode_der(SEQUENCE, encode_der(INTEGER, r, long_tag=True) + encode_der(INTEGER, s))
    bad_s = encode_der(SEQUENCE, encode_der(INTEGER, r) + encode_der(INTEGER, s, long_tag=True))

    num_tests = data["numberOfTests"]
    new_group = {
        "type": "EcdsaVerify",
        "source": {
            "name" : "github/davidben",
            "version" : "0.1"
        },
    }
    for key in ( "key", "keyDer", "keyPem", "publicKey", "publicKeyDer", "publicKeyPem", "sha"):
        if key in group:
            new_group[key] = group[key]
    new_group["tests"] = []

    def append_test(comment, sig):
        global num_tests
        num_tests += 1
        new_group["tests"].append({
            "tcId": num_tests,
            "comment": comment,
            "flags": ["InvalidEncoding"],
            "msg": msg.hex(),
            "sig": sig.hex(),
            "result": "invalid",
        })

    append_test("signature with non-minimal SEQUENCE tag", bad_seq)
    append_test("signature with non-minimal INTEGER tag on r", bad_r)
    append_test("signature with non-minimal INTEGER tag on s", bad_s)

    data["testGroups"].append(new_group)
    data["numberOfTests"] = num_tests
    with open(arg, "w") as f:
        json.dump(data, f, indent=2, separators=(",", " : "))
        f.write("\n")
    print(f"Added new tests to {arg}")
```

</summary>