### PR TITLE
expose Go embed.FS of schemas and vectors

### DIFF
--- a/testvectors.go
+++ b/testvectors.go
@@ -1,0 +1,21 @@
+// Wycheproof test vectors as an embedded filesystem of JSON content.
+//
+// Downstream Go code can import github.com/c2sp/wycheproof and access
+// TestVectors and Schemas using the standard library fs.FS interface.
+
+package wycheproof
+
+import (
+	"embed"
+	"io/fs"
+)
+
+var TestVectors, _ = fs.Sub(testVectors, "testvectors_v1")
+
+//go:embed testvectors_v1
+var testVectors embed.FS
+
+var Schemas, _ = fs.Sub(schemas, "schemas")
+
+//go:embed schemas
+var schemas embed.FS


### PR DESCRIPTION
This allows downstream Go code to import this repo and directly access JSON schema files and JSON test vector files using a FS interface (listing files, reading content, etc).

We already have a `go.mod` to manage the Go `vectorlint` program. I believe this addition [meets the language specific ecosystem considerations](https://github.com/C2SP/wycheproof/blob/main/CONTRIBUTING.md#language-specific-ecosystem-considerations). I will be relying on it downstream and commit to helping keep it working.

<details>
<summary>Example usage:</summary>

```go
package main

import (
	"fmt"
	"io/fs"

	"github.com/c2sp/wycheproof"
)

func main() {
	fmt.Println("schemas")
	schemas, _ := fs.ReadDir(wycheproof.Schemas, ".")
	for _, entry := range schemas {
		fmt.Printf("\t%s\n", entry.Name())
	}

	testvectors, _ := fs.ReadDir(wycheproof.TestVectors, ".")
	fmt.Println()
	fmt.Println("testvectors_v1/")
	for _, entry := range testvectors {
		fmt.Printf("\t%s\n", entry.Name())
	}
}
```