### PR TITLE
Provide JSON schema for EcCurveTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ At the time of writing, the following `testvectors_v1` files are missing schemas
 
 * `testvectors_v1/aes_ff1_base*_test.json`
 * `testvectors_v1/aes_ff1_radix*_test.json`
-* `testvectors_v1/ec_prime_order_curves_test.json`
 * `testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json`
 * `testvectors_v1/pbes2_hmacsha*_aes_*_test.json`
 * `testvectors_v1/pbkdf2_hmacsha*_test.json`

--- a/schemas/ec_curve_test_schema.json
+++ b/schemas/ec_curve_test_schema.json
@@ -1,0 +1,160 @@
+{
+  "type": "object",
+  "properties": {
+    "algorithm": {
+      "enum": [
+        "EcCurveTest"
+      ]
+    },
+    "schema": {
+      "enum": [
+        "ec_curve_test_schema.json"
+      ]
+    },
+    "generatorVersion": {
+      "type": "string",
+      "description": "DEPRECATED: prefer \"source\" property in test group",
+      "deprecated": true
+    },
+    "numberOfTests": {
+      "type": "integer",
+      "description": "the number of test vectors in this test"
+    },
+    "header": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "additional documentation"
+    },
+    "notes": {
+      "$ref": "common.json#/definitions/Notes"
+    },
+    "testGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EcCurveTest"
+      }
+    }
+  },
+  "required": [
+    "algorithm",
+    "numberOfTests",
+    "schema",
+    "testGroups"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "EcCurveTest": {
+      "type": "object",
+      "description": "A test for checking elliptic curve domain parameters.",
+      "properties": {
+        "type": {
+          "enum": [
+            "EcCurveTest"
+          ]
+        },
+        "source": {
+          "$ref": "common.json#/definitions/Source"
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tcId": {
+                "type": "integer",
+                "description": "Identifier of the test case"
+              },
+              "comment": {
+                "type": "string",
+                "description": "A brief description of the test case"
+              },
+              "flags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "A list of flags"
+              },
+              "name": {
+                "type": "string",
+                "description": "Name identifying the elliptic curve"
+              },
+              "oid": {
+                "type": "string",
+                "description": "Object identifier of the ellptic curve"
+              },
+              "ref": {
+                "type": "string",
+                "description": "Standard containing the domain parameters"
+              },
+              "p": {
+                "type": "string",
+                "format": "BigInt",
+                "description": "Prime identifying the field of definition"
+              },
+              "n": {
+                "type": "string",
+                "format": "BigInt",
+                "description": "Order of the curve"
+              },
+              "a": {
+                "type": "string",
+                "format": "BigInt",
+                "description": "Coefficient a of the curve's Weierstrass equation"
+              },
+              "b": {
+                "type": "string",
+                "format": "BigInt",
+                "description": "Coefficient b of the curve's Weierstrass equation"
+              },
+              "gx": {
+                "type": "string",
+                "format": "BigInt",
+                "description": "x coordinate of the curve's generator"
+              },
+              "gy": {
+                "type": "string",
+                "format": "BigInt",
+                "description": "y coordinate of the curve's generator"
+              },
+              "h": {
+                "type": "integer",
+                "description": "Cofactor of the curve"
+              },
+              "result": {
+                "type": "string",
+                "description": "Test result",
+                "enum": [
+                  "valid",
+                  "invalid",
+                  "acceptable"
+                ]
+              }
+            },
+            "required": [
+              "tcId",
+              "oid",
+              "p",
+              "n",
+              "a",
+              "b",
+              "gx",
+              "gy",
+              "h",
+              "result"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "type",
+        "source",
+        "tests"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/testvectors_v1/ec_prime_order_curves_test.json
+++ b/testvectors_v1/ec_prime_order_curves_test.json
@@ -11,6 +11,10 @@
   "testGroups" : [
     {
       "type" : "EcCurveTest",
+      "source" : {
+        "name" : "google-wycheproof",
+        "version" : "0.9rc5"
+      },
       "tests" : [
         {
           "tcId" : 1,

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -70,9 +70,6 @@ var (
 		// testvectors_v1/aes_ff1_radix*_test.json:
 		"fpe_list_test_schema.json": true,
 
-		// testvectors_v1/ec_prime_order_curves_test.json:
-		"ec_curve_test_schema.json": true,
-
 		// testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
 		"ecdsa_bitcoin_verify_schema.json": true,
 


### PR DESCRIPTION
The schema was mostly modeled after the one for the ML-KEM tests. It marks the generatorVersion as deprecated like in all other schemas and adds a source object to the TestGroup. Remove it from the list of missing schemas in the readme and the linter.

ec_prime_order_curve_test.json limits itself in scope to curves of prime order over prime fields. This doesn't seem entirely correct: First, its format is only really suitable for the short Weierstrass representation of a curve over a finite field. Second, that the order is prime is a desirable common feature of the curves it currently contains rather than a necessity. Perhaps the test should be renamed and then it could easily be extended in scope.