### PR TITLE
Small docs updates for algorithm coverage, language-ecosystem distribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,3 +73,35 @@ data added to `imaginary_algorithm_2048_test.json` may be preferrable to
 "github.com/myusername" if you intend to add other kinds of test vectors to
 `imaginary_algorithm_2048_test.json` in the future, and would want to be able to
 update those separately from the weak parameter test vector data.
+
+### Language specific ecosystem considerations
+
+Many programming language ecosystems have some sort of package distribution
+infrastructure (e.g. [Packagist], [PyPI], [crates.io], and many more). We're
+generally supportive of efforts to make Wycheproof test vectors easy to
+consume through those language specific ecosystems, but have some guidelines
+to help keep the maintenance burden manageable:
+
+1. We are happy to take contributions that add metadata and small bits of 
+   supporting code, but they should be focused on distributing the JSON data.
+   We are **not** able to take contributions that provide deserialization types
+   or in-memory representations that need to be kept in-sync with the JSON.
+   Similarly, contributions that require extensive tooling/code are likely to
+   be declined.
+2. We rely on the contributor to agree to help with continued maintenance. Each
+   ecosystem has its own best practices that members of that community are best
+   positioned to enforce. Similarly, as the ecosystem in question evolves we 
+   expect the original contributor to help keep the Wycheproof side in working 
+   condition, or we may remove the integration.
+3. Where possible, updates should be automatic, and performed as part of our
+   regular development cycle without needing additional manual steps. E.g. 
+   if we merge new vector data, or publish a new tag, the packaged version 
+   should be updated through CI or some other automated integration.
+
+A positive example to compare against is our [PHP ecosystem integration] with
+[Packagist].
+
+[Packagist]: https://packagist.org/
+[PyPI]: https://pypi.org/
+[crates.io]: https://crates.io/
+[PHP ecosystem integration]: ./composer.json

--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ You may find it helpful to examine how other projects like
 Project Wycheproof has test vectors for the most popular crypto algorithms,
 including
 
+- AEGIS
 - AES-EAX
+- AES-FF1
 - AES-GCM
+- AES-SIV
+- ARIA
+- ASCON
+- Camellia
 - ChaCha20-Poly1305
+- XChaCha20-Poly1305
 - [DH](doc/dh.md)
 - DHIES
 - [DSA](doc/dsa.md)
@@ -45,7 +52,14 @@ including
 - ECIES
 - HKDF
 - HMAC
+- KMAC
+- MORUS
+- PBKDF2
 - [RSA](doc/rsa.md)
+- SEED
+- SipHash
+- SM4
+- VMAC
 - X25519, X448
 - ML-KEM (Kyber)
 - ML-DSA (CRYSTALS-Dilithium)


### PR DESCRIPTION
### docs: add missing algorithms from coverage

Updated based on what's in `testvectors_v1/*.json`. Resolves https://github.com/C2SP/wycheproof/issues/151

### docs: update CONTRIBUTING.md with packaging considerations

Adds some text that came out of the discussion around PHP/Packagist in https://github.com/C2SP/wycheproof/pull/109