### PR TITLE
schemas: fix rsa_common.json otherPrimeInfos format

### DIFF
--- a/schemas/rsa_common.json
+++ b/schemas/rsa_common.json
@@ -42,7 +42,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "format": "Hex"
+              "format": "BigInt"
             }
           }
         }


### PR DESCRIPTION
As described in [doc/types.md](https://github.com/C2SP/wycheproof/blob/main/doc/types.md#rsaprivatekey) and confirmed in the [original generator src](https://github.com/C2SP/wycheproof/blob/cff6adf42662469a1871e57303a0ad1d758ed8c0/src/rsa_key.py#L727-L733) these array items are BigInt format, not Hex.

Thanks to @jpgoldberg for the report.

Resolves https://github.com/C2SP/wycheproof/issues/165