### PR TITLE
X25519: Change test 101 result to "acceptable" and add "Twist" flag

### DIFF
--- a/testvectors_v1/x25519_test.json
+++ b/testvectors_v1/x25519_test.json
@@ -1263,12 +1263,13 @@
           "tcId": 101,
           "comment": "RFC 7748",
           "flags": [
-            "Ktv"
+            "Ktv",
+            "Twist"
           ],
           "public": "e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a413",
           "private": "4866e9d4d1b4673c5ad22691957d6af5c11b6421e0ea01d42ca4169e7918ba4d",
           "shared": "95cbde9476e8907d7aade45cb4b873f88b595a68799fa152e6f8f7647aac7957",
-          "result": "valid"
+          "result": "acceptable"
         },
         {
           "tcId": 102,


### PR DESCRIPTION
Test case 101 in x25519_test.json uses a public key that lies on the twist of Curve25519, not on the main curve. This PR changes the result from "valid" to "acceptable" and adds the "Twist" flag so it matches with the other twist point tests.

The public key in 101 is:
```
e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a413
```
For a point to be on Curve25519, the value x^3 + 486662x^2 + x must be a quadratic residue (have a square root in the field). Computing the Legendre symbol:
x^3 + 486662x^2 + x = 2b5a0cb55d322bba66520d668373c2f655f4103ff12bfedf527d57b26d5fb505
Legendre symbol = -1 (quadratic non-residue)

This confirms the point is on the twist, not the main curve.

Implementations that reject twist points are making a valid security decision. Masked scalar multiplication implementations (used for side channel protection) may not be able to process twist points. While RFC 7748 recommends accepting all inputs (Section 7 notes rejecting twist points is 'not recommended'), Wycheproof's purpose is really for testing cryptographic correctness and security. Rejecting twist points is stricter than the RFC requires but arguably more secure against invalid curve attacks.

If it helps
 ```luau
-- Using https://github.com/daily3014/rbx-cryptography/tree/main/src/Verification/EdDSA
local PublicKeyHex = "e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a413"
local PublicKeyX = FieldPrime.Decode(FromHex(PublicKeyHex))

local X2 = FieldPrime.Square(PublicKeyX)
local X3 = FieldPrime.Mul(X2, PublicKeyX)
local AX2 = FieldPrime.KMul(X2, 486662)
local RHS = FieldPrime.Canonicalize(FieldPrime.Add(X3, FieldPrime.Add(AX2, PublicKeyX)))

print("Public key:", PublicKeyHex)
print("x^3 + 486662x^2 + x =", ToHex(FieldPrime.Encode(RHS)))

-- Compute Legendre symbol: RHS^((p-1)/2)
-- If result is 1, point is on curve. If result is -1 (p-1), point is on twist
local function NSquare(A, n)
    for i = 1, n do
        A = FieldPrime.Square(A)
    end
    return A
end

local R_2_254 = NSquare(RHS, 254)
local R8 = NSquare(RHS, 3)
local R2 = FieldPrime.Square(RHS)
local R10 = FieldPrime.Mul(R8, R2)
local R10Inv = FieldPrime.Invert(R10)
local Legendre = FieldPrime.Mul(R_2_254, R10Inv)

print("Legendre symbol:", ToHex(FieldPrime.Encode(FieldPrime.Canonicalize(Legendre))))
print("If 01000...00 = on curve (QR)")
print("If ecffff...7f = on twist (QNR)")
```