### PR TITLE
schemas: remove unnecessary ml-kem oneOf indirection

### DIFF
--- a/schemas/mlkem_encaps_test_schema.json
+++ b/schemas/mlkem_encaps_test_schema.json
@@ -28,11 +28,7 @@
     "testGroups": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "$ref": "#/definitions/MLKEMEncapsTestGroup"
-          }
-        ]
+        "$ref": "#/definitions/MLKEMEncapsTestGroup"
       }
     }
   },

--- a/schemas/mlkem_semi_expanded_decaps_test_schema.json
+++ b/schemas/mlkem_semi_expanded_decaps_test_schema.json
@@ -28,11 +28,7 @@
     "testGroups": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "$ref": "#/definitions/MLKEMDecapsTestGroup"
-          }
-        ]
+        "$ref": "#/definitions/MLKEMDecapsTestGroup"
       }
     }
   },

--- a/schemas/mlkem_test_schema.json
+++ b/schemas/mlkem_test_schema.json
@@ -28,11 +28,7 @@
     "testGroups": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "$ref": "#/definitions/MLKEMTestGroup"
-          }
-        ]
+        "$ref": "#/definitions/MLKEMTestGroup"
       }
     }
   },


### PR DESCRIPTION
`oneOf` with a single option doesn't offer us much, and comes at the cost of ugly code generation (e.g. `interface{}` types in generated Go code). Instead, just use a direct `$ref` of the one group definition in use.

Using `go-jsonschema`'s output as an example: 

Before:

```go
  type MlkemTestSchemaJson struct {
  	// ...
  	TestGroups []interface{} `json:"testGroups"`
  }
```

After:
```go
  type MlkemTestSchemaJson struct {
  	// ...
  	TestGroups []MLKEMTestGroup `json:"testGroups"`
  }
```