### PR TITLE
Remove reference to goals.md in doc index #163

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -2,7 +2,6 @@
 
 <!-- a list of links to the documentation -->
 
-*   [goals.md](goals.md) describes the goals of the project.
 *   [files.md](files.md) describes tests for which test vectors exists as well
     as the test vectors.
 *   [formats.md](formats.md) describes the general format of the test vectors.


### PR DESCRIPTION
Resolves #163 

This revolves the minor documentation issue #163 by removing the line mentioning `goals.md` from `doc/index.md`

There really wasn't much to test, but I have confirmed that the markdown renders correctly in at least one system.