### PR TITLE
Import some ECDSA edge cases into p1363 format

### DIFF
--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 219,
+  "numberOfTests": 227,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4210,6 +4210,246 @@
           "msg": "4d657373616765",
           "sig": "625f473ca2d15bb7f12da1235f90adcb69ed4818746cae2e2db26fe64ab817f6f1b9c8c49f681bed1568346f53ecbfacfd52d45e27abcbb0",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "048dad1f3183a05e6027303de8da57d45177d2e2b290a9ac255137245605b078cf0cca41bf2acc824200b885cf9c9afb0f45e31dc4c49192b6",
+        "wx": "8dad1f3183a05e6027303de8da57d45177d2e2b290a9ac2551372456",
+        "wy": "05b078cf0cca41bf2acc824200b885cf9c9afb0f45e31dc4c49192b6"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a00048dad1f3183a05e6027303de8da57d45177d2e2b290a9ac255137245605b078cf0cca41bf2acc824200b885cf9c9afb0f45e31dc4c49192b6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABI2tHzGDoF5gJzA96NpX1FF30uKy\nkKmsJVE3JFYFsHjPDMpBvyrMgkIAuIXPnJr7D0XjHcTEkZK2\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 220,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000001d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "040fb57733ac1ce9d808b78dd3a11e1da365b3fc73dcdcaa47856d482b47b95bed058d46af5bd31750be16c0f8a44819b6b66f99356f9b3420",
+        "wx": "0fb57733ac1ce9d808b78dd3a11e1da365b3fc73dcdcaa47856d482b",
+        "wy": "47b95bed058d46af5bd31750be16c0f8a44819b6b66f99356f9b3420"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a00040fb57733ac1ce9d808b78dd3a11e1da365b3fc73dcdcaa47856d482b47b95bed058d46af5bd31750be16c0f8a44819b6b66f99356f9b3420",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABA+1dzOsHOnYCLeN06EeHaNls/xz\n3NyqR4VtSCtHuVvtBY1Gr1vTF1C+FsD4pEgZtrZvmTVvmzQg\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000002d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "048dad1f3183a05e6027303de8da57d45177d2e2b290a9ac255137245605b078cf0cca41bf2acc824200b885cf9c9afb0f45e31dc4c49192b6",
+        "wx": "8dad1f3183a05e6027303de8da57d45177d2e2b290a9ac2551372456",
+        "wy": "05b078cf0cca41bf2acc824200b885cf9c9afb0f45e31dc4c49192b6"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a00048dad1f3183a05e6027303de8da57d45177d2e2b290a9ac255137245605b078cf0cca41bf2acc824200b885cf9c9afb0f45e31dc4c49192b6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABI2tHzGDoF5gJzA96NpX1FF30uKy\nkKmsJVE3JFYFsHjPDMpBvyrMgkIAuIXPnJr7D0XjHcTEkZK2\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a793a0d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "0440f5a0e304c2b81540a850fcccda86ed7e2bf6020939baf335323b009a573e6852a67c44d7b2063f1be310f9aebe04b797f9021ed4762a2b",
+        "wx": "40f5a0e304c2b81540a850fcccda86ed7e2bf6020939baf335323b00",
+        "wy": "9a573e6852a67c44d7b2063f1be310f9aebe04b797f9021ed4762a2b"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a000440f5a0e304c2b81540a850fcccda86ed7e2bf6020939baf335323b009a573e6852a67c44d7b2063f1be310f9aebe04b797f9021ed4762a2b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABED1oOMEwrgVQKhQ/Mzahu1+K/YC\nCTm68zUyOwCaVz5oUqZ8RNeyBj8b4xD5rr4Et5f5Ah7Udior\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "r = n - 2, x = n - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939dd7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "04c4a178ffc1460ff3aa326b45c11ac2b91c512ae644d2172be9d7b1f74ecc0e657061a0fcc086db6e7af56d3622215b2b4fa0d6fbab8ee1e7",
+        "wx": "c4a178ffc1460ff3aa326b45c11ac2b91c512ae644d2172be9d7b1f7",
+        "wy": "4ecc0e657061a0fcc086db6e7af56d3622215b2b4fa0d6fbab8ee1e7"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a0004c4a178ffc1460ff3aa326b45c11ac2b91c512ae644d2172be9d7b1f74ecc0e657061a0fcc086db6e7af56d3622215b2b4fa0d6fbab8ee1e7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABMSheP/BRg/zqjJrRcEawrkcUSrm\nRNIXK+nXsfdOzA5lcGGg/MCG22569W02IiFbK0+g1vurjuHn\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "r = 1, x = n + 1 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000001d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "04345194ec8030ebc38c6b809bcf932a06032d0f810fe2cdabf463638d598beb6e07edba254054cefb2e87ce723872aea5837fc249d6e031e4",
+        "wx": "345194ec8030ebc38c6b809bcf932a06032d0f810fe2cdabf463638d",
+        "wy": "598beb6e07edba254054cefb2e87ce723872aea5837fc249d6e031e4"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a0004345194ec8030ebc38c6b809bcf932a06032d0f810fe2cdabf463638d598beb6e07edba254054cefb2e87ce723872aea5837fc249d6e031e4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABDRRlOyAMOvDjGuAm8+TKgYDLQ+B\nD+LNq/RjY41Zi+tuB+26JUBUzvsuh85yOHKupYN/wknW4DHk\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "r = 2, x = n + 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000002d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "0454d30d85d7fd91cb119f5da7d22e4b7ed486875d25bcbf0a7a9ab1cdbc448f9349e50319560a06edb46e26fdf9b9709169a4eb487c82f854",
+        "wx": "54d30d85d7fd91cb119f5da7d22e4b7ed486875d25bcbf0a7a9ab1cd",
+        "wy": "bc448f9349e50319560a06edb46e26fdf9b9709169a4eb487c82f854"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a000454d30d85d7fd91cb119f5da7d22e4b7ed486875d25bcbf0a7a9ab1cdbc448f9349e50319560a06edb46e26fdf9b9709169a4eb487c82f854",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABFTTDYXX/ZHLEZ9dp9IuS37Uhodd\nJby/Cnqasc28RI+TSeUDGVYKBu20bib9+blwkWmk60h8gvhU\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 226,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000dbeedf884b0c29fbcd51d9212d61d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "04caf06cc0a63a8fa52cbc4e7ef9eb8758f8605221ba4fe29ae74ca1f1c1ac20a1f0224206cb5c48a75d0cd8ef94b38006c082bc000d26d7ff",
+        "wx": "caf06cc0a63a8fa52cbc4e7ef9eb8758f8605221ba4fe29ae74ca1f1",
+        "wy": "c1ac20a1f0224206cb5c48a75d0cd8ef94b38006c082bc000d26d7ff"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a0004caf06cc0a63a8fa52cbc4e7ef9eb8758f8605221ba4fe29ae74ca1f1c1ac20a1f0224206cb5c48a75d0cd8ef94b38006c082bc000d26d7ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABMrwbMCmOo+lLLxOfvnrh1j4YFIh\nuk/imudMofHBrCCh8CJCBstcSKddDNjvlLOABsCCvAANJtf/\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 227,
+          "comment": "r = 2^224 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^224 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "283ecb55d9bc9979d5e7cfda8a2f04672ee943b49221435c5a586c62d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json
@@ -4214,7 +4214,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4244,7 +4244,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4274,7 +4274,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4304,7 +4304,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4334,7 +4334,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4364,7 +4364,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4394,7 +4394,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4424,7 +4424,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 251,
+  "numberOfTests": 259,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4609,6 +4609,246 @@
           "msg": "4d657373616765",
           "sig": "6b0d70e09ba1642adac06dff9b52e22a3e4aab4180e372665691412241e743a04d7d30ff8a210de69e3e6d1ecf7175f89f481a4d9ed06beaf7148da47f4af9e9",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "04320b82e9c410b24a9cb94f4492dd650d6ca1a151e556b9d47aeb001a5ae38a6a5cc3ac6dcefb41a3282423cc8270f7481c8b175d52517da4645a69cbe15a4efb",
+        "wx": "320b82e9c410b24a9cb94f4492dd650d6ca1a151e556b9d47aeb001a5ae38a6a",
+        "wy": "5cc3ac6dcefb41a3282423cc8270f7481c8b175d52517da4645a69cbe15a4efb"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b240303020801010703420004320b82e9c410b24a9cb94f4492dd650d6ca1a151e556b9d47aeb001a5ae38a6a5cc3ac6dcefb41a3282423cc8270f7481c8b175d52517da4645a69cbe15a4efb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABDILgunEELJKnLlPRJLdZQ1soaFR\n5Va51HrrABpa44pqXMOsbc77QaMoJCPMgnD3SByLF11SUX2kZFppy+FaTvs=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 252,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "044828f0b4e4c3949a8d018c9c68903448cb95715345b5ec17f60b1ab7bc15f0521a10e140e33466de5cfd65dc031669f4a1b1036eeb92c842c79e77a7069131ad",
+        "wx": "4828f0b4e4c3949a8d018c9c68903448cb95715345b5ec17f60b1ab7bc15f052",
+        "wy": "1a10e140e33466de5cfd65dc031669f4a1b1036eeb92c842c79e77a7069131ad"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b2403030208010107034200044828f0b4e4c3949a8d018c9c68903448cb95715345b5ec17f60b1ab7bc15f0521a10e140e33466de5cfd65dc031669f4a1b1036eeb92c842c79e77a7069131ad",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABEgo8LTkw5SajQGMnGiQNEjLlXFT\nRbXsF/YLGre8FfBSGhDhQOM0Zt5c/WXcAxZp9KGxA27rkshCx553pwaRMa0=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 253,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "04320b82e9c410b24a9cb94f4492dd650d6ca1a151e556b9d47aeb001a5ae38a6a5cc3ac6dcefb41a3282423cc8270f7481c8b175d52517da4645a69cbe15a4efb",
+        "wx": "320b82e9c410b24a9cb94f4492dd650d6ca1a151e556b9d47aeb001a5ae38a6a",
+        "wy": "5cc3ac6dcefb41a3282423cc8270f7481c8b175d52517da4645a69cbe15a4efb"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b240303020801010703420004320b82e9c410b24a9cb94f4492dd650d6ca1a151e556b9d47aeb001a5ae38a6a5cc3ac6dcefb41a3282423cc8270f7481c8b175d52517da4645a69cbe15a4efb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABDILgunEELJKnLlPRJLdZQ1soaFR\n5Va51HrrABpa44pqXMOsbc77QaMoJCPMgnD3SByLF11SUX2kZFppy+FaTvs=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 254,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a8a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "0432c1e4ff4f1bb45c521f3a3e95d33cc5175aa28209b7df6bb402aede5a63159420a08fd7623ef9f91598e2fcd43b528a83ccea9563b6b725a473db05d4d7d9a4",
+        "wx": "32c1e4ff4f1bb45c521f3a3e95d33cc5175aa28209b7df6bb402aede5a631594",
+        "wy": "20a08fd7623ef9f91598e2fcd43b528a83ccea9563b6b725a473db05d4d7d9a4"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b24030302080101070342000432c1e4ff4f1bb45c521f3a3e95d33cc5175aa28209b7df6bb402aede5a63159420a08fd7623ef9f91598e2fcd43b528a83ccea9563b6b725a473db05d4d7d9a4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABDLB5P9PG7RcUh86PpXTPMUXWqKC\nCbffa7QCrt5aYxWUIKCP12I++fkVmOL81DtSioPM6pVjtrclpHPbBdTX2aQ=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 255,
+          "comment": "r = n - 5, x = n - 4 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a2a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "047071c84b00c185affb71662184d248d2e1f9e9dc749692e793ad1a0fa5a6a2f9a99af28e7d559f6e2bd9f03379260030bc9cde4a696ba5e2860a64bb00402562",
+        "wx": "7071c84b00c185affb71662184d248d2e1f9e9dc749692e793ad1a0fa5a6a2f9",
+        "wy": "a99af28e7d559f6e2bd9f03379260030bc9cde4a696ba5e2860a64bb00402562"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b2403030208010107034200047071c84b00c185affb71662184d248d2e1f9e9dc749692e793ad1a0fa5a6a2f9a99af28e7d559f6e2bd9f03379260030bc9cde4a696ba5e2860a64bb00402562",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABHBxyEsAwYWv+3FmIYTSSNLh+enc\ndJaS55OtGg+lpqL5qZryjn1Vn24r2fAzeSYAMLyc3kppa6XihgpkuwBAJWI=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 256,
+          "comment": "r = 1, x = n + 1 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "043e9dd04f85c6632894ec1872b9fc580567ff646b413e8065b5d9324d97f5700a513acad61e1976750e0901596e5e44920ac46e0362b98ee95770e48c9f6efd31",
+        "wx": "3e9dd04f85c6632894ec1872b9fc580567ff646b413e8065b5d9324d97f5700a",
+        "wy": "513acad61e1976750e0901596e5e44920ac46e0362b98ee95770e48c9f6efd31"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b2403030208010107034200043e9dd04f85c6632894ec1872b9fc580567ff646b413e8065b5d9324d97f5700a513acad61e1976750e0901596e5e44920ac46e0362b98ee95770e48c9f6efd31",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABD6d0E+FxmMolOwYcrn8WAVn/2Rr\nQT6AZbXZMk2X9XAKUTrK1h4ZdnUOCQFZbl5EkgrEbgNiuY7pV3DkjJ9u/TE=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 257,
+          "comment": "r = 2, x = n + 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "047711967a442f90a8dcc0ccf2768cfc41ba5e133d4d893ce679f06932d1bebd169d91d3890e25dc4882e97f26304ee6d1cf40a29c809e4fe69e443bfb7310bac5",
+        "wx": "7711967a442f90a8dcc0ccf2768cfc41ba5e133d4d893ce679f06932d1bebd16",
+        "wy": "9d91d3890e25dc4882e97f26304ee6d1cf40a29c809e4fe69e443bfb7310bac5"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b2403030208010107034200047711967a442f90a8dcc0ccf2768cfc41ba5e133d4d893ce679f06932d1bebd169d91d3890e25dc4882e97f26304ee6d1cf40a29c809e4fe69e443bfb7310bac5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABHcRlnpEL5Co3MDM8naM/EG6XhM9\nTYk85nnwaTLRvr0WnZHTiQ4l3EiC6X8mME7m0c9AopyAnk/mnkQ7+3MQusU=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 258,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000e2027b801fc479308ff5399a8825fcd1a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "047de346cac2b82ca792b9e706f9f3b95004422932b282732282540af6ac959fc2622567ad57284d39c4442f32feeea9d022a9365d572466da78c3b5bc4f1e85fc",
+        "wx": "7de346cac2b82ca792b9e706f9f3b95004422932b282732282540af6ac959fc2",
+        "wy": "622567ad57284d39c4442f32feeea9d022a9365d572466da78c3b5bc4f1e85fc"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b2403030208010107034200047de346cac2b82ca792b9e706f9f3b95004422932b282732282540af6ac959fc2622567ad57284d39c4442f32feeea9d022a9365d572466da78c3b5bc4f1e85fc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABH3jRsrCuCynkrnnBvnzuVAEQiky\nsoJzIoJUCvaslZ/CYiVnrVcoTTnERC8y/u6p0CKpNl1XJGbaeMO1vE8ehfw=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 259,
+          "comment": "r = 2^256 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "5604a8245e115643c199f56f627c728e73c6855c4a9e59086fe1f17d68b7a95aa9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json
@@ -4613,7 +4613,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4643,7 +4643,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4673,7 +4673,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4703,7 +4703,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4733,7 +4733,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4763,7 +4763,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4793,7 +4793,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4823,7 +4823,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 255,
+  "numberOfTests": 263,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4490,6 +4490,246 @@
           "msg": "0000000000000000000000000000000000000000",
           "sig": "2417eb10a538921621066608243fd6574de84ef1281520f01ebe0444b46a607ab9eda8f3721779a68f1e2ea294028baeb738181e128c86ad55cb1945436cf69e090c2f6159f6f22011d731733b4433ba",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "048ebaf056f8406e87463188cbd18bf878fc915325aba4259fd9f61890b7250a7224a7f379b2c09e6c603645c0815be3216cc370b996977fcb2dac4cd05eb9c27e79dea9d31ccd407c12b299bfb9049131",
+        "wx": "8ebaf056f8406e87463188cbd18bf878fc915325aba4259fd9f61890b7250a7224a7f379b2c09e6c",
+        "wy": "603645c0815be3216cc370b996977fcb2dac4cd05eb9c27e79dea9d31ccd407c12b299bfb9049131"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b2403030208010109035200048ebaf056f8406e87463188cbd18bf878fc915325aba4259fd9f61890b7250a7224a7f379b2c09e6c603645c0815be3216cc370b996977fcb2dac4cd05eb9c27e79dea9d31ccd407c12b299bfb9049131",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABI668Fb4QG6HRjGIy9GL+Hj8kVMl\nq6Qln9n2GJC3JQpyJKfzebLAnmxgNkXAgVvjIWzDcLmWl3/LLaxM0F65wn553qnT\nHM1AfBKymb+5BJEx\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 256,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000001d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "042980d0934759228f70bba440003b1912e9378bb4585227ca7f63d25788269ce6a480882d100cdf71be33a04672193a722dff90eb89a7e227ae3e8b8aa53702570abe4e0e8016cf7344bf9f70c907dbc7",
+        "wx": "2980d0934759228f70bba440003b1912e9378bb4585227ca7f63d25788269ce6a480882d100cdf71",
+        "wy": "be33a04672193a722dff90eb89a7e227ae3e8b8aa53702570abe4e0e8016cf7344bf9f70c907dbc7"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b2403030208010109035200042980d0934759228f70bba440003b1912e9378bb4585227ca7f63d25788269ce6a480882d100cdf71be33a04672193a722dff90eb89a7e227ae3e8b8aa53702570abe4e0e8016cf7344bf9f70c907dbc7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABCmA0JNHWSKPcLukQAA7GRLpN4u0\nWFInyn9j0leIJpzmpICILRAM33G+M6BGchk6ci3/kOuJp+Inrj6LiqU3AlcKvk4O\ngBbPc0S/n3DJB9vH\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 257,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000002d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "048ebaf056f8406e87463188cbd18bf878fc915325aba4259fd9f61890b7250a7224a7f379b2c09e6c603645c0815be3216cc370b996977fcb2dac4cd05eb9c27e79dea9d31ccd407c12b299bfb9049131",
+        "wx": "8ebaf056f8406e87463188cbd18bf878fc915325aba4259fd9f61890b7250a7224a7f379b2c09e6c",
+        "wy": "603645c0815be3216cc370b996977fcb2dac4cd05eb9c27e79dea9d31ccd407c12b299bfb9049131"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b2403030208010109035200048ebaf056f8406e87463188cbd18bf878fc915325aba4259fd9f61890b7250a7224a7f379b2c09e6c603645c0815be3216cc370b996977fcb2dac4cd05eb9c27e79dea9d31ccd407c12b299bfb9049131",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABI668Fb4QG6HRjGIy9GL+Hj8kVMl\nq6Qln9n2GJC3JQpyJKfzebLAnmxgNkXAgVvjIWzDcLmWl3/LLaxM0F65wn553qnT\nHM1AfBKymb+5BJEx\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 258,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c59312d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "0461a5bb259c60fa1f06b8beee7467efa2c905a8d158878b58ec88178fd1eafa727766e086c6d88459192008ca550c7f3ab097b0d9aa78de3de42853229d7b6de4f5138bcced10d6cac7ccb81f42b44a32",
+        "wx": "61a5bb259c60fa1f06b8beee7467efa2c905a8d158878b58ec88178fd1eafa727766e086c6d88459",
+        "wy": "192008ca550c7f3ab097b0d9aa78de3de42853229d7b6de4f5138bcced10d6cac7ccb81f42b44a32"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b24030302080101090352000461a5bb259c60fa1f06b8beee7467efa2c905a8d158878b58ec88178fd1eafa727766e086c6d88459192008ca550c7f3ab097b0d9aa78de3de42853229d7b6de4f5138bcced10d6cac7ccb81f42b44a32",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABGGluyWcYPofBri+7nRn76LJBajR\nWIeLWOyIF4/R6vpyd2bghsbYhFkZIAjKVQx/OrCXsNmqeN495ChTIp17beT1E4vM\n7RDWysfMuB9CtEoy\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 259,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930ed35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "04799544a2a5eefe3e10ce0ab3a3c5ddd4f2d174e761908043165878032cd396c24b522e96083c66641d231f9c7a3a46a7f46ab604f946f7131b510e6b4449f23f959a22ccb7b2996333e04091d0f7f7ac",
+        "wx": "799544a2a5eefe3e10ce0ab3a3c5ddd4f2d174e761908043165878032cd396c24b522e96083c6664",
+        "wy": "1d231f9c7a3a46a7f46ab604f946f7131b510e6b4449f23f959a22ccb7b2996333e04091d0f7f7ac"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b240303020801010903520004799544a2a5eefe3e10ce0ab3a3c5ddd4f2d174e761908043165878032cd396c24b522e96083c66641d231f9c7a3a46a7f46ab604f946f7131b510e6b4449f23f959a22ccb7b2996333e04091d0f7f7ac",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABHmVRKKl7v4+EM4Ks6PF3dTy0XTn\nYZCAQxZYeAMs05bCS1Iulgg8ZmQdIx+cejpGp/RqtgT5RvcTG1EOa0RJ8j+VmiLM\nt7KZYzPgQJHQ9/es\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 260,
+          "comment": "r = 1, x = n + 1 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000001d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "04c91c96c7d9b06ae6c4a519f793ee4da750e6262624048f7f2b4c6becc7d31c40c02b4607a96123619a036593ef20b9f610f81e7354cdc6d85a159b48fc9bdf33a904a190f41975f922a3ea3bee6c40ec",
+        "wx": "c91c96c7d9b06ae6c4a519f793ee4da750e6262624048f7f2b4c6becc7d31c40c02b4607a9612361",
+        "wy": "9a036593ef20b9f610f81e7354cdc6d85a159b48fc9bdf33a904a190f41975f922a3ea3bee6c40ec"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b240303020801010903520004c91c96c7d9b06ae6c4a519f793ee4da750e6262624048f7f2b4c6becc7d31c40c02b4607a96123619a036593ef20b9f610f81e7354cdc6d85a159b48fc9bdf33a904a190f41975f922a3ea3bee6c40ec",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABMkclsfZsGrmxKUZ95PuTadQ5iYm\nJASPfytMa+zH0xxAwCtGB6lhI2GaA2WT7yC59hD4HnNUzcbYWhWbSPyb3zOpBKGQ\n9Bl1+SKj6jvubEDs\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 261,
+          "comment": "r = 2, x = n + 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000002d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "04a896dc01dc8b446a1a96c142fa50869e9d2432c65b4a436b36fa7159a1d82a0a8e77055d3e5bb2102aac6aab9c69c136353d606d05f897ac2955aa1fe9114ed8ef3f3eb0c0cf30ebd826af9177e7d4a0",
+        "wx": "a896dc01dc8b446a1a96c142fa50869e9d2432c65b4a436b36fa7159a1d82a0a8e77055d3e5bb210",
+        "wy": "2aac6aab9c69c136353d606d05f897ac2955aa1fe9114ed8ef3f3eb0c0cf30ebd826af9177e7d4a0"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b240303020801010903520004a896dc01dc8b446a1a96c142fa50869e9d2432c65b4a436b36fa7159a1d82a0a8e77055d3e5bb2102aac6aab9c69c136353d606d05f897ac2955aa1fe9114ed8ef3f3eb0c0cf30ebd826af9177e7d4a0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABKiW3AHci0RqGpbBQvpQhp6dJDLG\nW0pDazb6cVmh2CoKjncFXT5bshAqrGqrnGnBNjU9YG0F+JesKVWqH+kRTtjvPz6w\nwM8w69gmr5F359Sg\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 262,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000014064fb4c224a8b248a0d933f7642bd56aced9b17d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "049617c9e69b71bf7f5511bc21a87b1434569d554d9e3be40ad21a6971745173eec5bea4c4f16cbede691a60cad2175c8b374e30514f1fe960c36fe19dcc7713db4ec9c1b1437625075ca6ba88ff74614a",
+        "wx": "9617c9e69b71bf7f5511bc21a87b1434569d554d9e3be40ad21a6971745173eec5bea4c4f16cbede",
+        "wy": "691a60cad2175c8b374e30514f1fe960c36fe19dcc7713db4ec9c1b1437625075ca6ba88ff74614a"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b2403030208010109035200049617c9e69b71bf7f5511bc21a87b1434569d554d9e3be40ad21a6971745173eec5bea4c4f16cbede691a60cad2175c8b374e30514f1fe960c36fe19dcc7713db4ec9c1b1437625075ca6ba88ff74614a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABJYXyeabcb9/VRG8Iah7FDRWnVVN\nnjvkCtIaaXF0UXPuxb6kxPFsvt5pGmDK0hdcizdOMFFPH+lgw2/hncx3E9tOycGx\nQ3YlB1ymuoj/dGFK\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 263,
+          "comment": "r = 2^320 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^320 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "2ca1b8dfc943b0481ec387a12dfe1f9a0670305a4970ed5cd2b7d1381179a716796eaaa4bb3a6cf0d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json
@@ -4494,7 +4494,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4524,7 +4524,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4554,7 +4554,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4584,7 +4584,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4614,7 +4614,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4644,7 +4644,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4674,7 +4674,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4704,7 +4704,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json
@@ -4946,7 +4946,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4976,7 +4976,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5006,7 +5006,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5036,7 +5036,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5066,7 +5066,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5096,7 +5096,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5126,7 +5126,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5156,7 +5156,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 282,
+  "numberOfTests": 290,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4942,6 +4942,246 @@
           "msg": "4d657373616765",
           "sig": "818b0fd6ca0978a59cad3fa15e84db2896f39b2aa462f0583834fa4444d153fe61e0c93071ba96c5ffa7193f77b806f31d2d6144172385f857db4b7e7e863962eacacdec034b4b4a9dd1af272604403f39f45a21948b30976e738e9e98fd9cee",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "046ccdfbab5508acb4d249874a289aa88f9c1f51c63aaa682a274853353060dd432030d70730c304aa6bee373ae6cc4d9e37e031b663362e6d9180b1e16640161d026fafba0c4de90d87584a52148cc70610b073da1ecb4c0db0c507cbc2a8fb6b",
+        "wx": "6ccdfbab5508acb4d249874a289aa88f9c1f51c63aaa682a274853353060dd432030d70730c304aa6bee373ae6cc4d9e",
+        "wy": "37e031b663362e6d9180b1e16640161d026fafba0c4de90d87584a52148cc70610b073da1ecb4c0db0c507cbc2a8fb6b"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200046ccdfbab5508acb4d249874a289aa88f9c1f51c63aaa682a274853353060dd432030d70730c304aa6bee373ae6cc4d9e37e031b663362e6d9180b1e16640161d026fafba0c4de90d87584a52148cc70610b073da1ecb4c0db0c507cbc2a8fb6b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABGzN+6tVCKy00kmHSiiaqI+cH1HG\nOqpoKidIUzUwYN1DIDDXBzDDBKpr7jc65sxNnjfgMbZjNi5tkYCx4WZAFh0Cb6+6\nDE3pDYdYSlIUjMcGELBz2h7LTA2wxQfLwqj7aw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 283,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "040bb23742fb3ca092a18cc0d55de6024fd9b69466c421fa8e8f9d572a5776af00364301a7c675fe7bbe42e24085e65cae76f3b9920b3953cd2d34dd0c538adcc5a79f0a5043205b1ba0e1439db0ef2a000920f723f5c3670b9338303c22ddd999",
+        "wx": "0bb23742fb3ca092a18cc0d55de6024fd9b69466c421fa8e8f9d572a5776af00364301a7c675fe7bbe42e24085e65cae",
+        "wy": "76f3b9920b3953cd2d34dd0c538adcc5a79f0a5043205b1ba0e1439db0ef2a000920f723f5c3670b9338303c22ddd999"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200040bb23742fb3ca092a18cc0d55de6024fd9b69466c421fa8e8f9d572a5776af00364301a7c675fe7bbe42e24085e65cae76f3b9920b3953cd2d34dd0c538adcc5a79f0a5043205b1ba0e1439db0ef2a000920f723f5c3670b9338303c22ddd999",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABAuyN0L7PKCSoYzA1V3mAk/ZtpRm\nxCH6jo+dVypXdq8ANkMBp8Z1/nu+QuJAheZcrnbzuZILOVPNLTTdDFOK3MWnnwpQ\nQyBbG6DhQ52w7yoACSD3I/XDZwuTODA8It3ZmQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 284,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000028cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "046ccdfbab5508acb4d249874a289aa88f9c1f51c63aaa682a274853353060dd432030d70730c304aa6bee373ae6cc4d9e37e031b663362e6d9180b1e16640161d026fafba0c4de90d87584a52148cc70610b073da1ecb4c0db0c507cbc2a8fb6b",
+        "wx": "6ccdfbab5508acb4d249874a289aa88f9c1f51c63aaa682a274853353060dd432030d70730c304aa6bee373ae6cc4d9e",
+        "wy": "37e031b663362e6d9180b1e16640161d026fafba0c4de90d87584a52148cc70610b073da1ecb4c0db0c507cbc2a8fb6b"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200046ccdfbab5508acb4d249874a289aa88f9c1f51c63aaa682a274853353060dd432030d70730c304aa6bee373ae6cc4d9e37e031b663362e6d9180b1e16640161d026fafba0c4de90d87584a52148cc70610b073da1ecb4c0db0c507cbc2a8fb6b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABGzN+6tVCKy00kmHSiiaqI+cH1HG\nOqpoKidIUzUwYN1DIDDXBzDDBKpr7jc65sxNnjfgMbZjNi5tkYCx4WZAFh0Cb6+6\nDE3pDYdYSlIUjMcGELBz2h7LTA2wxQfLwqj7aw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 285,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e90465668cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "040c85c7148557b3547b99179db691a3852e464695a96a8d80a4e729fa712217892f6edf396ed96322fde928695015dd45334049fc56d950c9b95260f1d23e8372e5a6e6cebb5fedb79e8dd5a638e2e75877a6c2be552f922f3ab957cfe1ae374d",
+        "wx": "0c85c7148557b3547b99179db691a3852e464695a96a8d80a4e729fa712217892f6edf396ed96322fde928695015dd45",
+        "wy": "334049fc56d950c9b95260f1d23e8372e5a6e6cebb5fedb79e8dd5a638e2e75877a6c2be552f922f3ab957cfe1ae374d"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200040c85c7148557b3547b99179db691a3852e464695a96a8d80a4e729fa712217892f6edf396ed96322fde928695015dd45334049fc56d950c9b95260f1d23e8372e5a6e6cebb5fedb79e8dd5a638e2e75877a6c2be552f922f3ab957cfe1ae374d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABAyFxxSFV7NUe5kXnbaRo4UuRkaV\nqWqNgKTnKfpxIheJL27fOW7ZYyL96ShpUBXdRTNASfxW2VDJuVJg8dI+g3LlpubO\nu1/tt56N1aY44udYd6bCvlUvki86uVfP4a43TQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 286,
+          "comment": "r = n - 2, x = n - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e90465638cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "047d93dfc3987183f62312f164852f511cc06f8f4b4fc29c370587da4927802edb6f030bae06abec906d031f409c2f2b355f60e860d34357956647540e692743533f59911f0d8f0a093c4ff84f66288867e2fa753c1342ef05e510d528574bd2bf",
+        "wx": "7d93dfc3987183f62312f164852f511cc06f8f4b4fc29c370587da4927802edb6f030bae06abec906d031f409c2f2b35",
+        "wy": "5f60e860d34357956647540e692743533f59911f0d8f0a093c4ff84f66288867e2fa753c1342ef05e510d528574bd2bf"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200047d93dfc3987183f62312f164852f511cc06f8f4b4fc29c370587da4927802edb6f030bae06abec906d031f409c2f2b355f60e860d34357956647540e692743533f59911f0d8f0a093c4ff84f66288867e2fa753c1342ef05e510d528574bd2bf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABH2T38OYcYP2IxLxZIUvURzAb49L\nT8KcNwWH2kkngC7bbwMLrgar7JBtAx9AnC8rNV9g6GDTQ1eVZkdUDmknQ1M/WZEf\nDY8KCTxP+E9mKIhn4vp1PBNC7wXlENUoV0vSvw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 287,
+          "comment": "r = 1, x = n + 1 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "044903be502d35a3bff2ea965679d02092d6eea949d8be120b08a2f465ae8b4103ff81d6b5875638aa6974801c3bea265b6e397e60b4ccadadff35975ddbf97a513b750c352048bc7ffb88fd38aefb379b3ce1525d8016b99b6e15f1747a028b30",
+        "wx": "4903be502d35a3bff2ea965679d02092d6eea949d8be120b08a2f465ae8b4103ff81d6b5875638aa6974801c3bea265b",
+        "wy": "6e397e60b4ccadadff35975ddbf97a513b750c352048bc7ffb88fd38aefb379b3ce1525d8016b99b6e15f1747a028b30"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200044903be502d35a3bff2ea965679d02092d6eea949d8be120b08a2f465ae8b4103ff81d6b5875638aa6974801c3bea265b6e397e60b4ccadadff35975ddbf97a513b750c352048bc7ffb88fd38aefb379b3ce1525d8016b99b6e15f1747a028b30",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABEkDvlAtNaO/8uqWVnnQIJLW7qlJ\n2L4SCwii9GWui0ED/4HWtYdWOKppdIAcO+omW245fmC0zK2t/zWXXdv5elE7dQw1\nIEi8f/uI/Tiu+zebPOFSXYAWuZtuFfF0egKLMA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 288,
+          "comment": "r = 2, x = n + 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000028cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "047992d55b377e7e60ca1592f9bab814aa0a1e80585b0bf3718f5c7465dcdfb3a72181ebfdcf4c77a635eee318ef0b4c496665964ce63eed78e81a31ca1e64997f91ad7b64f4387d8beb5b18dad3bacfb6d522d23355b0d34e951e7054ee5c3e8d",
+        "wx": "7992d55b377e7e60ca1592f9bab814aa0a1e80585b0bf3718f5c7465dcdfb3a72181ebfdcf4c77a635eee318ef0b4c49",
+        "wy": "6665964ce63eed78e81a31ca1e64997f91ad7b64f4387d8beb5b18dad3bacfb6d522d23355b0d34e951e7054ee5c3e8d"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200047992d55b377e7e60ca1592f9bab814aa0a1e80585b0bf3718f5c7465dcdfb3a72181ebfdcf4c77a635eee318ef0b4c496665964ce63eed78e81a31ca1e64997f91ad7b64f4387d8beb5b18dad3bacfb6d522d23355b0d34e951e7054ee5c3e8d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABHmS1Vs3fn5gyhWS+bq4FKoKHoBY\nWwvzcY9cdGXc37OnIYHr/c9Md6Y17uMY7wtMSWZllkzmPu146Boxyh5kmX+RrXtk\n9Dh9i+tbGNrTus+21SLSM1Ww006VHnBU7lw+jQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 289,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000f39b6bacd3b2eb7bdd98f07a249d57614bbece10480386ef8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "044c2600392d8674f2d0cf9119f522c59722a763eed686177e0b3bcd5f56d84d2fbcb5c2fd911f33c8a20e4748ffd2b5f721a0395e024a681cb6bd32702f61f5e64c35d4f9a87e489d5d4b64de264febe685b6c6d0f03e23e7939fbfed2df28814",
+        "wx": "4c2600392d8674f2d0cf9119f522c59722a763eed686177e0b3bcd5f56d84d2fbcb5c2fd911f33c8a20e4748ffd2b5f7",
+        "wy": "21a0395e024a681cb6bd32702f61f5e64c35d4f9a87e489d5d4b64de264febe685b6c6d0f03e23e7939fbfed2df28814"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200044c2600392d8674f2d0cf9119f522c59722a763eed686177e0b3bcd5f56d84d2fbcb5c2fd911f33c8a20e4748ffd2b5f721a0395e024a681cb6bd32702f61f5e64c35d4f9a87e489d5d4b64de264febe685b6c6d0f03e23e7939fbfed2df28814",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABEwmADkthnTy0M+RGfUixZcip2Pu\n1oYXfgs7zV9W2E0vvLXC/ZEfM8iiDkdI/9K19yGgOV4CSmgctr0ycC9h9eZMNdT5\nqH5InV1LZN4mT+vmhbbG0PA+I+eTn7/tLfKIFA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 290,
+          "comment": "r = 2^384 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^384 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "7346e17d5cc792d7f0a29081af19be20ead08ef612aba94ce0e9919353fbda5830c5495094803cefc477cdfd16fb9a9c8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json
@@ -5456,7 +5456,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5486,7 +5486,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5516,7 +5516,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5546,7 +5546,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5576,7 +5576,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5606,7 +5606,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5636,7 +5636,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5666,7 +5666,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 327,
+  "numberOfTests": 335,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5452,6 +5452,246 @@
           "msg": "4d657373616765",
           "sig": "19524b15cf4ecb400b938ef5f752b86ec8f07c5903da5dba9c91ab7965b1223a8e262bef8cca8973ed98797f37a35e1c5999cf203e610ef773c6aa2786bba06498cf7526f5a24a0e2f22f909f8190b13130451b15dd6774bdea9d929342d924bc7eba1df89919c1b9aee8d09203606d10cebff89904cb7e71a82d8972d755306",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "040ba4c3466eae96e1261f08991563127947581c0e54feef11e5ee64646ca25e860aa220ef075f8135d162047398ca355875114f6cdbb51e231595d5fea8e631ba47446ef3c0c6a6901aac287cefdc3f915d86a6e7e1e20215623138464dcbc650208fde9c2beb3934a4fdec3e5855d2a14db41e65bb83817f4db65a252e007f3e",
+        "wx": "0ba4c3466eae96e1261f08991563127947581c0e54feef11e5ee64646ca25e860aa220ef075f8135d162047398ca355875114f6cdbb51e231595d5fea8e631ba",
+        "wy": "47446ef3c0c6a6901aac287cefdc3f915d86a6e7e1e20215623138464dcbc650208fde9c2beb3934a4fdec3e5855d2a14db41e65bb83817f4db65a252e007f3e"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d03818200040ba4c3466eae96e1261f08991563127947581c0e54feef11e5ee64646ca25e860aa220ef075f8135d162047398ca355875114f6cdbb51e231595d5fea8e631ba47446ef3c0c6a6901aac287cefdc3f915d86a6e7e1e20215623138464dcbc650208fde9c2beb3934a4fdec3e5855d2a14db41e65bb83817f4db65a252e007f3e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEC6TDRm6uluEmHwiZFWMSeUdY\nHA5U/u8R5e5kZGyiXoYKoiDvB1+BNdFiBHOYyjVYdRFPbNu1HiMVldX+qOYxukdE\nbvPAxqaQGqwofO/cP5Fdhqbn4eICFWIxOEZNy8ZQII/enCvrOTSk/ew+WFXSoU20\nHmW7g4F/TbZaJS4Afz4=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 328,
+          "comment": "r = 3, x = 3 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "046ffee3781399cd1fc118e83e0f5a6d70dfc5d2448744a7dd9e1a4716d3c92cd4d047a323cc2b9dced43ef3a9eb0118c28e47f34259af4f92fe8588a6aced00dba4ae23dfe8e2b8129ff60e97a52ac8a972f3f59d9c4dca865e0a988c3e12203af670220c4cf5a3015288e592e4d83cf699223a291e845007115487919e3517e7",
+        "wx": "6ffee3781399cd1fc118e83e0f5a6d70dfc5d2448744a7dd9e1a4716d3c92cd4d047a323cc2b9dced43ef3a9eb0118c28e47f34259af4f92fe8588a6aced00db",
+        "wy": "a4ae23dfe8e2b8129ff60e97a52ac8a972f3f59d9c4dca865e0a988c3e12203af670220c4cf5a3015288e592e4d83cf699223a291e845007115487919e3517e7"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d03818200046ffee3781399cd1fc118e83e0f5a6d70dfc5d2448744a7dd9e1a4716d3c92cd4d047a323cc2b9dced43ef3a9eb0118c28e47f34259af4f92fe8588a6aced00dba4ae23dfe8e2b8129ff60e97a52ac8a972f3f59d9c4dca865e0a988c3e12203af670220c4cf5a3015288e592e4d83cf699223a291e845007115487919e3517e7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEb/7jeBOZzR/BGOg+D1ptcN/F\n0kSHRKfdnhpHFtPJLNTQR6MjzCudztQ+86nrARjCjkfzQlmvT5L+hYimrO0A26Su\nI9/o4rgSn/YOl6UqyKly8/WdnE3Khl4KmIw+EiA69nAiDEz1owFSiOWS5Ng89pki\nOikehFAHEVSHkZ41F+c=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 329,
+          "comment": "r = 4, x = 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "040ba4c3466eae96e1261f08991563127947581c0e54feef11e5ee64646ca25e860aa220ef075f8135d162047398ca355875114f6cdbb51e231595d5fea8e631ba47446ef3c0c6a6901aac287cefdc3f915d86a6e7e1e20215623138464dcbc650208fde9c2beb3934a4fdec3e5855d2a14db41e65bb83817f4db65a252e007f3e",
+        "wx": "0ba4c3466eae96e1261f08991563127947581c0e54feef11e5ee64646ca25e860aa220ef075f8135d162047398ca355875114f6cdbb51e231595d5fea8e631ba",
+        "wy": "47446ef3c0c6a6901aac287cefdc3f915d86a6e7e1e20215623138464dcbc650208fde9c2beb3934a4fdec3e5855d2a14db41e65bb83817f4db65a252e007f3e"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d03818200040ba4c3466eae96e1261f08991563127947581c0e54feef11e5ee64646ca25e860aa220ef075f8135d162047398ca355875114f6cdbb51e231595d5fea8e631ba47446ef3c0c6a6901aac287cefdc3f915d86a6e7e1e20215623138464dcbc650208fde9c2beb3934a4fdec3e5855d2a14db41e65bb83817f4db65a252e007f3e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEC6TDRm6uluEmHwiZFWMSeUdY\nHA5U/u8R5e5kZGyiXoYKoiDvB1+BNdFiBHOYyjVYdRFPbNu1HiMVldX+qOYxukdE\nbvPAxqaQGqwofO/cP5Fdhqbn4eICFWIxOEZNy8ZQII/enCvrOTSk/ew+WFXSoU20\nHmW7g4F/TbZaJS4Afz4=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 330,
+          "comment": "r = 3 + n, x = 3 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca9006caadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "0441caf931097d532fbd0e7809304c1b62d2b4a0dedd189bcad12de84932b42714743c45009e964273822b570257521b61342d4d78ce94926493329584b5258967295e3ff92406055c6bcfb58565e4edcb8e016141818a40024e010f1d103e93a9ccb9b457bbab72da792c848240927129f7dde8a576cff5985d3580f60b5ff709",
+        "wx": "41caf931097d532fbd0e7809304c1b62d2b4a0dedd189bcad12de84932b42714743c45009e964273822b570257521b61342d4d78ce94926493329584b5258967",
+        "wy": "295e3ff92406055c6bcfb58565e4edcb8e016141818a40024e010f1d103e93a9ccb9b457bbab72da792c848240927129f7dde8a576cff5985d3580f60b5ff709"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d038182000441caf931097d532fbd0e7809304c1b62d2b4a0dedd189bcad12de84932b42714743c45009e964273822b570257521b61342d4d78ce94926493329584b5258967295e3ff92406055c6bcfb58565e4edcb8e016141818a40024e010f1d103e93a9ccb9b457bbab72da792c848240927129f7dde8a576cff5985d3580f60b5ff709",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEQcr5MQl9Uy+9DngJMEwbYtK0\noN7dGJvK0S3oSTK0JxR0PEUAnpZCc4IrVwJXUhthNC1NeM6UkmSTMpWEtSWJZyle\nP/kkBgVca8+1hWXk7cuOAWFBgYpAAk4BDx0QPpOpzLm0V7urctp5LISCQJJxKffd\n6KV2z/WYXTWA9gtf9wk=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 331,
+          "comment": "r = n - 5, x = n - 4 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90064aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "0411a28a14506d538a1595753bf9961463923d9062a19bd9058338f285226a7b95ea862f6392a17fc1c8356bc37bb4043fe2e4302a31baa4d76dccbb16adcf31a3090a9a44e6da51f7574adbbcc8dd67071a38e29d37e13e69881edce729db8afd14d075a511fe8da315f77daa3275a233a6b015442ac5cd8e1141d61ae2c95301",
+        "wx": "11a28a14506d538a1595753bf9961463923d9062a19bd9058338f285226a7b95ea862f6392a17fc1c8356bc37bb4043fe2e4302a31baa4d76dccbb16adcf31a3",
+        "wy": "090a9a44e6da51f7574adbbcc8dd67071a38e29d37e13e69881edce729db8afd14d075a511fe8da315f77daa3275a233a6b015442ac5cd8e1141d61ae2c95301"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d038182000411a28a14506d538a1595753bf9961463923d9062a19bd9058338f285226a7b95ea862f6392a17fc1c8356bc37bb4043fe2e4302a31baa4d76dccbb16adcf31a3090a9a44e6da51f7574adbbcc8dd67071a38e29d37e13e69881edce729db8afd14d075a511fe8da315f77daa3275a233a6b015442ac5cd8e1141d61ae2c95301",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEEaKKFFBtU4oVlXU7+ZYUY5I9\nkGKhm9kFgzjyhSJqe5Xqhi9jkqF/wcg1a8N7tAQ/4uQwKjG6pNdtzLsWrc8xowkK\nmkTm2lH3V0rbvMjdZwcaOOKdN+E+aYge3Ocp24r9FNB1pRH+jaMV932qMnWiM6aw\nFUQqxc2OEUHWGuLJUwE=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 332,
+          "comment": "r = 2, x = n + 2 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "0468ab0f1528091a609301963aa88bd12ff825ee2a4c870ada8d955e30440f07279e24f333c7247fc90811503bf0aaf22077ae9cd9acc339c796086d647caffb5828d4159801d03b154a7e7f36ad66a3178bdc757d6bb87926166a77e2970934aaf7548aa5e0a19ea4ef908ac61f8ea67c458d326c65724114084eb70f771359f1",
+        "wx": "68ab0f1528091a609301963aa88bd12ff825ee2a4c870ada8d955e30440f07279e24f333c7247fc90811503bf0aaf22077ae9cd9acc339c796086d647caffb58",
+        "wy": "28d4159801d03b154a7e7f36ad66a3178bdc757d6bb87926166a77e2970934aaf7548aa5e0a19ea4ef908ac61f8ea67c458d326c65724114084eb70f771359f1"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d038182000468ab0f1528091a609301963aa88bd12ff825ee2a4c870ada8d955e30440f07279e24f333c7247fc90811503bf0aaf22077ae9cd9acc339c796086d647caffb5828d4159801d03b154a7e7f36ad66a3178bdc757d6bb87926166a77e2970934aaf7548aa5e0a19ea4ef908ac61f8ea67c458d326c65724114084eb70f771359f1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEaKsPFSgJGmCTAZY6qIvRL/gl\n7ipMhwrajZVeMEQPByeeJPMzxyR/yQgRUDvwqvIgd66c2azDOceWCG1kfK/7WCjU\nFZgB0DsVSn5/Nq1moxeL3HV9a7h5JhZqd+KXCTSq91SKpeChnqTvkIrGH46mfEWN\nMmxlckEUCE63D3cTWfE=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 333,
+          "comment": "r = 3, x = n + 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "041e6ddc1b76a1ae0d7ea89fdf5e1731bb2d68f17748b99a51add8b62bdc1ff1070d68b5f5640c0a6e5b5f237bf938c59363ca4c4b06c9df54de891e37068789b6720ec94b0311536d3ab8a51cac2e4ba2c50f9ca71b05256a86c9070b06f2b8de765aaf82d45381d7a17e2ee81e70a07fdd99cf0372793c2d371b9c0579492147",
+        "wx": "1e6ddc1b76a1ae0d7ea89fdf5e1731bb2d68f17748b99a51add8b62bdc1ff1070d68b5f5640c0a6e5b5f237bf938c59363ca4c4b06c9df54de891e37068789b6",
+        "wy": "720ec94b0311536d3ab8a51cac2e4ba2c50f9ca71b05256a86c9070b06f2b8de765aaf82d45381d7a17e2ee81e70a07fdd99cf0372793c2d371b9c0579492147"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d03818200041e6ddc1b76a1ae0d7ea89fdf5e1731bb2d68f17748b99a51add8b62bdc1ff1070d68b5f5640c0a6e5b5f237bf938c59363ca4c4b06c9df54de891e37068789b6720ec94b0311536d3ab8a51cac2e4ba2c50f9ca71b05256a86c9070b06f2b8de765aaf82d45381d7a17e2ee81e70a07fdd99cf0372793c2d371b9c0579492147",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEHm3cG3ahrg1+qJ/fXhcxuy1o\n8XdIuZpRrdi2K9wf8QcNaLX1ZAwKbltfI3v5OMWTY8pMSwbJ31TeiR43BoeJtnIO\nyUsDEVNtOrilHKwuS6LFD5ynGwUlaobJBwsG8rjedlqvgtRTgdehfi7oHnCgf92Z\nzwNyeTwtNxucBXlJIUc=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 334,
+          "comment": "r = p - n + 3, x = 3 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001280f3ebf4f1d42296d47401166f7709f0ad02bae2524eba77322c9d3bb91488daadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "04120618e2916f4d0fc6c9d7eb87d1db353ad1eb2676ee55c9e5bb94e12e015cbf378f34143261762360b3423bc8caafa5422876e32f584bb364b7e5e8a84a43c9a68d025688876e0dda01e0665a946261505a542d8a1d9675656c397a8024da8e4e949b7d8ea9ad604aac14b9089f654b2a3191db6973f41975ec0249e5d88d95",
+        "wx": "120618e2916f4d0fc6c9d7eb87d1db353ad1eb2676ee55c9e5bb94e12e015cbf378f34143261762360b3423bc8caafa5422876e32f584bb364b7e5e8a84a43c9",
+        "wy": "a68d025688876e0dda01e0665a946261505a542d8a1d9675656c397a8024da8e4e949b7d8ea9ad604aac14b9089f654b2a3191db6973f41975ec0249e5d88d95"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d0381820004120618e2916f4d0fc6c9d7eb87d1db353ad1eb2676ee55c9e5bb94e12e015cbf378f34143261762360b3423bc8caafa5422876e32f584bb364b7e5e8a84a43c9a68d025688876e0dda01e0665a946261505a542d8a1d9675656c397a8024da8e4e949b7d8ea9ad604aac14b9089f654b2a3191db6973f41975ec0249e5d88d95",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEEgYY4pFvTQ/Gydfrh9HbNTrR\n6yZ27lXJ5buU4S4BXL83jzQUMmF2I2CzQjvIyq+lQih24y9YS7Nkt+XoqEpDyaaN\nAlaIh24N2gHgZlqUYmFQWlQtih2WdWVsOXqAJNqOTpSbfY6prWBKrBS5CJ9lSyox\nkdtpc/QZdewCSeXYjZU=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 335,
+          "comment": "r = 2^512 - n + 3, x = 3 is invalid; r + n is too large to compare r + n with x, and overflows 2^512 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "5522624724163b74c02b1951cc3603f834cf724c4c362df1299c63358fccf78faac1a3beb356d9e6be799ee68053efb8e24e2c7ef7a225224a78697d6356ff9aaadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json
@@ -3994,7 +3994,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4024,7 +4024,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4054,7 +4054,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4084,7 +4084,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4114,7 +4114,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 217,
+  "numberOfTests": 222,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -3990,6 +3990,156 @@
           "msg": "0000000000000000000000000000000000000000",
           "sig": "00f036a3151449a8f854c12c6fd55bd9fb02ee67af00c3bc5227188b85b9b9c33fa7c5088f8e8e02de86",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160k1",
+        "keySize": 160,
+        "uncompressed": "04be99ac6fc9a59531dc6f2a2906b64cb487299ab7837d23e3a700057d02da9124b634a6d5d8d34954",
+        "wx": "be99ac6fc9a59531dc6f2a2906b64cb487299ab7",
+        "wy": "837d23e3a700057d02da9124b634a6d5d8d34954"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040009032a0004be99ac6fc9a59531dc6f2a2906b64cb487299ab7837d23e3a700057d02da9124b634a6d5d8d34954",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEvpmsb8mllTHcbyopBrZMtIcpmreDfSPj\npwAFfQLakSS2NKbV2NNJVA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 218,
+          "comment": "r = 3, x = 3 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000030100000000000000000001b8fa16dfab9aca16b6b0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160k1",
+        "keySize": 160,
+        "uncompressed": "04bb656e313ad998608600072c49466d1f64867509d386273de3a608e2979400b631d863f98ce9e30d",
+        "wx": "bb656e313ad998608600072c49466d1f64867509",
+        "wy": "d386273de3a608e2979400b631d863f98ce9e30d"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040009032a0004bb656e313ad998608600072c49466d1f64867509d386273de3a608e2979400b631d863f98ce9e30d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEu2VuMTrZmGCGAAcsSUZtH2SGdQnThic9\n46YI4peUALYx2GP5jOnjDQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 219,
+          "comment": "r = 4, x = 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000040100000000000000000001b8fa16dfab9aca16b6b0",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160k1",
+        "keySize": 160,
+        "uncompressed": "04be99ac6fc9a59531dc6f2a2906b64cb487299ab7837d23e3a700057d02da9124b634a6d5d8d34954",
+        "wx": "be99ac6fc9a59531dc6f2a2906b64cb487299ab7",
+        "wy": "837d23e3a700057d02da9124b634a6d5d8d34954"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040009032a0004be99ac6fc9a59531dc6f2a2906b64cb487299ab7837d23e3a700057d02da9124b634a6d5d8d34954",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEvpmsb8mllTHcbyopBrZMtIcpmreDfSPj\npwAFfQLakSS2NKbV2NNJVA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 220,
+          "comment": "r = 3 + n, x = 3 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0100000000000000000001b8fa16dfab9aca16b6b60100000000000000000001b8fa16dfab9aca16b6b0",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160k1",
+        "keySize": 160,
+        "uncompressed": "0448857214d28ab26924ec9a0238ec5b66dd33d3f91e9f77ded71f64ffc98ed61717285c1ee88d7cf1",
+        "wx": "48857214d28ab26924ec9a0238ec5b66dd33d3f9",
+        "wy": "1e9f77ded71f64ffc98ed61717285c1ee88d7cf1"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040009032a000448857214d28ab26924ec9a0238ec5b66dd33d3f91e9f77ded71f64ffc98ed61717285c1ee88d7cf1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAESIVyFNKKsmkk7JoCOOxbZt0z0/ken3fe\n1x9k/8mO1hcXKFwe6I188Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "r = p - 2, x = p - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00fffffffffffffffffffffffffffffffeffffac710100000000000000000001b8fa16dfab9aca16b6b0",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160k1",
+        "keySize": 160,
+        "uncompressed": "04101c1d751ec61e29e54098baa65affef438ba63e16dc3f72f790d92ea035ac8bdc687f51eb802c21",
+        "wx": "101c1d751ec61e29e54098baa65affef438ba63e",
+        "wy": "16dc3f72f790d92ea035ac8bdc687f51eb802c21"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040009032a0004101c1d751ec61e29e54098baa65affef438ba63e16dc3f72f790d92ea035ac8bdc687f51eb802c21",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEEBwddR7GHinlQJi6plr/70OLpj4W3D9y\n95DZLqA1rIvcaH9R64AsIQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r = 3 + p, x = 3 is invalid; values only match mod p",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00fffffffffffffffffffffffffffffffeffffac760100000000000000000001b8fa16dfab9aca16b6b0",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 221,
+  "numberOfTests": 226,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4093,6 +4093,156 @@
           "msg": "0000000000000000000000000000000000000000",
           "sig": "004f71014057dde59269ba089c49082dab3ffa9af3008d1abb842b2f932a04c2dd19a2f2109a57c88c32",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r1",
+        "keySize": 160,
+        "uncompressed": "0439891bd61138e775cd012518ff00f59ae01c473325026b77b1c44affb1592dcf711b4290e9404c9f",
+        "wx": "39891bd61138e775cd012518ff00f59ae01c4733",
+        "wy": "25026b77b1c44affb1592dcf711b4290e9404c9f"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040008032a000439891bd61138e775cd012518ff00f59ae01c473325026b77b1c44affb1592dcf711b4290e9404c9f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEOYkb1hE453XNASUY/wD1muAcRzMlAmt3\nscRK/7FZLc9xG0KQ6UBMnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r = 4, x = 4 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000040100000000000000000001f4c8f927aed3ca752254",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r1",
+        "keySize": 160,
+        "uncompressed": "041a56b4e2ab0384b1daa35459f77066b5918b49d5a3a47844c1b449a82f14658948402cf8c592e0af",
+        "wx": "1a56b4e2ab0384b1daa35459f77066b5918b49d5",
+        "wy": "a3a47844c1b449a82f14658948402cf8c592e0af"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040008032a00041a56b4e2ab0384b1daa35459f77066b5918b49d5a3a47844c1b449a82f14658948402cf8c592e0af",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEGla04qsDhLHao1RZ93BmtZGLSdWjpHhE\nwbRJqC8UZYlIQCz4xZLgrw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "r = 5, x = 4 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000050100000000000000000001f4c8f927aed3ca752254",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r1",
+        "keySize": 160,
+        "uncompressed": "0439891bd61138e775cd012518ff00f59ae01c473325026b77b1c44affb1592dcf711b4290e9404c9f",
+        "wx": "39891bd61138e775cd012518ff00f59ae01c4733",
+        "wy": "25026b77b1c44affb1592dcf711b4290e9404c9f"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040008032a000439891bd61138e775cd012518ff00f59ae01c473325026b77b1c44affb1592dcf711b4290e9404c9f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEOYkb1hE453XNASUY/wD1muAcRzMlAmt3\nscRK/7FZLc9xG0KQ6UBMnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "r = 4 + n, x = 4 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0100000000000000000001f4c8f927aed3ca75225b0100000000000000000001f4c8f927aed3ca752254",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r1",
+        "keySize": 160,
+        "uncompressed": "042a675dfed49c0f8c298abae00cd7afdcb7fd84caa94d8033f6cbbb84b9f8b7e4838c495c46439355",
+        "wx": "2a675dfed49c0f8c298abae00cd7afdcb7fd84ca",
+        "wy": "a94d8033f6cbbb84b9f8b7e4838c495c46439355"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040008032a00042a675dfed49c0f8c298abae00cd7afdcb7fd84caa94d8033f6cbbb84b9f8b7e4838c495c46439355",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEKmdd/tScD4wpirrgDNev3Lf9hMqpTYAz\n9su7hLn4t+SDjElcRkOTVQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "r = p - 4, x = p - 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00ffffffffffffffffffffffffffffffff7ffffffb0100000000000000000001f4c8f927aed3ca752254",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r1",
+        "keySize": 160,
+        "uncompressed": "04d8add22064027856c162243ab09ea966429752978822a506712385ab3ebe5c61737c3bbb722b06b9",
+        "wx": "d8add22064027856c162243ab09ea96642975297",
+        "wy": "8822a506712385ab3ebe5c61737c3bbb722b06b9"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040008032a0004d8add22064027856c162243ab09ea966429752978822a506712385ab3ebe5c61737c3bbb722b06b9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAE2K3SIGQCeFbBYiQ6sJ6pZkKXUpeIIqUG\ncSOFqz6+XGFzfDu7cisGuQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 226,
+          "comment": "r = 4 + p, x = 4 is invalid; values only match mod p",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00ffffffffffffffffffffffffffffffff800000030100000000000000000001f4c8f927aed3ca752254",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json
@@ -4097,7 +4097,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4127,7 +4127,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4157,7 +4157,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4187,7 +4187,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4217,7 +4217,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json
@@ -4065,7 +4065,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4095,7 +4095,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4125,7 +4125,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4155,7 +4155,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4185,7 +4185,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 220,
+  "numberOfTests": 225,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4061,6 +4061,156 @@
           "msg": "0000000000000000000000000000000000000000",
           "sig": "004f71a123bf7c4983f5707c17ce4782c833e833f000dcfb123cf5470f21375e62ba4054ffd9a836908c",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r2",
+        "keySize": 160,
+        "uncompressed": "04731d9060a1a48ace681f5ab3f4588c1d17d05c97ca47ca29efc067d0ca45f0ce74bc1c3405c587bf",
+        "wx": "731d9060a1a48ace681f5ab3f4588c1d17d05c97",
+        "wy": "ca47ca29efc067d0ca45f0ce74bc1c3405c587bf"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b8104001e032a0004731d9060a1a48ace681f5ab3f4588c1d17d05c97ca47ca29efc067d0ca45f0ce74bc1c3405c587bf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAEcx2QYKGkis5oH1qz9FiMHRfQXJfKR8op\n78Bn0MpF8M50vBw0BcWHvw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "r = 3, x = 3 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000030100000000000000000000351ee786a818f3a1a168",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r2",
+        "keySize": 160,
+        "uncompressed": "043a81986b55b5d613359e0375585f0c7ab161ddc464bba54f9c7d98bb0cb65c796350486dbb8a2882",
+        "wx": "3a81986b55b5d613359e0375585f0c7ab161ddc4",
+        "wy": "64bba54f9c7d98bb0cb65c796350486dbb8a2882"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b8104001e032a00043a81986b55b5d613359e0375585f0c7ab161ddc464bba54f9c7d98bb0cb65c796350486dbb8a2882",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAEOoGYa1W11hM1ngN1WF8MerFh3cRku6VP\nnH2Yuwy2XHljUEhtu4oogg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r = 4, x = 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000040100000000000000000000351ee786a818f3a1a168",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r2",
+        "keySize": 160,
+        "uncompressed": "04731d9060a1a48ace681f5ab3f4588c1d17d05c97ca47ca29efc067d0ca45f0ce74bc1c3405c587bf",
+        "wx": "731d9060a1a48ace681f5ab3f4588c1d17d05c97",
+        "wy": "ca47ca29efc067d0ca45f0ce74bc1c3405c587bf"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b8104001e032a0004731d9060a1a48ace681f5ab3f4588c1d17d05c97ca47ca29efc067d0ca45f0ce74bc1c3405c587bf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAEcx2QYKGkis5oH1qz9FiMHRfQXJfKR8op\n78Bn0MpF8M50vBw0BcWHvw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "r = 3 + n, x = 3 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0100000000000000000000351ee786a818f3a1a16e0100000000000000000000351ee786a818f3a1a168",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r2",
+        "keySize": 160,
+        "uncompressed": "04b1dfe1d39caec7f5d8d316754308140be4a811bb46a582b1ad79c9c208ce78edeadfa424ec8a73d5",
+        "wx": "b1dfe1d39caec7f5d8d316754308140be4a811bb",
+        "wy": "46a582b1ad79c9c208ce78edeadfa424ec8a73d5"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b8104001e032a0004b1dfe1d39caec7f5d8d316754308140be4a811bb46a582b1ad79c9c208ce78edeadfa424ec8a73d5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAEsd/h05yux/XY0xZ1QwgUC+SoEbtGpYKx\nrXnJwgjOeO3q36Qk7Ipz1Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "r = p - 4, x = p - 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00fffffffffffffffffffffffffffffffeffffac6f0100000000000000000000351ee786a818f3a1a168",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r2",
+        "keySize": 160,
+        "uncompressed": "04246fb12b286861d3005b95bc673b96f3f3a7a1576d24754f9f5a9b281c679a55418b47c0e4facef7",
+        "wx": "246fb12b286861d3005b95bc673b96f3f3a7a157",
+        "wy": "6d24754f9f5a9b281c679a55418b47c0e4facef7"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b8104001e032a0004246fb12b286861d3005b95bc673b96f3f3a7a1576d24754f9f5a9b281c679a55418b47c0e4facef7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAEJG+xKyhoYdMAW5W8ZzuW8/OnoVdtJHVP\nn1qbKBxnmlVBi0fA5PrO9w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "r = 3 + p, x = 3 is invalid; values only match mod p",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00fffffffffffffffffffffffffffffffeffffac760100000000000000000000351ee786a818f3a1a168",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json
@@ -4021,7 +4021,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4051,7 +4051,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4081,7 +4081,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4111,7 +4111,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4141,7 +4141,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4171,7 +4171,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4201,7 +4201,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4231,7 +4231,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 218,
+  "numberOfTests": 226,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4017,6 +4017,246 @@
           "msg": "0000000000000000000000000000000000000000",
           "sig": "28d91785c005c416c436222a06578939d12c9ead1cfcd63c828921b3e632424caa08ce947d2ef43a3b9ccb89f5a74820",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "04ff1f7d8ad7dc75fe26ac6f6791c22b2b0e7b22d0a92db4f3e97fd6c42846a22a122864f0ac24cde3abdf5e13763afe1f",
+        "wx": "ff1f7d8ad7dc75fe26ac6f6791c22b2b0e7b22d0a92db4f3",
+        "wy": "e97fd6c42846a22a122864f0ac24cde3abdf5e13763afe1f"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f03320004ff1f7d8ad7dc75fe26ac6f6791c22b2b0e7b22d0a92db4f3e97fd6c42846a22a122864f0ac24cde3abdf5e13763afe1f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAE/x99itfcdf4mrG9nkcIrKw57ItCpLbTz\n6X/WxChGoioSKGTwrCTN46vfXhN2Ov4f\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 219,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000001fffffffffffffffffffffffe26f2fc170f69466a74defd8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "04951690bd295c2a46d114024be14475eb555d98b64224c2fa9ae391fa777dac60a5843e4a2b1e2a4393ee44db23104884",
+        "wx": "951690bd295c2a46d114024be14475eb555d98b64224c2fa",
+        "wy": "9ae391fa777dac60a5843e4a2b1e2a4393ee44db23104884"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f03320004951690bd295c2a46d114024be14475eb555d98b64224c2fa9ae391fa777dac60a5843e4a2b1e2a4393ee44db23104884",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAElRaQvSlcKkbRFAJL4UR161VdmLZCJML6\nmuOR+nd9rGClhD5KKx4qQ5PuRNsjEEiE\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 220,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000002fffffffffffffffffffffffe26f2fc170f69466a74defd8a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "04ff1f7d8ad7dc75fe26ac6f6791c22b2b0e7b22d0a92db4f3e97fd6c42846a22a122864f0ac24cde3abdf5e13763afe1f",
+        "wx": "ff1f7d8ad7dc75fe26ac6f6791c22b2b0e7b22d0a92db4f3",
+        "wy": "e97fd6c42846a22a122864f0ac24cde3abdf5e13763afe1f"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f03320004ff1f7d8ad7dc75fe26ac6f6791c22b2b0e7b22d0a92db4f3e97fd6c42846a22a122864f0ac24cde3abdf5e13763afe1f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAE/x99itfcdf4mrG9nkcIrKw57ItCpLbTz\n6X/WxChGoioSKGTwrCTN46vfXhN2Ov4f\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "fffffffffffffffffffffffe26f2fc170f69466a74defd8efffffffffffffffffffffffe26f2fc170f69466a74defd8a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "049ffd878b0bd9815a333953553f206083ae9399b23ed0fc45d2418b5d256753e5f38fc20d6a6b4e961cbc0580c504d293",
+        "wx": "9ffd878b0bd9815a333953553f206083ae9399b23ed0fc45",
+        "wy": "d2418b5d256753e5f38fc20d6a6b4e961cbc0580c504d293"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f033200049ffd878b0bd9815a333953553f206083ae9399b23ed0fc45d2418b5d256753e5f38fc20d6a6b4e961cbc0580c504d293",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAEn/2HiwvZgVozOVNVPyBgg66TmbI+0PxF\n0kGLXSVnU+Xzj8INamtOlhy8BYDFBNKT\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "fffffffffffffffffffffffe26f2fc170f69466a74defd8afffffffffffffffffffffffe26f2fc170f69466a74defd8a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "0463457e379b340f72ff41562bca19028a61572dfbcb1d64553aecdd860458a311db876a1b56a7b15024b468423aeea918",
+        "wx": "63457e379b340f72ff41562bca19028a61572dfbcb1d6455",
+        "wy": "3aecdd860458a311db876a1b56a7b15024b468423aeea918"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f0332000463457e379b340f72ff41562bca19028a61572dfbcb1d64553aecdd860458a311db876a1b56a7b15024b468423aeea918",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAEY0V+N5s0D3L/QVYryhkCimFXLfvLHWRV\nOuzdhgRYoxHbh2obVqexUCS0aEI67qkY\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "r = 1, x = n + 1 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000001fffffffffffffffffffffffe26f2fc170f69466a74defd8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "0411dd4d219a418132f0a52ac9ab38d46700bf25ed0956a8170847ccf90aa8514fd3f439d7e58159fdad5ab535868000d0",
+        "wx": "11dd4d219a418132f0a52ac9ab38d46700bf25ed0956a817",
+        "wy": "0847ccf90aa8514fd3f439d7e58159fdad5ab535868000d0"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f0332000411dd4d219a418132f0a52ac9ab38d46700bf25ed0956a8170847ccf90aa8514fd3f439d7e58159fdad5ab535868000d0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAEEd1NIZpBgTLwpSrJqzjUZwC/Je0JVqgX\nCEfM+QqoUU/T9DnX5YFZ/a1atTWGgADQ\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "r = 2, x = n + 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000002fffffffffffffffffffffffe26f2fc170f69466a74defd8a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "048397cddf9bfdc07cc8e065bbeb6faf956fd008978327682872acd9aad89ea9647da3f92d6d0e70352a13afadf804cbe6",
+        "wx": "8397cddf9bfdc07cc8e065bbeb6faf956fd0089783276828",
+        "wy": "72acd9aad89ea9647da3f92d6d0e70352a13afadf804cbe6"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f033200048397cddf9bfdc07cc8e065bbeb6faf956fd008978327682872acd9aad89ea9647da3f92d6d0e70352a13afadf804cbe6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAEg5fN35v9wHzI4GW762+vlW/QCJeDJ2go\ncqzZqtieqWR9o/ktbQ5wNSoTr634BMvm\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000001d90d03e8f096b9948b20f0abfffffffffffffffffffffffe26f2fc170f69466a74defd8a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "0468511128a11519b4bafe7f7d2afc000ab4e057a62967b48d197aac8c740b07f4098bae99e50ddd5c0e9778a693eec9fb",
+        "wx": "68511128a11519b4bafe7f7d2afc000ab4e057a62967b48d",
+        "wy": "197aac8c740b07f4098bae99e50ddd5c0e9778a693eec9fb"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f0332000468511128a11519b4bafe7f7d2afc000ab4e057a62967b48d197aac8c740b07f4098bae99e50ddd5c0e9778a693eec9fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAEaFERKKEVGbS6/n99KvwACrTgV6YpZ7SN\nGXqsjHQLB/QJi66Z5Q3dXA6XeKaT7sn7\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 226,
+          "comment": "r = 2^192 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^192 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000001d90d03e8f096b9958b210274fffffffffffffffffffffffe26f2fc170f69466a74defd8a",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 220,
+  "numberOfTests": 228,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4077,6 +4077,246 @@
           "msg": "0000000000000000000000000000000000000000",
           "sig": "91cd55bb1984e9d793f9a17bd516aa7aa597569d296222503996aa1d58df66bddd4aaf70964775198137c819c9e6b88e",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "04a4f622d7ce2147769490296999e9b9d7fb50e555d31379b58ec1663424f8706136a8e69115de49ab66e772924a7ed44a",
+        "wx": "a4f622d7ce2147769490296999e9b9d7fb50e555d31379b5",
+        "wy": "8ec1663424f8706136a8e69115de49ab66e772924a7ed44a"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d03010103320004a4f622d7ce2147769490296999e9b9d7fb50e555d31379b58ec1663424f8706136a8e69115de49ab66e772924a7ed44a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEpPYi184hR3aUkClpmem51/tQ5VXT\nE3m1jsFmNCT4cGE2qOaRFd5Jq2bncpJKftRK\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "r = 2, x = 2 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000002ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "0469343dd459b7a8ef8e2547630e644c419c9ad442f3a758eb302da6252c958f978758adacd52e310bed81b9e3d224aaf9",
+        "wx": "69343dd459b7a8ef8e2547630e644c419c9ad442f3a758eb",
+        "wy": "302da6252c958f978758adacd52e310bed81b9e3d224aaf9"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d0301010332000469343dd459b7a8ef8e2547630e644c419c9ad442f3a758eb302da6252c958f978758adacd52e310bed81b9e3d224aaf9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEaTQ91Fm3qO+OJUdjDmRMQZya1ELz\np1jrMC2mJSyVj5eHWK2s1S4xC+2BuePSJKr5\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r = 3, x = 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000003ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "04a4f622d7ce2147769490296999e9b9d7fb50e555d31379b58ec1663424f8706136a8e69115de49ab66e772924a7ed44a",
+        "wx": "a4f622d7ce2147769490296999e9b9d7fb50e555d31379b5",
+        "wy": "8ec1663424f8706136a8e69115de49ab66e772924a7ed44a"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d03010103320004a4f622d7ce2147769490296999e9b9d7fb50e555d31379b58ec1663424f8706136a8e69115de49ab66e772924a7ed44a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEpPYi184hR3aUkClpmem51/tQ5VXT\nE3m1jsFmNCT4cGE2qOaRFd5Jq2bncpJKftRK\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "r = 2 + n, x = 2 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffff99def836146bc9b1b4d22833ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "04f1a475704d9b92ef2d89f52c4b6abc3906268938edf2abc58bf3122ed7a74c27f53970f748e8e9d497f090950e6b7b2d",
+        "wx": "f1a475704d9b92ef2d89f52c4b6abc3906268938edf2abc5",
+        "wy": "8bf3122ed7a74c27f53970f748e8e9d497f090950e6b7b2d"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d03010103320004f1a475704d9b92ef2d89f52c4b6abc3906268938edf2abc58bf3122ed7a74c27f53970f748e8e9d497f090950e6b7b2d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAE8aR1cE2bku8tifUsS2q8OQYmiTjt\n8qvFi/MSLtenTCf1OXD3SOjp1JfwkJUOa3st\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "r = n - 2, x = n - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffff99def836146bc9b1b4d2282fffffffffffffffffffffffff99def836146bc9b1b4d2282e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "041eb1fd205aa94025909f17ad4572da996402d736629561bc7392ffd0de0b05ef86f9733ec9cac6e06d4910dc61980053",
+        "wx": "1eb1fd205aa94025909f17ad4572da996402d736629561bc",
+        "wy": "7392ffd0de0b05ef86f9733ec9cac6e06d4910dc61980053"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d030101033200041eb1fd205aa94025909f17ad4572da996402d736629561bc7392ffd0de0b05ef86f9733ec9cac6e06d4910dc61980053",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEHrH9IFqpQCWQnxetRXLamWQC1zZi\nlWG8c5L/0N4LBe+G+XM+ycrG4G1JENxhmABT\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "r = 7, x = n + 7 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000007ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "0492cd909f749db5e50364dfce4738d8849842322e03c8bcb2e1f2910803c24e7546da1aa3cd843169510180c0091ea422",
+        "wx": "92cd909f749db5e50364dfce4738d8849842322e03c8bcb2",
+        "wy": "e1f2910803c24e7546da1aa3cd843169510180c0091ea422"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d0301010332000492cd909f749db5e50364dfce4738d8849842322e03c8bcb2e1f2910803c24e7546da1aa3cd843169510180c0091ea422",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEks2Qn3SdteUDZN/ORzjYhJhCMi4D\nyLyy4fKRCAPCTnVG2hqjzYQxaVEBgMAJHqQi\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 226,
+          "comment": "r = 8, x = n + 7 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000008ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "041421c77f2f26977430ce32a52b55081bf3f202c10ec3d80eae5b5ca0223bd18027b725e1dfd760532b15975d6bf0e906",
+        "wx": "1421c77f2f26977430ce32a52b55081bf3f202c10ec3d80e",
+        "wy": "ae5b5ca0223bd18027b725e1dfd760532b15975d6bf0e906"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d030101033200041421c77f2f26977430ce32a52b55081bf3f202c10ec3d80eae5b5ca0223bd18027b725e1dfd760532b15975d6bf0e906",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEFCHHfy8ml3QwzjKlK1UIG/PyAsEO\nw9gOrltcoCI70YAntyXh39dgUysVl11r8OkG\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 227,
+          "comment": "r = p - n + 2, x = 2 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000662107c8eb94364e4b2dd7d0ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "04b5dc3dd655d93bc1b90fde515d46d150fdc75beac3084a8f95793b64e5280c4fc9ef37806d70f4d98a5fb50c4863f0f2",
+        "wx": "b5dc3dd655d93bc1b90fde515d46d150fdc75beac3084a8f",
+        "wy": "95793b64e5280c4fc9ef37806d70f4d98a5fb50c4863f0f2"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d03010103320004b5dc3dd655d93bc1b90fde515d46d150fdc75beac3084a8f95793b64e5280c4fc9ef37806d70f4d98a5fb50c4863f0f2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEtdw91lXZO8G5D95RXUbRUP3HW+rD\nCEqPlXk7ZOUoDE/J7zeAbXD02YpftQxIY/Dy\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 228,
+          "comment": "r = 2^192 - n + 2, x = 2 is invalid; r + n is too large to compare r + n with x, and overflows 2^192 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000662107c9eb94364e4b2dd7d1ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json
@@ -4081,7 +4081,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4111,7 +4111,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4141,7 +4141,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4171,7 +4171,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4201,7 +4201,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4231,7 +4231,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4261,7 +4261,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4291,7 +4291,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json
@@ -3724,7 +3724,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -3754,7 +3754,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -3784,7 +3784,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -3814,7 +3814,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -3844,7 +3844,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 190,
+  "numberOfTests": 195,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -3720,6 +3720,156 @@
           "msg": "0000000000000000000000000000000000000000",
           "sig": "00e52fb6cbddf6d21cb346b19229ebd5c548dfeac27011b8663ed06b7e0077051043ce80a21bfb944639e526c335bd7f07c79a038a1431cea5e4",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "041b69081da066af8e332b09989a0d72e05c775a0853751e57cb016c18610b52a00579880b7f4dbfccd3a96b9380f8196b1c2217ed0c6ccfc0",
+        "wx": "1b69081da066af8e332b09989a0d72e05c775a0853751e57cb016c18",
+        "wy": "610b52a00579880b7f4dbfccd3a96b9380f8196b1c2217ed0c6ccfc0"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a00041b69081da066af8e332b09989a0d72e05c775a0853751e57cb016c18610b52a00579880b7f4dbfccd3a96b9380f8196b1c2217ed0c6ccfc0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEG2kIHaBmr44zKwmYmg1y4Fx3WghTdR5X\nywFsGGELUqAFeYgLf02/zNOpa5OA+BlrHCIX7Qxsz8A=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 191,
+          "comment": "r = 2, x = 2 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000002010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "041da2ececcdcd1e121f98371f3fa198ba40a9ed0b50c95ed6e1186c0c4271af4c0b5a6ef668bee757bbe5a232bbab25e71ca272c63dec68c5",
+        "wx": "1da2ececcdcd1e121f98371f3fa198ba40a9ed0b50c95ed6e1186c0c",
+        "wy": "4271af4c0b5a6ef668bee757bbe5a232bbab25e71ca272c63dec68c5"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a00041da2ececcdcd1e121f98371f3fa198ba40a9ed0b50c95ed6e1186c0c4271af4c0b5a6ef668bee757bbe5a232bbab25e71ca272c63dec68c5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEHaLs7M3NHhIfmDcfP6GYukCp7QtQyV7W\n4RhsDEJxr0wLWm72aL7nV7vlojK7qyXnHKJyxj3saMU=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 192,
+          "comment": "r = 3, x = 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000003010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "041b69081da066af8e332b09989a0d72e05c775a0853751e57cb016c18610b52a00579880b7f4dbfccd3a96b9380f8196b1c2217ed0c6ccfc0",
+        "wx": "1b69081da066af8e332b09989a0d72e05c775a0853751e57cb016c18",
+        "wy": "610b52a00579880b7f4dbfccd3a96b9380f8196b1c2217ed0c6ccfc0"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a00041b69081da066af8e332b09989a0d72e05c775a0853751e57cb016c18610b52a00579880b7f4dbfccd3a96b9380f8196b1c2217ed0c6ccfc0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEG2kIHaBmr44zKwmYmg1y4Fx3WghTdR5X\nywFsGGELUqAFeYgLf02/zNOpa5OA+BlrHCIX7Qxsz8A=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 193,
+          "comment": "r = 2 + n, x = 2 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "010000000000000000000000000001dce8d2ec6184caf0a971769fb1f9010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "04bccfb3c0f6efa633d7c821a5ebe676eee502095e8b02f44867b16e818e7a3c40443df3a1361b61cc21106361c7112039a0a4ed3dbd91739d",
+        "wx": "bccfb3c0f6efa633d7c821a5ebe676eee502095e8b02f44867b16e81",
+        "wy": "8e7a3c40443df3a1361b61cc21106361c7112039a0a4ed3dbd91739d"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a0004bccfb3c0f6efa633d7c821a5ebe676eee502095e8b02f44867b16e818e7a3c40443df3a1361b61cc21106361c7112039a0a4ed3dbd91739d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEvM+zwPbvpjPXyCGl6+Z27uUCCV6LAvRI\nZ7FugY56PEBEPfOhNhthzCEQY2HHESA5oKTtPb2Rc50=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 194,
+          "comment": "r = p - 2, x = p - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56b010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "04192bd07a1b8ac5188261ccd07447bde73d096b679667fb28b204a04072942be7964f124c74cc5af2f9b65382a48b87a428e2c728d5cb9258",
+        "wx": "192bd07a1b8ac5188261ccd07447bde73d096b679667fb28b204a040",
+        "wy": "72942be7964f124c74cc5af2f9b65382a48b87a428e2c728d5cb9258"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a0004192bd07a1b8ac5188261ccd07447bde73d096b679667fb28b204a04072942be7964f124c74cc5af2f9b65382a48b87a428e2c728d5cb9258",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEGSvQehuKxRiCYczQdEe95z0Ja2eWZ/so\nsgSgQHKUK+eWTxJMdMxa8vm2U4Kki4ekKOLHKNXLklg=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 195,
+          "comment": "r = 2 + p, x = 2 is invalid; values only match mod p",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56f010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json
@@ -4018,7 +4018,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4048,7 +4048,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4078,7 +4078,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4108,7 +4108,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4138,7 +4138,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 219,
+  "numberOfTests": 224,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4014,6 +4014,156 @@
           "msg": "0000000000000000000000000000000000000000",
           "sig": "0031ec5c59558df32ce76d49cce64d63bf85ce4c28b20bc3b375fd4a9c00adf21d877868bc754eaa1db8847caa33ddd9ace6fdcea59c1e37e32d",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "04a911e33eff1e86c66a45ab4f3661cb2d893fb2a5e54da79fd5ccf2f75dca2bf4c6f8e56587fe7275f7389efba79ff9b579f169ea7b523a0c",
+        "wx": "a911e33eff1e86c66a45ab4f3661cb2d893fb2a5e54da79fd5ccf2f7",
+        "wy": "5dca2bf4c6f8e56587fe7275f7389efba79ff9b579f169ea7b523a0c"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a0004a911e33eff1e86c66a45ab4f3661cb2d893fb2a5e54da79fd5ccf2f75dca2bf4c6f8e56587fe7275f7389efba79ff9b579f169ea7b523a0c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEqRHjPv8ehsZqRatPNmHLLYk/sqXlTaef\n1czy913KK/TG+OVlh/5ydfc4nvunn/m1efFp6ntSOgw=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 220,
+          "comment": "r = 2, x = 2 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000002010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "0442e5f313c92730facbc6e2c2e86729bedb9e300d921c882f9e8df191c00ce253829a8e695af216471aaa5622e79d363fd96971fb152c1fbb",
+        "wx": "42e5f313c92730facbc6e2c2e86729bedb9e300d921c882f9e8df191",
+        "wy": "c00ce253829a8e695af216471aaa5622e79d363fd96971fb152c1fbb"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a000442e5f313c92730facbc6e2c2e86729bedb9e300d921c882f9e8df191c00ce253829a8e695af216471aaa5622e79d363fd96971fb152c1fbb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEQuXzE8knMPrLxuLC6GcpvtueMA2SHIgv\nno3xkcAM4lOCmo5pWvIWRxqqViLnnTY/2Wlx+xUsH7s=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "r = 3, x = 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000003010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "04a911e33eff1e86c66a45ab4f3661cb2d893fb2a5e54da79fd5ccf2f75dca2bf4c6f8e56587fe7275f7389efba79ff9b579f169ea7b523a0c",
+        "wx": "a911e33eff1e86c66a45ab4f3661cb2d893fb2a5e54da79fd5ccf2f7",
+        "wy": "5dca2bf4c6f8e56587fe7275f7389efba79ff9b579f169ea7b523a0c"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a0004a911e33eff1e86c66a45ab4f3661cb2d893fb2a5e54da79fd5ccf2f75dca2bf4c6f8e56587fe7275f7389efba79ff9b579f169ea7b523a0c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEqRHjPv8ehsZqRatPNmHLLYk/sqXlTaef\n1czy913KK/TG+OVlh/5ydfc4nvunn/m1efFp6ntSOgw=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r = 2 + n, x = 2 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "010000000000000000000000000001dce8d2ec6184caf0a971769fb1f9010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "04fd98a3a0013c4e419a9eba5573603cd1c5149c9aab98090a5e2acc3245eeaa262f1ce4b2e1f1cc52f8e6e4cf066cce70d4a8fe46ab0b8c7d",
+        "wx": "fd98a3a0013c4e419a9eba5573603cd1c5149c9aab98090a5e2acc32",
+        "wy": "45eeaa262f1ce4b2e1f1cc52f8e6e4cf066cce70d4a8fe46ab0b8c7d"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a0004fd98a3a0013c4e419a9eba5573603cd1c5149c9aab98090a5e2acc3245eeaa262f1ce4b2e1f1cc52f8e6e4cf066cce70d4a8fe46ab0b8c7d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAE/ZijoAE8TkGanrpVc2A80cUUnJqrmAkK\nXirMMkXuqiYvHOSy4fHMUvjm5M8GbM5w1Kj+RqsLjH0=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "r = p - 2, x = p - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56b010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "041da460c39781eb145324dcaccccbfce952eb9b631d4b46ea6afbc9dd548f82751b73c2f790afcdad85784a24f53a9459b1f1da1f3bf6c7c3",
+        "wx": "1da460c39781eb145324dcaccccbfce952eb9b631d4b46ea6afbc9dd",
+        "wy": "548f82751b73c2f790afcdad85784a24f53a9459b1f1da1f3bf6c7c3"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a00041da460c39781eb145324dcaccccbfce952eb9b631d4b46ea6afbc9dd548f82751b73c2f790afcdad85784a24f53a9459b1f1da1f3bf6c7c3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEHaRgw5eB6xRTJNyszMv86VLrm2MdS0bq\navvJ3VSPgnUbc8L3kK/NrYV4SiT1OpRZsfHaHzv2x8M=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "r = 2 + p, x = 2 is invalid; values only match mod p",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56f010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 219,
+  "numberOfTests": 227,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4212,6 +4212,246 @@
           "msg": "4d657373616765",
           "sig": "a4de0d931ddab90e667ebc0ad800ce49e971c60543abdc46cefff926550816170bd87593b9fb8ad5ed9ab4ddb12403ff6fe032252833bac4",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04da9971c869ce23030694138e95381868b3a5609507d6c796619357f4342c88a07164ff00ead6c178f0fdf06aec17ee4ccaa818e9273b3256",
+        "wx": "da9971c869ce23030694138e95381868b3a5609507d6c796619357f4",
+        "wy": "342c88a07164ff00ead6c178f0fdf06aec17ee4ccaa818e9273b3256"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004da9971c869ce23030694138e95381868b3a5609507d6c796619357f4342c88a07164ff00ead6c178f0fdf06aec17ee4ccaa818e9273b3256",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE2plxyGnOIwMGlBOOlTgYaLOlYJUH1seW\nYZNX9DQsiKBxZP8A6tbBePD98GrsF+5MyqgY6Sc7MlY=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 220,
+          "comment": "r = 3, x = 3 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04512997d74afa9f10ea167b4a817489fe72deb2c32a14bbf2724a9ccfb77f157044d957980c15384a4f821003a6920137d68608032298cec9",
+        "wx": "512997d74afa9f10ea167b4a817489fe72deb2c32a14bbf2724a9ccf",
+        "wy": "b77f157044d957980c15384a4f821003a6920137d68608032298cec9"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004512997d74afa9f10ea167b4a817489fe72deb2c32a14bbf2724a9ccfb77f157044d957980c15384a4f821003a6920137d68608032298cec9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEUSmX10r6nxDqFntKgXSJ/nLessMqFLvy\nckqcz7d/FXBE2VeYDBU4Sk+CEAOmkgE31oYIAyKYzsk=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "r = 4, x = 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000004ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04da9971c869ce23030694138e95381868b3a5609507d6c796619357f4342c88a07164ff00ead6c178f0fdf06aec17ee4ccaa818e9273b3256",
+        "wx": "da9971c869ce23030694138e95381868b3a5609507d6c796619357f4",
+        "wy": "342c88a07164ff00ead6c178f0fdf06aec17ee4ccaa818e9273b3256"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004da9971c869ce23030694138e95381868b3a5609507d6c796619357f4342c88a07164ff00ead6c178f0fdf06aec17ee4ccaa818e9273b3256",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE2plxyGnOIwMGlBOOlTgYaLOlYJUH1seW\nYZNX9DQsiKBxZP8A6tbBePD98GrsF+5MyqgY6Sc7MlY=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r = 3 + n, x = 3 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a40ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "047f5c34474f9e98cebe214e0032c88e4ca51bb67b18b93bb2eb8215eeda5d7e5d963503ded471c7984e99f934e3db0bfec60b01f98b41076d",
+        "wx": "7f5c34474f9e98cebe214e0032c88e4ca51bb67b18b93bb2eb8215ee",
+        "wy": "da5d7e5d963503ded471c7984e99f934e3db0bfec60b01f98b41076d"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00047f5c34474f9e98cebe214e0032c88e4ca51bb67b18b93bb2eb8215eeda5d7e5d963503ded471c7984e99f934e3db0bfec60b01f98b41076d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEf1w0R0+emM6+IU4AMsiOTKUbtnsYuTuy\n64IV7tpdfl2WNQPe1HHHmE6Z+TTj2wv+xgsB+YtBB20=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "r = n - 2, x = n - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3bffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "0427534656e4e23fa3dc4bd50d9f8efa9b3ff053d5c3d8c1156dd608181cbe1c97d482d9508dfc505cc3f95424212c60fd7c22d7761c748511",
+        "wx": "27534656e4e23fa3dc4bd50d9f8efa9b3ff053d5c3d8c1156dd60818",
+        "wy": "1cbe1c97d482d9508dfc505cc3f95424212c60fd7c22d7761c748511"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a000427534656e4e23fa3dc4bd50d9f8efa9b3ff053d5c3d8c1156dd608181cbe1c97d482d9508dfc505cc3f95424212c60fd7c22d7761c748511",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEJ1NGVuTiP6PcS9UNn476mz/wU9XD2MEV\nbdYIGBy+HJfUgtlQjfxQXMP5VCQhLGD9fCLXdhx0hRE=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "r = 3, x = n + 3 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "047b4f2604b1ac9d7e308dac85ad346151068b015208280c730792d0da7841db039c5f4218999a66a7281be030740e2c7d794a22caf706b585",
+        "wx": "7b4f2604b1ac9d7e308dac85ad346151068b015208280c730792d0da",
+        "wy": "7841db039c5f4218999a66a7281be030740e2c7d794a22caf706b585"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00047b4f2604b1ac9d7e308dac85ad346151068b015208280c730792d0da7841db039c5f4218999a66a7281be030740e2c7d794a22caf706b585",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEe08mBLGsnX4wjayFrTRhUQaLAVIIKAxz\nB5LQ2nhB2wOcX0IYmZpmpygb4DB0Dix9eUoiyvcGtYU=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "r = 4, x = n + 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000004ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "047f499315b54561350be2dfb3ce86b94e6f85735d8e0ff9b5d69369447daf545bbaaf3016fc9360c79b778cad40eaccb52a44904cb3d78d89",
+        "wx": "7f499315b54561350be2dfb3ce86b94e6f85735d8e0ff9b5d6936944",
+        "wy": "7daf545bbaaf3016fc9360c79b778cad40eaccb52a44904cb3d78d89"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00047f499315b54561350be2dfb3ce86b94e6f85735d8e0ff9b5d69369447daf545bbaaf3016fc9360c79b778cad40eaccb52a44904cb3d78d89",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEf0mTFbVFYTUL4t+zzoa5Tm+Fc12OD/m1\n1pNpRH2vVFu6rzAW/JNgx5t3jK1A6sy1KkSQTLPXjYk=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 226,
+          "comment": "r = p - n + 3, x = 3 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000e95c1f470fc1ec22d6baa3a3d5c7ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04c1fe4ad9b8da81070d4772a736821a5e9d343a36dc13fff49e9fe99e3a95acb5d2e8a2f58275ddf7ac02dbd9ab97b9d86a7afff59279913b",
+        "wx": "c1fe4ad9b8da81070d4772a736821a5e9d343a36dc13fff49e9fe99e",
+        "wy": "3a95acb5d2e8a2f58275ddf7ac02dbd9ab97b9d86a7afff59279913b"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004c1fe4ad9b8da81070d4772a736821a5e9d343a36dc13fff49e9fe99e3a95acb5d2e8a2f58275ddf7ac02dbd9ab97b9d86a7afff59279913b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEwf5K2bjagQcNR3KnNoIaXp00OjbcE//0\nnp/pnjqVrLXS6KL1gnXd96wC29mrl7nYanr/9ZJ5kTs=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 227,
+          "comment": "r = 2^224 - n + 3, x = 3 is invalid; r + n is too large to compare r + n with x, and overflows 2^224 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000e95d1f470fc1ec22d6baa3a3d5c6ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json
@@ -4216,7 +4216,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4246,7 +4246,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4276,7 +4276,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4306,7 +4306,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4336,7 +4336,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4366,7 +4366,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4396,7 +4396,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4426,7 +4426,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json
@@ -4510,7 +4510,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4540,7 +4540,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4570,7 +4570,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4600,7 +4600,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4630,7 +4630,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4660,7 +4660,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4690,7 +4690,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -4720,7 +4720,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 248,
+  "numberOfTests": 256,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4506,6 +4506,246 @@
           "msg": "4d657373616765",
           "sig": "1526eb2f657ebea9af4ca184b975c02372c88e24e835f3f5774c0e121f1ecce38ee52372cb201907794de17b6d6c1afa13c316c51cb07bc7",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04f43eeb550591547d6a6479726b72be181d4ea26dea5516ae1c0b0ab3e127deeb94536c67793ac172ba31f3a6f81efbbf2ab3d7868d0cc9f9",
+        "wx": "f43eeb550591547d6a6479726b72be181d4ea26dea5516ae1c0b0ab3",
+        "wy": "e127deeb94536c67793ac172ba31f3a6f81efbbf2ab3d7868d0cc9f9"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004f43eeb550591547d6a6479726b72be181d4ea26dea5516ae1c0b0ab3e127deeb94536c67793ac172ba31f3a6f81efbbf2ab3d7868d0cc9f9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE9D7rVQWRVH1qZHlya3K+GB1Oom3qVRau\nHAsKs+En3uuUU2xneTrBcrox86b4Hvu/KrPXho0Myfk=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 249,
+          "comment": "r = 3, x = 3 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04d46c2c988ac6b6a88213097a51ffbe400829cde78078403c3164480bf3e5c7ec0b798c6b16cc1c9733fc517b1e55f591a5ffef90a8beb80a",
+        "wx": "d46c2c988ac6b6a88213097a51ffbe400829cde78078403c3164480b",
+        "wy": "f3e5c7ec0b798c6b16cc1c9733fc517b1e55f591a5ffef90a8beb80a"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004d46c2c988ac6b6a88213097a51ffbe400829cde78078403c3164480bf3e5c7ec0b798c6b16cc1c9733fc517b1e55f591a5ffef90a8beb80a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE1GwsmIrGtqiCEwl6Uf++QAgpzeeAeEA8\nMWRIC/Plx+wLeYxrFswclzP8UXseVfWRpf/vkKi+uAo=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 250,
+          "comment": "r = 4, x = 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000004ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04f43eeb550591547d6a6479726b72be181d4ea26dea5516ae1c0b0ab3e127deeb94536c67793ac172ba31f3a6f81efbbf2ab3d7868d0cc9f9",
+        "wx": "f43eeb550591547d6a6479726b72be181d4ea26dea5516ae1c0b0ab3",
+        "wy": "e127deeb94536c67793ac172ba31f3a6f81efbbf2ab3d7868d0cc9f9"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004f43eeb550591547d6a6479726b72be181d4ea26dea5516ae1c0b0ab3e127deeb94536c67793ac172ba31f3a6f81efbbf2ab3d7868d0cc9f9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE9D7rVQWRVH1qZHlya3K+GB1Oom3qVRau\nHAsKs+En3uuUU2xneTrBcrox86b4Hvu/KrPXho0Myfk=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 251,
+          "comment": "r = 3 + n, x = 3 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a40ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04404a7defdf659496eaab27a8cd1c2e06916235a966afe9a48c5fa8247b0d2b5d180d41433b5067e6ef4fe2f021f0802d130833ec0a13431e",
+        "wx": "404a7defdf659496eaab27a8cd1c2e06916235a966afe9a48c5fa824",
+        "wy": "7b0d2b5d180d41433b5067e6ef4fe2f021f0802d130833ec0a13431e"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004404a7defdf659496eaab27a8cd1c2e06916235a966afe9a48c5fa8247b0d2b5d180d41433b5067e6ef4fe2f021f0802d130833ec0a13431e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEQEp9799llJbqqyeozRwuBpFiNalmr+mk\njF+oJHsNK10YDUFDO1Bn5u9P4vAh8IAtEwgz7AoTQx4=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 252,
+          "comment": "r = n - 2, x = n - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3bffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04d7afcc97eefcf32becf100cf967588c68f9c149fa18344ac08e245b43b853f6c6d955587d9ac080c8f10bf355f9992a0103a27aa30dac7e8",
+        "wx": "d7afcc97eefcf32becf100cf967588c68f9c149fa18344ac08e245b4",
+        "wy": "3b853f6c6d955587d9ac080c8f10bf355f9992a0103a27aa30dac7e8"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004d7afcc97eefcf32becf100cf967588c68f9c149fa18344ac08e245b43b853f6c6d955587d9ac080c8f10bf355f9992a0103a27aa30dac7e8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE16/Ml+788yvs8QDPlnWIxo+cFJ+hg0Ss\nCOJFtDuFP2xtlVWH2awIDI8QvzVfmZKgEDonqjDax+g=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 253,
+          "comment": "r = 3, x = n + 3 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04624ed81d4901bcd1c4211d3763344569c4fda5247910f57da613382a460be585f9346719de51a63884e3a10967a054e938f96782da941159",
+        "wx": "624ed81d4901bcd1c4211d3763344569c4fda5247910f57da613382a",
+        "wy": "460be585f9346719de51a63884e3a10967a054e938f96782da941159"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004624ed81d4901bcd1c4211d3763344569c4fda5247910f57da613382a460be585f9346719de51a63884e3a10967a054e938f96782da941159",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEYk7YHUkBvNHEIR03YzRFacT9pSR5EPV9\nphM4KkYL5YX5NGcZ3lGmOITjoQlnoFTpOPlngtqUEVk=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 254,
+          "comment": "r = 4, x = n + 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000004ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04ef9169ef146a19c9a7220c6f25f597e7345e25fa1267712b9a20e30d454b19373a67ad81ca37ba8de9a96e881896df7160ba740f4c7373b9",
+        "wx": "ef9169ef146a19c9a7220c6f25f597e7345e25fa1267712b9a20e30d",
+        "wy": "454b19373a67ad81ca37ba8de9a96e881896df7160ba740f4c7373b9"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004ef9169ef146a19c9a7220c6f25f597e7345e25fa1267712b9a20e30d454b19373a67ad81ca37ba8de9a96e881896df7160ba740f4c7373b9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE75Fp7xRqGcmnIgxvJfWX5zReJfoSZ3Er\nmiDjDUVLGTc6Z62Byje6jempbogYlt9xYLp0D0xzc7k=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 255,
+          "comment": "r = p - n + 3, x = 3 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000e95c1f470fc1ec22d6baa3a3d5c7ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04b6f15017406f16ebb6df8976aabb40f835f2cec1da165703aacaba40156f85ccc18f71c435ead14fcdceccff705be965f38049dcc2528867",
+        "wx": "b6f15017406f16ebb6df8976aabb40f835f2cec1da165703aacaba40",
+        "wy": "156f85ccc18f71c435ead14fcdceccff705be965f38049dcc2528867"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004b6f15017406f16ebb6df8976aabb40f835f2cec1da165703aacaba40156f85ccc18f71c435ead14fcdceccff705be965f38049dcc2528867",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEtvFQF0BvFuu234l2qrtA+DXyzsHaFlcD\nqsq6QBVvhczBj3HENerRT83OzP9wW+ll84BJ3MJSiGc=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 256,
+          "comment": "r = 2^224 - n + 3, x = 3 is invalid; r + n is too large to compare r + n with x, and overflows 2^224 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000e95d1f470fc1ec22d6baa3a3d5c6ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json
@@ -5200,7 +5200,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5230,7 +5230,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5260,7 +5260,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5290,7 +5290,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5320,7 +5320,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5350,7 +5350,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5380,7 +5380,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5410,7 +5410,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 317,
+  "numberOfTests": 325,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5196,6 +5196,246 @@
           "msg": "4d657373616765",
           "sig": "0eb9dc5d67bb0d4009544f8654977907dfe770e7fae4571d31d7b4faab5cda53e868bff5198be4be3681b186cb0c1396d272c71f093f8b12",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "048f44063cebc3c836bb284533ad46da8ac1431e6cf013db71d0a2dca714196c1b5c002beafb21c6a39d792b11ad0f56b97cbf8452a3525955",
+        "wx": "8f44063cebc3c836bb284533ad46da8ac1431e6cf013db71d0a2dca7",
+        "wy": "14196c1b5c002beafb21c6a39d792b11ad0f56b97cbf8452a3525955"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00048f44063cebc3c836bb284533ad46da8ac1431e6cf013db71d0a2dca714196c1b5c002beafb21c6a39d792b11ad0f56b97cbf8452a3525955",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEj0QGPOvDyDa7KEUzrUbaisFDHmzwE9tx\n0KLcpxQZbBtcACvq+yHGo515KxGtD1a5fL+EUqNSWVU=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 318,
+          "comment": "r = 3, x = 3 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "0486c1e2f48a6d5b6d34faa969e7f84b3fbc6759c0416854701476f15adcb7cac10453dd9a4f0dc4810f310580e7a4890139d29cf5c48f5663",
+        "wx": "86c1e2f48a6d5b6d34faa969e7f84b3fbc6759c0416854701476f15a",
+        "wy": "dcb7cac10453dd9a4f0dc4810f310580e7a4890139d29cf5c48f5663"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a000486c1e2f48a6d5b6d34faa969e7f84b3fbc6759c0416854701476f15adcb7cac10453dd9a4f0dc4810f310580e7a4890139d29cf5c48f5663",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEhsHi9IptW200+qlp5/hLP7xnWcBBaFRw\nFHbxWty3ysEEU92aTw3EgQ8xBYDnpIkBOdKc9cSPVmM=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 319,
+          "comment": "r = 4, x = 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000004ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "048f44063cebc3c836bb284533ad46da8ac1431e6cf013db71d0a2dca714196c1b5c002beafb21c6a39d792b11ad0f56b97cbf8452a3525955",
+        "wx": "8f44063cebc3c836bb284533ad46da8ac1431e6cf013db71d0a2dca7",
+        "wy": "14196c1b5c002beafb21c6a39d792b11ad0f56b97cbf8452a3525955"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00048f44063cebc3c836bb284533ad46da8ac1431e6cf013db71d0a2dca714196c1b5c002beafb21c6a39d792b11ad0f56b97cbf8452a3525955",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEj0QGPOvDyDa7KEUzrUbaisFDHmzwE9tx\n0KLcpxQZbBtcACvq+yHGo515KxGtD1a5fL+EUqNSWVU=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 320,
+          "comment": "r = 3 + n, x = 3 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a40ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "048f3a12006360a09eb1a93b91fff93a082d21edbfe0da868997087b5c361c6e382df83cede8febcd26b0f209354f4341a6d4b99ebf16193d6",
+        "wx": "8f3a12006360a09eb1a93b91fff93a082d21edbfe0da868997087b5c",
+        "wy": "361c6e382df83cede8febcd26b0f209354f4341a6d4b99ebf16193d6"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00048f3a12006360a09eb1a93b91fff93a082d21edbfe0da868997087b5c361c6e382df83cede8febcd26b0f209354f4341a6d4b99ebf16193d6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEjzoSAGNgoJ6xqTuR//k6CC0h7b/g2oaJ\nlwh7XDYcbjgt+Dzt6P680msPIJNU9DQabUuZ6/Fhk9Y=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 321,
+          "comment": "r = n - 2, x = n - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3bffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04d0524a681c81fdfed6395cff13b637436dadd53dec966a2ef996644613a40dac30ed26f98c4b555ae9ae0876bfe5dca05cb7548a4560a367",
+        "wx": "d0524a681c81fdfed6395cff13b637436dadd53dec966a2ef9966446",
+        "wy": "13a40dac30ed26f98c4b555ae9ae0876bfe5dca05cb7548a4560a367"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004d0524a681c81fdfed6395cff13b637436dadd53dec966a2ef996644613a40dac30ed26f98c4b555ae9ae0876bfe5dca05cb7548a4560a367",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE0FJKaByB/f7WOVz/E7Y3Q22t1T3slmou\n+ZZkRhOkDaww7Sb5jEtVWumuCHa/5dygXLdUikVgo2c=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 322,
+          "comment": "r = 3, x = n + 3 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04aa5dd18b6ab4368e4957d22de84affc74d29dcfe06876a15a50dfc0720dc2e90143ce9b0fcd8c92e0e4d669836b38dda00922ceb86d1afdd",
+        "wx": "aa5dd18b6ab4368e4957d22de84affc74d29dcfe06876a15a50dfc07",
+        "wy": "20dc2e90143ce9b0fcd8c92e0e4d669836b38dda00922ceb86d1afdd"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004aa5dd18b6ab4368e4957d22de84affc74d29dcfe06876a15a50dfc0720dc2e90143ce9b0fcd8c92e0e4d669836b38dda00922ceb86d1afdd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEql3Ri2q0No5JV9It6Er/x00p3P4Gh2oV\npQ38ByDcLpAUPOmw/NjJLg5NZpg2s43aAJIs64bRr90=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 323,
+          "comment": "r = 4, x = n + 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000004ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04d44b21e5c37db247828689f0489572e0cce7c589603827c5dbcbe3e807cb43eacd35e98abd76a7eb05a5f1fb08b570ec6753828732dbdcb9",
+        "wx": "d44b21e5c37db247828689f0489572e0cce7c589603827c5dbcbe3e8",
+        "wy": "07cb43eacd35e98abd76a7eb05a5f1fb08b570ec6753828732dbdcb9"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004d44b21e5c37db247828689f0489572e0cce7c589603827c5dbcbe3e807cb43eacd35e98abd76a7eb05a5f1fb08b570ec6753828732dbdcb9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE1Esh5cN9skeChonwSJVy4MznxYlgOCfF\n28vj6AfLQ+rNNemKvXan6wWl8fsItXDsZ1OChzLb3Lk=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 324,
+          "comment": "r = p - n + 3, x = 3 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000e95c1f470fc1ec22d6baa3a3d5c7ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "042cab4e44840e414523640699a3df6bf5eea6fe7522180b7262f60a37d3693863a15896fa31d8421a7eb42a9f567b24211de2980d5edeb94f",
+        "wx": "2cab4e44840e414523640699a3df6bf5eea6fe7522180b7262f60a37",
+        "wy": "d3693863a15896fa31d8421a7eb42a9f567b24211de2980d5edeb94f"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00042cab4e44840e414523640699a3df6bf5eea6fe7522180b7262f60a37d3693863a15896fa31d8421a7eb42a9f567b24211de2980d5edeb94f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAELKtORIQOQUUjZAaZo99r9e6m/nUiGAty\nYvYKN9NpOGOhWJb6MdhCGn60Kp9WeyQhHeKYDV7euU8=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 325,
+          "comment": "r = 2^224 - n + 3, x = 3 is invalid; r + n is too large to compare r + n with x, and overflows 2^224 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000e95d1f470fc1ec22d6baa3a3d5c6ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json
@@ -5217,7 +5217,7 @@
       }
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5247,7 +5247,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5277,7 +5277,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5307,7 +5307,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5337,7 +5337,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5367,7 +5367,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5397,7 +5397,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5427,7 +5427,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 242,
+  "numberOfTests": 250,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5215,6 +5215,246 @@
         "y": "5lnTTk3zjZ6MnqrfujZhLHaRlb6Gx3qsPzbni1OGgPs",
         "kid": "none"
       }
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b9520873424b8b7099104a5a0eb1acac48e189719971b9131bf9ca8c25f436c92ff805b36e40d651ffb7573edd9b4998c2f2fe39891baf3d83670e9242c0d4ad",
+        "wx": "b9520873424b8b7099104a5a0eb1acac48e189719971b9131bf9ca8c25f436c9",
+        "wy": "2ff805b36e40d651ffb7573edd9b4998c2f2fe39891baf3d83670e9242c0d4ad"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b9520873424b8b7099104a5a0eb1acac48e189719971b9131bf9ca8c25f436c92ff805b36e40d651ffb7573edd9b4998c2f2fe39891baf3d83670e9242c0d4ad",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuVIIc0JLi3CZEEpaDrGsrEjhiXGZcbkT\nG/nKjCX0Nskv+AWzbkDWUf+3Vz7dm0mYwvL+OYkbrz2DZw6SQsDUrQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 243,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0415f0573de014498f1ee256977a7a21ce5663888d223f841b24495d599a2bd2dfaec48b59fbc8ce644a8d0e5feae572a9dce6d94ab5c1cc04ca5b3d82591aa640",
+        "wx": "15f0573de014498f1ee256977a7a21ce5663888d223f841b24495d599a2bd2df",
+        "wy": "aec48b59fbc8ce644a8d0e5feae572a9dce6d94ab5c1cc04ca5b3d82591aa640"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000415f0573de014498f1ee256977a7a21ce5663888d223f841b24495d599a2bd2dfaec48b59fbc8ce644a8d0e5feae572a9dce6d94ab5c1cc04ca5b3d82591aa640",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFfBXPeAUSY8e4laXenohzlZjiI0iP4Qb\nJEldWZor0t+uxItZ+8jOZEqNDl/q5XKp3ObZSrXBzATKWz2CWRqmQA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 244,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b9520873424b8b7099104a5a0eb1acac48e189719971b9131bf9ca8c25f436c92ff805b36e40d651ffb7573edd9b4998c2f2fe39891baf3d83670e9242c0d4ad",
+        "wx": "b9520873424b8b7099104a5a0eb1acac48e189719971b9131bf9ca8c25f436c9",
+        "wy": "2ff805b36e40d651ffb7573edd9b4998c2f2fe39891baf3d83670e9242c0d4ad"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b9520873424b8b7099104a5a0eb1acac48e189719971b9131bf9ca8c25f436c92ff805b36e40d651ffb7573edd9b4998c2f2fe39891baf3d83670e9242c0d4ad",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuVIIc0JLi3CZEEpaDrGsrEjhiXGZcbkT\nG/nKjCX0Nskv+AWzbkDWUf+3Vz7dm0mYwvL+OYkbrz2DZw6SQsDUrQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 245,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b0fa79bc98baff15d39cf88f8343aea79c0df7f4265361e97a2428b355e460d78fa95eec6e2e02d72c259d20e0ca273468e83f36cee40eed76934c57354ca6a3",
+        "wx": "b0fa79bc98baff15d39cf88f8343aea79c0df7f4265361e97a2428b355e460d7",
+        "wy": "8fa95eec6e2e02d72c259d20e0ca273468e83f36cee40eed76934c57354ca6a3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b0fa79bc98baff15d39cf88f8343aea79c0df7f4265361e97a2428b355e460d78fa95eec6e2e02d72c259d20e0ca273468e83f36cee40eed76934c57354ca6a3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsPp5vJi6/xXTnPiPg0Oup5wN9/QmU2Hp\neiQos1XkYNePqV7sbi4C1ywlnSDgyic0aOg/Ns7kDu12k0xXNUymow==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 246,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413efffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0449be80da98fb7ea4165f898c36c696c50bd9da6485038c6cbda36d82dad41cfd64613a0e2c7224a85e29f774726b434e969db2d4765eafdf3c36004b7202ff3f",
+        "wx": "49be80da98fb7ea4165f898c36c696c50bd9da6485038c6cbda36d82dad41cfd",
+        "wy": "64613a0e2c7224a85e29f774726b434e969db2d4765eafdf3c36004b7202ff3f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000449be80da98fb7ea4165f898c36c696c50bd9da6485038c6cbda36d82dad41cfd64613a0e2c7224a85e29f774726b434e969db2d4765eafdf3c36004b7202ff3f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESb6A2pj7fqQWX4mMNsaWxQvZ2mSFA4xs\nvaNtgtrUHP1kYToOLHIkqF4p93Rya0NOlp2y1HZer988NgBLcgL/Pw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 247,
+          "comment": "r = 2, x = n + 2 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04682cb28dfdcb3e72f200307a6146151338a7143914439c046980c805f0e9d12681d073c1b1dd129e3627d75d8a231a80342149abfcdd8ab9b5775fde215ab9a0",
+        "wx": "682cb28dfdcb3e72f200307a6146151338a7143914439c046980c805f0e9d126",
+        "wy": "81d073c1b1dd129e3627d75d8a231a80342149abfcdd8ab9b5775fde215ab9a0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004682cb28dfdcb3e72f200307a6146151338a7143914439c046980c805f0e9d12681d073c1b1dd129e3627d75d8a231a80342149abfcdd8ab9b5775fde215ab9a0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaCyyjf3LPnLyADB6YUYVEzinFDkUQ5wE\naYDIBfDp0SaB0HPBsd0SnjYn112KIxqANCFJq/zdirm1d1/eIVq5oA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 248,
+          "comment": "r = 3, x = n + 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0493c9400c1fc5ed1aefb9f463e7650ae09778313fc188e84564e711a7b84588867e72afd2a40cd15f7b92c6ce7ea95dc7327e54a5309312f43628273534a86ae9",
+        "wx": "93c9400c1fc5ed1aefb9f463e7650ae09778313fc188e84564e711a7b8458886",
+        "wy": "7e72afd2a40cd15f7b92c6ce7ea95dc7327e54a5309312f43628273534a86ae9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000493c9400c1fc5ed1aefb9f463e7650ae09778313fc188e84564e711a7b84588867e72afd2a40cd15f7b92c6ce7ea95dc7327e54a5309312f43628273534a86ae9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk8lADB/F7RrvufRj52UK4Jd4MT/BiOhF\nZOcRp7hFiIZ+cq/SpAzRX3uSxs5+qV3HMn5UpTCTEvQ2KCc1NKhq6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 249,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1722fc9baeffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e7ed253ac1810f174a83443264f57efbc090bb478a1fac8296f637b4694502a86f48fbb04579fa9e3bbce880915211b24de7f21511e3acf63ea49d737fc6459d",
+        "wx": "e7ed253ac1810f174a83443264f57efbc090bb478a1fac8296f637b4694502a8",
+        "wy": "6f48fbb04579fa9e3bbce880915211b24de7f21511e3acf63ea49d737fc6459d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e7ed253ac1810f174a83443264f57efbc090bb478a1fac8296f637b4694502a86f48fbb04579fa9e3bbce880915211b24de7f21511e3acf63ea49d737fc6459d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5+0lOsGBDxdKg0QyZPV++8CQu0eKH6yC\nlvY3tGlFAqhvSPuwRXn6nju86ICRUhGyTefyFRHjrPY+pJ1zf8ZFnQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 250,
+          "comment": "r = 2^256 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1732fc9bec0fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
     }
   ]
 }

--- a/testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 312,
+  "numberOfTests": 320,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5919,6 +5919,246 @@
         "y": "5lnTTk3zjZ6MnqrfujZhLHaRlb6Gx3qsPzbni1OGgPs",
         "kid": "none"
       }
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+        "wx": "2df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5b",
+        "wy": "aa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELfOElG+CrhPOJTCU9AYOSV/JfUjpTSxs\nHw0SLgcWG1uqNna+Bp5er1Vs8FLmpp5DD0ut7Iz7qMJ35Wl/aQb79g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 313,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0497047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db19830546618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066",
+        "wx": "97047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db198305",
+        "wy": "46618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000497047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db19830546618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAElwR7PbONaGbrFvQubaE6I1NTxrbVX/9U\n8vhPhNsZgwVGYY+M93jhHcoJVJ45fy8FTUCYsoxDfnPrKZAvA4owZg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 314,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+        "wx": "2df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5b",
+        "wy": "aa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELfOElG+CrhPOJTCU9AYOSV/JfUjpTSxs\nHw0SLgcWG1uqNna+Bp5er1Vs8FLmpp5DD0ut7Iz7qMJ35Wl/aQb79g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 315,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a9941c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1",
+        "wx": "bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a99",
+        "wy": "41c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a9941c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEu9JNFP5aKjJMYcaYRajeoiphwaR7HYpM\nAXFEuKxQeplBx+fD3nSmWvp9LU0QiS9nz3hNQGpYfmy5+Vghu77roQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 316,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413efffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532db3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae",
+        "wx": "d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532d",
+        "wy": "b3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532db3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE18Qr2rXTjWQ5/mRFl0W0+xctbmoORhhD\nmu6rSJ/2Uy2z0UtWULmx6CPRi/3om1XQe1z+FmgVo+Tai7NPQFVFrg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 317,
+          "comment": "r = 2, x = n + 2 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da",
+        "wx": "4fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a",
+        "wy": "256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAET+TMmNZlpJz9oyvqjei9PmrYY5Ec0HfA\ncr4rNbSHlGolb5y2FPqbyzRa6HJqn2GKc31FzOlqdmvw+2EMIC1W2g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 318,
+          "comment": "r = 3, x = n + 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862",
+        "wx": "f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c",
+        "wy": "0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE89AQzJkyDLw5vukQGqe6fo7fTjLqgRDp\n8kQtakmut4wK4UTLgUZUFVUEOHKSLfoU6P9rT5mDza55srzpWO+IYg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 319,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1722fc9baeffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d",
+        "wx": "a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc",
+        "wy": "74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpiRVg+E9I8nMAInJni4gJ2bqM3lkXBR2\nLPAphzsJnfx06ZQtqfGDJ9Wx+8yqlYmS0wYq5GAtDtc2qkuHKR7xDQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 320,
+          "comment": "r = 2^256 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1732fc9bec0fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
     }
   ]
 }

--- a/testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
@@ -5921,7 +5921,7 @@
       }
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5951,7 +5951,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5981,7 +5981,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6011,7 +6011,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6041,7 +6041,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6071,7 +6071,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6101,7 +6101,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6131,7 +6131,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 252,
+  "numberOfTests": 260,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5429,6 +5429,246 @@
         "y": "_____uytRLbwXRWzMUZUnCKXtSKl7thDDP9ZZ1jmxD0",
         "kid": "none"
       }
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64",
+        "wx": "264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9",
+        "wy": "cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJk15ag2rmzdtNO6m/il93hx7c+U5\nRLyWyPHopoULtsnPUwgCDu1GDGSd2uYdTvi7eZWBE/EGvvr08Yh20SpeZA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 253,
+          "comment": "r = 5, x = 5 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000005ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04add76677e54a92e79bbee36a70e1754838273ec4b39295e4018a587290a7fc73f240d625642c943e610d80d953c5c6b8a12760a624ba3b90a0b7902755e1ae79",
+        "wx": "add76677e54a92e79bbee36a70e1754838273ec4b39295e4018a587290a7fc73",
+        "wy": "f240d625642c943e610d80d953c5c6b8a12760a624ba3b90a0b7902755e1ae79"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004add76677e54a92e79bbee36a70e1754838273ec4b39295e4018a587290a7fc73f240d625642c943e610d80d953c5c6b8a12760a624ba3b90a0b7902755e1ae79",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErddmd+VKkuebvuNqcOF1SDgnPsSz\nkpXkAYpYcpCn/HPyQNYlZCyUPmENgNlTxca4oSdgpiS6O5Cgt5AnVeGueQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 254,
+          "comment": "r = 6, x = 5 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000006ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64",
+        "wx": "264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9",
+        "wy": "cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004264d796a0dab9b376d34eea6fe297dde1c7b73e53944bc96c8f1e8a6850bb6c9cf5308020eed460c649ddae61d4ef8bb79958113f106befaf4f18876d12a5e64",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJk15ag2rmzdtNO6m/il93hx7c+U5\nRLyWyPHopoULtsnPUwgCDu1GDGSd2uYdTvi7eZWBE/EGvvr08Yh20SpeZA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 255,
+          "comment": "r = 5 + n, x = 5 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632556ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04e7e49dd82812432744fefe723f7f69663214ad1b85c02b2650b4ca0354743a325223c51c415f457aec69cb019bbe3d27585b38f8b79c39dfea6c27c2f0d8146a",
+        "wx": "e7e49dd82812432744fefe723f7f69663214ad1b85c02b2650b4ca0354743a32",
+        "wy": "5223c51c415f457aec69cb019bbe3d27585b38f8b79c39dfea6c27c2f0d8146a"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004e7e49dd82812432744fefe723f7f69663214ad1b85c02b2650b4ca0354743a325223c51c415f457aec69cb019bbe3d27585b38f8b79c39dfea6c27c2f0d8146a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5+Sd2CgSQydE/v5yP39pZjIUrRuF\nwCsmULTKA1R0OjJSI8UcQV9FeuxpywGbvj0nWFs4+LecOd/qbCfC8NgUag==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 256,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254effffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ce24c99032d52ac6ead23c0ae3ec68ef41e51a281fd457808c83136d7dcce90e8f7a154b551e9f39c59279357aa491b2a62bdebc2bb78613883fc72936c057e0",
+        "wx": "ce24c99032d52ac6ead23c0ae3ec68ef41e51a281fd457808c83136d7dcce90e",
+        "wy": "8f7a154b551e9f39c59279357aa491b2a62bdebc2bb78613883fc72936c057e0"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ce24c99032d52ac6ead23c0ae3ec68ef41e51a281fd457808c83136d7dcce90e8f7a154b551e9f39c59279357aa491b2a62bdebc2bb78613883fc72936c057e0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEziTJkDLVKsbq0jwK4+xo70HlGigf\n1FeAjIMTbX3M6Q6PehVLVR6fOcWSeTV6pJGypivevCu3hhOIP8cpNsBX4A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 257,
+          "comment": "r = 3, x = n + 3 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000003ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04c981c75ddfd3910387eb147098fe5658c43aaaa34c681cd6d514b6ad5b6baa6d14fbddb53a6e6db18e90602bc60f2e736d625765f7f2cca4be76f4eeccf12c18",
+        "wx": "c981c75ddfd3910387eb147098fe5658c43aaaa34c681cd6d514b6ad5b6baa6d",
+        "wy": "14fbddb53a6e6db18e90602bc60f2e736d625765f7f2cca4be76f4eeccf12c18"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004c981c75ddfd3910387eb147098fe5658c43aaaa34c681cd6d514b6ad5b6baa6d14fbddb53a6e6db18e90602bc60f2e736d625765f7f2cca4be76f4eeccf12c18",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyYHHXd/TkQOH6xRwmP5WWMQ6qqNM\naBzW1RS2rVtrqm0U+921Om5tsY6QYCvGDy5zbWJXZffyzKS+dvTuzPEsGA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 258,
+          "comment": "r = 4, x = n + 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000004ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040ec505bc19b14a43e05678cccf07a443d3e871a2e19b68a4da91859a0650f32477300e4f64e9982d94dff5d294428bb37cc9be66117cae9c389d2d495f68b987",
+        "wx": "0ec505bc19b14a43e05678cccf07a443d3e871a2e19b68a4da91859a0650f324",
+        "wy": "77300e4f64e9982d94dff5d294428bb37cc9be66117cae9c389d2d495f68b987"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040ec505bc19b14a43e05678cccf07a443d3e871a2e19b68a4da91859a0650f32477300e4f64e9982d94dff5d294428bb37cc9be66117cae9c389d2d495f68b987",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDsUFvBmxSkPgVnjMzwekQ9PocaLh\nm2ik2pGFmgZQ8yR3MA5PZOmYLZTf9dKUQouzfMm+ZhF8rpw4nS1JX2i5hw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 259,
+          "comment": "r = p - n + 5, x = 5 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000004319055358e8617b0c46353d039cdab3ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04d42ce21e730f3d2a84e949828574b4dceeb77d4f89556735f34fba03028ee3ed32daf8bfd3f0a7a0821170840f4e032056722386b35d9bdd4f4f450696f4fb52",
+        "wx": "d42ce21e730f3d2a84e949828574b4dceeb77d4f89556735f34fba03028ee3ed",
+        "wy": "32daf8bfd3f0a7a0821170840f4e032056722386b35d9bdd4f4f450696f4fb52"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004d42ce21e730f3d2a84e949828574b4dceeb77d4f89556735f34fba03028ee3ed32daf8bfd3f0a7a0821170840f4e032056722386b35d9bdd4f4f450696f4fb52",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1CziHnMPPSqE6UmChXS03O63fU+J\nVWc180+6AwKO4+0y2vi/0/CnoIIRcIQPTgMgVnIjhrNdm91PT0UGlvT7Ug==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 260,
+          "comment": "r = 2^256 - n + 5, x = 5 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000ffffffff00000000000000004319055258e8617b0c46353d039cdab4ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
     }
   ]
 }

--- a/testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json
@@ -5431,7 +5431,7 @@
       }
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5461,7 +5461,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5491,7 +5491,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5521,7 +5521,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5551,7 +5551,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5581,7 +5581,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5611,7 +5611,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5641,7 +5641,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json
@@ -6135,7 +6135,7 @@
       }
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6165,7 +6165,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6195,7 +6195,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6225,7 +6225,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6255,7 +6255,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6285,7 +6285,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6315,7 +6315,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6345,7 +6345,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 322,
+  "numberOfTests": 330,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -6133,6 +6133,246 @@
         "y": "_____uytRLbwXRWzMUZUnCKXtSKl7thDDP9ZZ1jmxD0",
         "kid": "none"
       }
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0486bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe",
+        "wx": "86bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981",
+        "wy": "cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000486bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhr3OOpLFZHD7pQLW5pcTPa/4haDv\nTQvQVgM180DCCYHLxgiSmtvlAo452HZvSyyGhdl6L+DtKP7eT5j7D3cMvg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 323,
+          "comment": "r = 5, x = 5 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000005ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "048936f32d1479a4e39b857e082d34f8a6c33a0a0d6fe21f156419b484b3ebedf8f9869ef53c92a87fe002a14668b307f8a7a020e7ec2fb36e76d53447faf02b12",
+        "wx": "8936f32d1479a4e39b857e082d34f8a6c33a0a0d6fe21f156419b484b3ebedf8",
+        "wy": "f9869ef53c92a87fe002a14668b307f8a7a020e7ec2fb36e76d53447faf02b12"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200048936f32d1479a4e39b857e082d34f8a6c33a0a0d6fe21f156419b484b3ebedf8f9869ef53c92a87fe002a14668b307f8a7a020e7ec2fb36e76d53447faf02b12",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiTbzLRR5pOObhX4ILTT4psM6Cg1v\n4h8VZBm0hLPr7fj5hp71PJKof+ACoUZoswf4p6Ag5+wvs2521TRH+vArEg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 324,
+          "comment": "r = 6, x = 5 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000006ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0486bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe",
+        "wx": "86bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981",
+        "wy": "cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000486bdce3a92c56470fba502d6e697133daff885a0ef4d0bd0560335f340c20981cbc608929adbe5028e39d8766f4b2c8685d97a2fe0ed28fede4f98fb0f770cbe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhr3OOpLFZHD7pQLW5pcTPa/4haDv\nTQvQVgM180DCCYHLxgiSmtvlAo452HZvSyyGhdl6L+DtKP7eT5j7D3cMvg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 325,
+          "comment": "r = 5 + n, x = 5 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632556ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04fbfa53e8658bce3e1325b118d39b046aa55d6775cbf42dd4fd9dada7b42b5ec2c848f72bc2f7049196d56b6690472f4d23569a0648510cb8feec9d34f4f7f226",
+        "wx": "fbfa53e8658bce3e1325b118d39b046aa55d6775cbf42dd4fd9dada7b42b5ec2",
+        "wy": "c848f72bc2f7049196d56b6690472f4d23569a0648510cb8feec9d34f4f7f226"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004fbfa53e8658bce3e1325b118d39b046aa55d6775cbf42dd4fd9dada7b42b5ec2c848f72bc2f7049196d56b6690472f4d23569a0648510cb8feec9d34f4f7f226",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+/pT6GWLzj4TJbEY05sEaqVdZ3XL\n9C3U/Z2tp7QrXsLISPcrwvcEkZbVa2aQRy9NI1aaBkhRDLj+7J009PfyJg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 326,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254effffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04249ab0e745b4a2aae5cd92a3b4cdc68d00795dcf2721b9b1d749a83c5c346ceb33e51922356e3281799e327ed0627c6c5588ff3b2663ee389d7616522dadfcdf",
+        "wx": "249ab0e745b4a2aae5cd92a3b4cdc68d00795dcf2721b9b1d749a83c5c346ceb",
+        "wy": "33e51922356e3281799e327ed0627c6c5588ff3b2663ee389d7616522dadfcdf"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004249ab0e745b4a2aae5cd92a3b4cdc68d00795dcf2721b9b1d749a83c5c346ceb33e51922356e3281799e327ed0627c6c5588ff3b2663ee389d7616522dadfcdf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJJqw50W0oqrlzZKjtM3GjQB5Xc8n\nIbmx10moPFw0bOsz5RkiNW4ygXmeMn7QYnxsVYj/OyZj7jiddhZSLa383w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 327,
+          "comment": "r = 3, x = n + 3 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000003ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04a495c3752b645eef19d87471511393559dcf399d50ddbcc14b5264b06e9d0de3074805c963f45a35db08d2349f2f1893db3a219512342c1160c2c307deac8c02",
+        "wx": "a495c3752b645eef19d87471511393559dcf399d50ddbcc14b5264b06e9d0de3",
+        "wy": "074805c963f45a35db08d2349f2f1893db3a219512342c1160c2c307deac8c02"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004a495c3752b645eef19d87471511393559dcf399d50ddbcc14b5264b06e9d0de3074805c963f45a35db08d2349f2f1893db3a219512342c1160c2c307deac8c02",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpJXDdStkXu8Z2HRxUROTVZ3POZ1Q\n3bzBS1JksG6dDeMHSAXJY/RaNdsI0jSfLxiT2zohlRI0LBFgwsMH3qyMAg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 328,
+          "comment": "r = 4, x = n + 3 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000004ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "04ed141e3d790add9e090cc9cb6a4866854a2fe3e5c9c09cc74e2cb32f1cae182d21124d25d8f62f890e3e45bb66c09b3331cef82e1dcd6a0615fad74c5464686d",
+        "wx": "ed141e3d790add9e090cc9cb6a4866854a2fe3e5c9c09cc74e2cb32f1cae182d",
+        "wy": "21124d25d8f62f890e3e45bb66c09b3331cef82e1dcd6a0615fad74c5464686d"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d03010703420004ed141e3d790add9e090cc9cb6a4866854a2fe3e5c9c09cc74e2cb32f1cae182d21124d25d8f62f890e3e45bb66c09b3331cef82e1dcd6a0615fad74c5464686d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7RQePXkK3Z4JDMnLakhmhUov4+XJ\nwJzHTiyzLxyuGC0hEk0l2PYviQ4+RbtmwJszMc74Lh3NagYV+tdMVGRobQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 329,
+          "comment": "r = p - n + 5, x = 5 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000004319055358e8617b0c46353d039cdab3ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "040997e2769537eff2ec78b27d716a5efd50a0737bc66bf7fec8fdb04e709544bde69d8aaa401b4a81ed474bc124db119b3555f60cae696790c77d64d994abc2d6",
+        "wx": "0997e2769537eff2ec78b27d716a5efd50a0737bc66bf7fec8fdb04e709544bd",
+        "wy": "e69d8aaa401b4a81ed474bc124db119b3555f60cae696790c77d64d994abc2d6"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200040997e2769537eff2ec78b27d716a5efd50a0737bc66bf7fec8fdb04e709544bde69d8aaa401b4a81ed474bc124db119b3555f60cae696790c77d64d994abc2d6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECZfidpU37/LseLJ9cWpe/VCgc3vG\na/f+yP2wTnCVRL3mnYqqQBtKge1HS8Ek2xGbNVX2DK5pZ5DHfWTZlKvC1g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 330,
+          "comment": "r = 2^256 - n + 5, x = 5 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000ffffffff00000000000000004319055258e8617b0c46353d039cdab4ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result": "invalid"
+        }
+      ]
     }
   ]
 }

--- a/testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 270,
+  "numberOfTests": 278,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5387,6 +5387,246 @@
         "y": "_____990wKUsTGyFM2KfkzoTE1S1j-CKEr1qgVsoenHMCj2SlR31YzMlqWeY_ylL",
         "kid": "none"
       }
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04016d2db67561bc126ad6c344d6eeb2713a9e2892c649af0f015c6b7617f160c8a3b3a88add669d7155025073c5ac5b4f43bf2ed0088af08645c80aa0a24a567a94ba2d794e9689d3ad4b185bc5d2dd008333e2dd2ebb5069a9b32251a3cac71e",
+        "wx": "016d2db67561bc126ad6c344d6eeb2713a9e2892c649af0f015c6b7617f160c8a3b3a88add669d7155025073c5ac5b4f",
+        "wy": "43bf2ed0088af08645c80aa0a24a567a94ba2d794e9689d3ad4b185bc5d2dd008333e2dd2ebb5069a9b32251a3cac71e"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004016d2db67561bc126ad6c344d6eeb2713a9e2892c649af0f015c6b7617f160c8a3b3a88add669d7155025073c5ac5b4f43bf2ed0088af08645c80aa0a24a567a94ba2d794e9689d3ad4b185bc5d2dd008333e2dd2ebb5069a9b32251a3cac71e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAW0ttnVhvBJq1sNE1u6ycTqeKJLGSa8P\nAVxrdhfxYMijs6iK3WadcVUCUHPFrFtPQ78u0AiK8IZFyAqgokpWepS6LXlOlonT\nrUsYW8XS3QCDM+LdLrtQaamzIlGjysce\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 271,
+          "comment": "r = 2, x = 2 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "043354c45736316411d883a2b6fd4db06eba3f265a91b785483a7ae20762fa3c4c079d07ade93074c25bebe755ba359907acba758be8e3c4e0c2e7b81d31296dc4bb0ce13d3eeac936b016260912c6dc0e98c95b2455bf9f9633d80c5430054663",
+        "wx": "3354c45736316411d883a2b6fd4db06eba3f265a91b785483a7ae20762fa3c4c079d07ade93074c25bebe755ba359907",
+        "wy": "acba758be8e3c4e0c2e7b81d31296dc4bb0ce13d3eeac936b016260912c6dc0e98c95b2455bf9f9633d80c5430054663"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200043354c45736316411d883a2b6fd4db06eba3f265a91b785483a7ae20762fa3c4c079d07ade93074c25bebe755ba359907acba758be8e3c4e0c2e7b81d31296dc4bb0ce13d3eeac936b016260912c6dc0e98c95b2455bf9f9633d80c5430054663",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEM1TEVzYxZBHYg6K2/U2wbro/JlqRt4VI\nOnriB2L6PEwHnQet6TB0wlvr51W6NZkHrLp1i+jjxODC57gdMSltxLsM4T0+6sk2\nsBYmCRLG3A6YyVskVb+fljPYDFQwBUZj\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 272,
+          "comment": "r = 3, x = 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04016d2db67561bc126ad6c344d6eeb2713a9e2892c649af0f015c6b7617f160c8a3b3a88add669d7155025073c5ac5b4f43bf2ed0088af08645c80aa0a24a567a94ba2d794e9689d3ad4b185bc5d2dd008333e2dd2ebb5069a9b32251a3cac71e",
+        "wx": "016d2db67561bc126ad6c344d6eeb2713a9e2892c649af0f015c6b7617f160c8a3b3a88add669d7155025073c5ac5b4f",
+        "wy": "43bf2ed0088af08645c80aa0a24a567a94ba2d794e9689d3ad4b185bc5d2dd008333e2dd2ebb5069a9b32251a3cac71e"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004016d2db67561bc126ad6c344d6eeb2713a9e2892c649af0f015c6b7617f160c8a3b3a88add669d7155025073c5ac5b4f43bf2ed0088af08645c80aa0a24a567a94ba2d794e9689d3ad4b185bc5d2dd008333e2dd2ebb5069a9b32251a3cac71e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAW0ttnVhvBJq1sNE1u6ycTqeKJLGSa8P\nAVxrdhfxYMijs6iK3WadcVUCUHPFrFtPQ78u0AiK8IZFyAqgokpWepS6LXlOlonT\nrUsYW8XS3QCDM+LdLrtQaamzIlGjysce\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 273,
+          "comment": "r = 2 + n, x = 2 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52975ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "041ffc8be6cf440e2649263c7b0c535b5828effcd7403d1e3c0460b5d06e179eb09f4672c299ef0839719f01e3212522136df29eae630caabbfd328c538de8989e651a6192ba52a7117dccb23d822ccc3e1875a39d8c9621676fc67c952ac6e304",
+        "wx": "1ffc8be6cf440e2649263c7b0c535b5828effcd7403d1e3c0460b5d06e179eb09f4672c299ef0839719f01e321252213",
+        "wy": "6df29eae630caabbfd328c538de8989e651a6192ba52a7117dccb23d822ccc3e1875a39d8c9621676fc67c952ac6e304"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200041ffc8be6cf440e2649263c7b0c535b5828effcd7403d1e3c0460b5d06e179eb09f4672c299ef0839719f01e3212522136df29eae630caabbfd328c538de8989e651a6192ba52a7117dccb23d822ccc3e1875a39d8c9621676fc67c952ac6e304",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEH/yL5s9EDiZJJjx7DFNbWCjv/NdAPR48\nBGC10G4XnrCfRnLCme8IOXGfAeMhJSITbfKermMMqrv9MoxTjeiYnmUaYZK6UqcR\nfcyyPYIszD4YdaOdjJYhZ2/GfJUqxuME\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 274,
+          "comment": "r = n - 2, x = n - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52971ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "0401b54a697305092bac2939fb906d7471b411c4eba8654169166a5da3810e1fc96795df921f7abbf519be4a027435176ca19012a3518773d508106d4153adee43c3c384fa62ce36a4addea08f593ec9c76b09a6b9c69d29bd7d47eb48e167dd2f",
+        "wx": "01b54a697305092bac2939fb906d7471b411c4eba8654169166a5da3810e1fc96795df921f7abbf519be4a027435176c",
+        "wy": "a19012a3518773d508106d4153adee43c3c384fa62ce36a4addea08f593ec9c76b09a6b9c69d29bd7d47eb48e167dd2f"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b810400220362000401b54a697305092bac2939fb906d7471b411c4eba8654169166a5da3810e1fc96795df921f7abbf519be4a027435176ca19012a3518773d508106d4153adee43c3c384fa62ce36a4addea08f593ec9c76b09a6b9c69d29bd7d47eb48e167dd2f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAbVKaXMFCSusKTn7kG10cbQRxOuoZUFp\nFmpdo4EOH8lnld+SH3q79Rm+SgJ0NRdsoZASo1GHc9UIEG1BU63uQ8PDhPpizjak\nrd6gj1k+ycdrCaa5xp0pvX1H60jhZ90v\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 275,
+          "comment": "r = 2, x = n + 2 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "043c8ea2db06ef48ecd59f8c0e1accb1d0c40b9f5ff4e5af3d326c9c8cb74bc941b8fa489468a607bb04b9817ce039d6099629deac1964857b6d7268fb3ff50330a6dafc2510f557053bf42f11c61cf85ececc95cfa754725a05f5a8184920056a",
+        "wx": "3c8ea2db06ef48ecd59f8c0e1accb1d0c40b9f5ff4e5af3d326c9c8cb74bc941b8fa489468a607bb04b9817ce039d609",
+        "wy": "9629deac1964857b6d7268fb3ff50330a6dafc2510f557053bf42f11c61cf85ececc95cfa754725a05f5a8184920056a"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200043c8ea2db06ef48ecd59f8c0e1accb1d0c40b9f5ff4e5af3d326c9c8cb74bc941b8fa489468a607bb04b9817ce039d6099629deac1964857b6d7268fb3ff50330a6dafc2510f557053bf42f11c61cf85ececc95cfa754725a05f5a8184920056a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPI6i2wbvSOzVn4wOGsyx0MQLn1/05a89\nMmycjLdLyUG4+kiUaKYHuwS5gXzgOdYJlinerBlkhXttcmj7P/UDMKba/CUQ9VcF\nO/QvEcYc+F7OzJXPp1RyWgX1qBhJIAVq\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 276,
+          "comment": "r = 3, x = n + 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "044e5e4f1a6e97059a6cf2f4e8129e5c7c64cb84f9994a41ff5bf30b29c1bf5ba6898627c91a23c73e05cd1a43c8f908c006a0aed7f1e63a728f87dbd5360a67571a076ab0b4cde81b10d499959814ddb3a8c7854b0bbfa87cc272f90bca2a2254",
+        "wx": "4e5e4f1a6e97059a6cf2f4e8129e5c7c64cb84f9994a41ff5bf30b29c1bf5ba6898627c91a23c73e05cd1a43c8f908c0",
+        "wy": "06a0aed7f1e63a728f87dbd5360a67571a076ab0b4cde81b10d499959814ddb3a8c7854b0bbfa87cc272f90bca2a2254"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200044e5e4f1a6e97059a6cf2f4e8129e5c7c64cb84f9994a41ff5bf30b29c1bf5ba6898627c91a23c73e05cd1a43c8f908c006a0aed7f1e63a728f87dbd5360a67571a076ab0b4cde81b10d499959814ddb3a8c7854b0bbfa87cc272f90bca2a2254",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAETl5PGm6XBZps8vToEp5cfGTLhPmZSkH/\nW/MLKcG/W6aJhifJGiPHPgXNGkPI+QjABqCu1/HmOnKPh9vVNgpnVxoHarC0zegb\nENSZlZgU3bOox4VLC7+ofMJy+QvKKiJU\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 277,
+          "comment": "r = p - n + 2, x = 2 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000389cb27e0bc8d21fa7e5f24cb74f58851313e696333ad68effffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04a7d0faaa124302cddcc1f46addca5a4cac48e02387ed0c51c46641a58999f16278255343522467f104bb296670458f817896fa77fb2eb80058b4d86b94a633bc82184843c9b163155e3071c4e1c876f6de2c91444393b22019e4f83a8d34b0d2",
+        "wx": "a7d0faaa124302cddcc1f46addca5a4cac48e02387ed0c51c46641a58999f16278255343522467f104bb296670458f81",
+        "wy": "7896fa77fb2eb80058b4d86b94a633bc82184843c9b163155e3071c4e1c876f6de2c91444393b22019e4f83a8d34b0d2"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004a7d0faaa124302cddcc1f46addca5a4cac48e02387ed0c51c46641a58999f16278255343522467f104bb296670458f817896fa77fb2eb80058b4d86b94a633bc82184843c9b163155e3071c4e1c876f6de2c91444393b22019e4f83a8d34b0d2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEp9D6qhJDAs3cwfRq3cpaTKxI4COH7QxR\nxGZBpYmZ8WJ4JVNDUiRn8QS7KWZwRY+BeJb6d/suuABYtNhrlKYzvIIYSEPJsWMV\nXjBxxOHIdvbeLJFEQ5OyIBnk+DqNNLDS\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 278,
+          "comment": "r = 2^384 - n + 2, x = 2 is invalid; r + n is too large to compare r + n with x, and overflows 2^384 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000389cb27e0bc8d220a7e5f24db74f58851313e695333ad68fffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
     }
   ]
 }

--- a/testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json
@@ -5389,7 +5389,7 @@
       }
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5419,7 +5419,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5449,7 +5449,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5479,7 +5479,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5509,7 +5509,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5539,7 +5539,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5569,7 +5569,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5599,7 +5599,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 308,
+  "numberOfTests": 316,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5771,6 +5771,246 @@
         "y": "_____990wKUsTGyFM2KfkzoTE1S1j-CKEr1qgVsoenHMCj2SlR31YzMlqWeY_ylL",
         "kid": "none"
       }
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "042d34643b2379ae47987213438b26bcd69bc6efca084ccaf7370d28d3bd2d8a30264d3b982378511ae31c306432557d6f0f1cc076b2914bfb2820ea34853fc950b27534e3838ec58d8b1e25bbb9855d413642adc213a0a28ea2cb6e1af2683aed",
+        "wx": "2d34643b2379ae47987213438b26bcd69bc6efca084ccaf7370d28d3bd2d8a30264d3b982378511ae31c306432557d6f",
+        "wy": "0f1cc076b2914bfb2820ea34853fc950b27534e3838ec58d8b1e25bbb9855d413642adc213a0a28ea2cb6e1af2683aed"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200042d34643b2379ae47987213438b26bcd69bc6efca084ccaf7370d28d3bd2d8a30264d3b982378511ae31c306432557d6f0f1cc076b2914bfb2820ea34853fc950b27534e3838ec58d8b1e25bbb9855d413642adc213a0a28ea2cb6e1af2683aed",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELTRkOyN5rkeYchNDiya81pvG78oITMr3\nNw0o070tijAmTTuYI3hRGuMcMGQyVX1vDxzAdrKRS/soIOo0hT/JULJ1NOODjsWN\nix4lu7mFXUE2Qq3CE6CijqLLbhryaDrt\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 309,
+          "comment": "r = 2, x = 2 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04ed1df914b31fa611da1ac317d4e412860b7472f5cf045f5c5000335b5f033b33bc40087a7462790fa1f8eab76068ae04831af423b088f21b724615a57c9972d7a0be7999d84ffd78d447668fa78ab52b0112349d2d03e94681d02f017e7f246b",
+        "wx": "ed1df914b31fa611da1ac317d4e412860b7472f5cf045f5c5000335b5f033b33bc40087a7462790fa1f8eab76068ae04",
+        "wy": "831af423b088f21b724615a57c9972d7a0be7999d84ffd78d447668fa78ab52b0112349d2d03e94681d02f017e7f246b"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004ed1df914b31fa611da1ac317d4e412860b7472f5cf045f5c5000335b5f033b33bc40087a7462790fa1f8eab76068ae04831af423b088f21b724615a57c9972d7a0be7999d84ffd78d447668fa78ab52b0112349d2d03e94681d02f017e7f246b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE7R35FLMfphHaGsMX1OQShgt0cvXPBF9c\nUAAzW18DOzO8QAh6dGJ5D6H46rdgaK4Egxr0I7CI8htyRhWlfJly16C+eZnYT/14\n1Edmj6eKtSsBEjSdLQPpRoHQLwF+fyRr\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 310,
+          "comment": "r = 3, x = 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "042d34643b2379ae47987213438b26bcd69bc6efca084ccaf7370d28d3bd2d8a30264d3b982378511ae31c306432557d6f0f1cc076b2914bfb2820ea34853fc950b27534e3838ec58d8b1e25bbb9855d413642adc213a0a28ea2cb6e1af2683aed",
+        "wx": "2d34643b2379ae47987213438b26bcd69bc6efca084ccaf7370d28d3bd2d8a30264d3b982378511ae31c306432557d6f",
+        "wy": "0f1cc076b2914bfb2820ea34853fc950b27534e3838ec58d8b1e25bbb9855d413642adc213a0a28ea2cb6e1af2683aed"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200042d34643b2379ae47987213438b26bcd69bc6efca084ccaf7370d28d3bd2d8a30264d3b982378511ae31c306432557d6f0f1cc076b2914bfb2820ea34853fc950b27534e3838ec58d8b1e25bbb9855d413642adc213a0a28ea2cb6e1af2683aed",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELTRkOyN5rkeYchNDiya81pvG78oITMr3\nNw0o070tijAmTTuYI3hRGuMcMGQyVX1vDxzAdrKRS/soIOo0hT/JULJ1NOODjsWN\nix4lu7mFXUE2Qq3CE6CijqLLbhryaDrt\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 311,
+          "comment": "r = 2 + n, x = 2 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52975ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "049112bce7572304bc3b79c0c09d291de07c8e1b4aed0a46938a2f3349708e532be744b865fd4565aed12b6aa5a61f95f56ec37fb8ddda9922dd4390f4e2351f55299a365d97fabfd1692fe47f2370a3229093869a660b1a3370895736396fb674",
+        "wx": "9112bce7572304bc3b79c0c09d291de07c8e1b4aed0a46938a2f3349708e532be744b865fd4565aed12b6aa5a61f95f5",
+        "wy": "6ec37fb8ddda9922dd4390f4e2351f55299a365d97fabfd1692fe47f2370a3229093869a660b1a3370895736396fb674"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200049112bce7572304bc3b79c0c09d291de07c8e1b4aed0a46938a2f3349708e532be744b865fd4565aed12b6aa5a61f95f56ec37fb8ddda9922dd4390f4e2351f55299a365d97fabfd1692fe47f2370a3229093869a660b1a3370895736396fb674",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkRK851cjBLw7ecDAnSkd4HyOG0rtCkaT\nii8zSXCOUyvnRLhl/UVlrtEraqWmH5X1bsN/uN3amSLdQ5D04jUfVSmaNl2X+r/R\naS/kfyNwoyKQk4aaZgsaM3CJVzY5b7Z0\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 312,
+          "comment": "r = n - 2, x = n - 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52971ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04d9f95e6e72b9ade325cd5973aa3d724333c16646862f986d3f2e944053bde4fcf16801407c6479e625ed5fa2e94ea7723a95e104c9d9bb6a3b0928d90e151accddc867d12e7fb16095d4b39d17cab0a7cb846584b9d167d5aaaf818be3abadde",
+        "wx": "d9f95e6e72b9ade325cd5973aa3d724333c16646862f986d3f2e944053bde4fcf16801407c6479e625ed5fa2e94ea772",
+        "wy": "3a95e104c9d9bb6a3b0928d90e151accddc867d12e7fb16095d4b39d17cab0a7cb846584b9d167d5aaaf818be3abadde"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004d9f95e6e72b9ade325cd5973aa3d724333c16646862f986d3f2e944053bde4fcf16801407c6479e625ed5fa2e94ea7723a95e104c9d9bb6a3b0928d90e151accddc867d12e7fb16095d4b39d17cab0a7cb846584b9d167d5aaaf818be3abadde",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2flebnK5reMlzVlzqj1yQzPBZkaGL5ht\nPy6UQFO95PzxaAFAfGR55iXtX6LpTqdyOpXhBMnZu2o7CSjZDhUazN3IZ9Euf7Fg\nldSznRfKsKfLhGWEudFn1aqvgYvjq63e\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 313,
+          "comment": "r = 2, x = n + 2 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04981b5c4cef5472f30d0a3233e61205670dd919d4c761514af936b46686a54176289b82224c808eeecea0143dcb2368f9d9e2955c55cef250fe2d21edd6e752d121338c74ec17618ecec7e908a755b3becb2d0f7577c4903c0ab625147a250ae2",
+        "wx": "981b5c4cef5472f30d0a3233e61205670dd919d4c761514af936b46686a54176289b82224c808eeecea0143dcb2368f9",
+        "wy": "d9e2955c55cef250fe2d21edd6e752d121338c74ec17618ecec7e908a755b3becb2d0f7577c4903c0ab625147a250ae2"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004981b5c4cef5472f30d0a3233e61205670dd919d4c761514af936b46686a54176289b82224c808eeecea0143dcb2368f9d9e2955c55cef250fe2d21edd6e752d121338c74ec17618ecec7e908a755b3becb2d0f7577c4903c0ab625147a250ae2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEmBtcTO9UcvMNCjIz5hIFZw3ZGdTHYVFK\n+Ta0ZoalQXYom4IiTICO7s6gFD3LI2j52eKVXFXO8lD+LSHt1udS0SEzjHTsF2GO\nzsfpCKdVs77LLQ91d8SQPAq2JRR6JQri\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 314,
+          "comment": "r = 3, x = n + 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "0438932f2ac31d5d3722c3fa64d849b32afc766affce7e81dc1d080f933fa9f8d281b3c9824459f5af40d2f7a7c1d858f09d62ae3548d099766f99a78fa5cd3a2120a89a38dcf208880021d9d612935abe299eef77b7ad6ce3c602cce652c07a2a",
+        "wx": "38932f2ac31d5d3722c3fa64d849b32afc766affce7e81dc1d080f933fa9f8d281b3c9824459f5af40d2f7a7c1d858f0",
+        "wy": "9d62ae3548d099766f99a78fa5cd3a2120a89a38dcf208880021d9d612935abe299eef77b7ad6ce3c602cce652c07a2a"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b810400220362000438932f2ac31d5d3722c3fa64d849b32afc766affce7e81dc1d080f933fa9f8d281b3c9824459f5af40d2f7a7c1d858f09d62ae3548d099766f99a78fa5cd3a2120a89a38dcf208880021d9d612935abe299eef77b7ad6ce3c602cce652c07a2a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOJMvKsMdXTciw/pk2EmzKvx2av/OfoHc\nHQgPkz+p+NKBs8mCRFn1r0DS96fB2FjwnWKuNUjQmXZvmaePpc06ISComjjc8giI\nACHZ1hKTWr4pnu93t61s48YCzOZSwHoq\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 315,
+          "comment": "r = p - n + 2, x = 2 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000389cb27e0bc8d21fa7e5f24cb74f58851313e696333ad68effffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04ca92097e845a4bbe63a5cfbe04fb18d74a3810594563ee9cb1e5ac0d598986d01f227e258064e6a896a0b32e15f43ff0c5f19b80fd82c92e36fefaa7ecf26daae5a4671f2f22d4379342a8719f15091d72afb13bc248b88215e9cd8f3c5b4529",
+        "wx": "ca92097e845a4bbe63a5cfbe04fb18d74a3810594563ee9cb1e5ac0d598986d01f227e258064e6a896a0b32e15f43ff0",
+        "wy": "c5f19b80fd82c92e36fefaa7ecf26daae5a4671f2f22d4379342a8719f15091d72afb13bc248b88215e9cd8f3c5b4529"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004ca92097e845a4bbe63a5cfbe04fb18d74a3810594563ee9cb1e5ac0d598986d01f227e258064e6a896a0b32e15f43ff0c5f19b80fd82c92e36fefaa7ecf26daae5a4671f2f22d4379342a8719f15091d72afb13bc248b88215e9cd8f3c5b4529",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEypIJfoRaS75jpc++BPsY10o4EFlFY+6c\nseWsDVmJhtAfIn4lgGTmqJagsy4V9D/wxfGbgP2CyS42/vqn7PJtquWkZx8vItQ3\nk0KocZ8VCR1yr7E7wki4ghXpzY88W0Up\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 316,
+          "comment": "r = 2^384 - n + 2, x = 2 is invalid; r + n is too large to compare r + n with x, and overflows 2^384 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000000000000000000000389cb27e0bc8d220a7e5f24db74f58851313e695333ad68fffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result": "invalid"
+        }
+      ]
     }
   ]
 }

--- a/testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json
@@ -5773,7 +5773,7 @@
       }
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5803,7 +5803,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5833,7 +5833,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5863,7 +5863,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5893,7 +5893,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5923,7 +5923,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5953,7 +5953,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5983,7 +5983,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"

--- a/testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 308,
+  "numberOfTests": 316,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5848,6 +5848,246 @@
         "y": "AAi_C-KXmruBEf0NdorcrXdBE6giwbtgiHBTtc-MlWPnZwWjkezhVLXfsRSyDjUd9AFL7Bn6h3IIRYAc8Gt_____",
         "kid": "none"
       }
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "0400f07e0b593332d09ec4fd0bae93f648a3da04dd224faae3f64cc490ec8fce3a6fe53d1b2c9e326be076cafb921b7e3f8b2288db491819522d65472870668c3808c9018e42509aca542a8de421589c38ba653e8cfd69322336217042a9dc0f67f6d7ae2cd4e385f480ffaf8981f715c7ca3765d9867dfd5a02947b0895f82eaf8b257e88",
+        "wx": "00f07e0b593332d09ec4fd0bae93f648a3da04dd224faae3f64cc490ec8fce3a6fe53d1b2c9e326be076cafb921b7e3f8b2288db491819522d65472870668c3808c9",
+        "wy": "018e42509aca542a8de421589c38ba653e8cfd69322336217042a9dc0f67f6d7ae2cd4e385f480ffaf8981f715c7ca3765d9867dfd5a02947b0895f82eaf8b257e88"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b81040023038186000400f07e0b593332d09ec4fd0bae93f648a3da04dd224faae3f64cc490ec8fce3a6fe53d1b2c9e326be076cafb921b7e3f8b2288db491819522d65472870668c3808c9018e42509aca542a8de421589c38ba653e8cfd69322336217042a9dc0f67f6d7ae2cd4e385f480ffaf8981f715c7ca3765d9867dfd5a02947b0895f82eaf8b257e88",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQA8H4LWTMy0J7E/Quuk/ZIo9oE3SJP\nquP2TMSQ7I/OOm/lPRssnjJr4HbK+5Ibfj+LIojbSRgZUi1lRyhwZow4CMkBjkJQ\nmspUKo3kIVicOLplPoz9aTIjNiFwQqncD2f2164s1OOF9ID/r4mB9xXHyjdl2YZ9\n/VoClHsIlfgur4slfog=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 309,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000101fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "04009f8e02c30a20c6a61dc6f86ef4db54cc0be2c90db388f632ab2865698ee18de8329d8bfd55a90debe1d41a24221aa07208babc9ef784c99fa94ecd0c8a90389c7001b0c38a7429379d17b8ce49fb58af3eb6d4cd34581f6556dec3c46e11aaa7b493641cac7e6ddede322d7f0eb509d51d2bcd771cd78cc03c6852ce1ff6cdaf002d47",
+        "wx": "009f8e02c30a20c6a61dc6f86ef4db54cc0be2c90db388f632ab2865698ee18de8329d8bfd55a90debe1d41a24221aa07208babc9ef784c99fa94ecd0c8a90389c70",
+        "wy": "01b0c38a7429379d17b8ce49fb58af3eb6d4cd34581f6556dec3c46e11aaa7b493641cac7e6ddede322d7f0eb509d51d2bcd771cd78cc03c6852ce1ff6cdaf002d47"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b810400230381860004009f8e02c30a20c6a61dc6f86ef4db54cc0be2c90db388f632ab2865698ee18de8329d8bfd55a90debe1d41a24221aa07208babc9ef784c99fa94ecd0c8a90389c7001b0c38a7429379d17b8ce49fb58af3eb6d4cd34581f6556dec3c46e11aaa7b493641cac7e6ddede322d7f0eb509d51d2bcd771cd78cc03c6852ce1ff6cdaf002d47",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAn44CwwogxqYdxvhu9NtUzAviyQ2z\niPYyqyhlaY7hjegynYv9VakN6+HUGiQiGqByCLq8nveEyZ+pTs0MipA4nHABsMOK\ndCk3nRe4zkn7WK8+ttTNNFgfZVbew8RuEaqntJNkHKx+bd7eMi1/DrUJ1R0rzXcc\n14zAPGhSzh/2za8ALUc=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 310,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "0400f07e0b593332d09ec4fd0bae93f648a3da04dd224faae3f64cc490ec8fce3a6fe53d1b2c9e326be076cafb921b7e3f8b2288db491819522d65472870668c3808c9018e42509aca542a8de421589c38ba653e8cfd69322336217042a9dc0f67f6d7ae2cd4e385f480ffaf8981f715c7ca3765d9867dfd5a02947b0895f82eaf8b257e88",
+        "wx": "00f07e0b593332d09ec4fd0bae93f648a3da04dd224faae3f64cc490ec8fce3a6fe53d1b2c9e326be076cafb921b7e3f8b2288db491819522d65472870668c3808c9",
+        "wy": "018e42509aca542a8de421589c38ba653e8cfd69322336217042a9dc0f67f6d7ae2cd4e385f480ffaf8981f715c7ca3765d9867dfd5a02947b0895f82eaf8b257e88"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b81040023038186000400f07e0b593332d09ec4fd0bae93f648a3da04dd224faae3f64cc490ec8fce3a6fe53d1b2c9e326be076cafb921b7e3f8b2288db491819522d65472870668c3808c9018e42509aca542a8de421589c38ba653e8cfd69322336217042a9dc0f67f6d7ae2cd4e385f480ffaf8981f715c7ca3765d9867dfd5a02947b0895f82eaf8b257e88",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQA8H4LWTMy0J7E/Quuk/ZIo9oE3SJP\nquP2TMSQ7I/OOm/lPRssnjJr4HbK+5Ibfj+LIojbSRgZUi1lRyhwZow4CMkBjkJQ\nmspUKo3kIVicOLplPoz9aTIjNiFwQqncD2f2164s1OOF9ID/r4mB9xXHyjdl2YZ9\n/VoClHsIlfgur4slfog=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 311,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "04009f7559ec0a616df84857117c31ead682f898944ea97d08217fc6d24fb70f8b79e30dab0ac2554aae2d80e28c8d19e83d451899fc6cd581779cba3762768d411c4c017b14b10af332582e8ceb47e5b00cda1a264b73b4d15df8918667630682b608b9aceadd240685cc35691c82fd9e2c73eaf2f9480a81211b256879d7dd9c3a1215f9",
+        "wx": "009f7559ec0a616df84857117c31ead682f898944ea97d08217fc6d24fb70f8b79e30dab0ac2554aae2d80e28c8d19e83d451899fc6cd581779cba3762768d411c4c",
+        "wy": "017b14b10af332582e8ceb47e5b00cda1a264b73b4d15df8918667630682b608b9aceadd240685cc35691c82fd9e2c73eaf2f9480a81211b256879d7dd9c3a1215f9"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b810400230381860004009f7559ec0a616df84857117c31ead682f898944ea97d08217fc6d24fb70f8b79e30dab0ac2554aae2d80e28c8d19e83d451899fc6cd581779cba3762768d411c4c017b14b10af332582e8ceb47e5b00cda1a264b73b4d15df8918667630682b608b9aceadd240685cc35691c82fd9e2c73eaf2f9480a81211b256879d7dd9c3a1215f9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAn3VZ7AphbfhIVxF8MerWgviYlE6p\nfQghf8bST7cPi3njDasKwlVKri2A4oyNGeg9RRiZ/GzVgXecujdido1BHEwBexSx\nCvMyWC6M60flsAzaGiZLc7TRXfiRhmdjBoK2CLms6t0kBoXMNWkcgv2eLHPq8vlI\nCoEhGyVoedfdnDoSFfk=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 312,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640601fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "040049bbb2d3267a6eab2c59fac5b138b9e9c383db6637fcfe5d9f430e4c4c2ba0332340975448bd86c92a55c1a8288adf7f774096022419aa8c497499dafee7b9325700bb52fd444ec497ce228135f2498d40fb84eb6f674df1245d3aaac3c75b55ff5fff8e90b6f0189a3132cb9fd8d6e74fda5866fe2b9fc7484c628fde97e0b00f2b67",
+        "wx": "0049bbb2d3267a6eab2c59fac5b138b9e9c383db6637fcfe5d9f430e4c4c2ba0332340975448bd86c92a55c1a8288adf7f774096022419aa8c497499dafee7b93257",
+        "wy": "00bb52fd444ec497ce228135f2498d40fb84eb6f674df1245d3aaac3c75b55ff5fff8e90b6f0189a3132cb9fd8d6e74fda5866fe2b9fc7484c628fde97e0b00f2b67"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b8104002303818600040049bbb2d3267a6eab2c59fac5b138b9e9c383db6637fcfe5d9f430e4c4c2ba0332340975448bd86c92a55c1a8288adf7f774096022419aa8c497499dafee7b9325700bb52fd444ec497ce228135f2498d40fb84eb6f674df1245d3aaac3c75b55ff5fff8e90b6f0189a3132cb9fd8d6e74fda5866fe2b9fc7484c628fde97e0b00f2b67",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQASbuy0yZ6bqssWfrFsTi56cOD22Y3\n/P5dn0MOTEwroDMjQJdUSL2GySpVwagoit9/d0CWAiQZqoxJdJna/ue5MlcAu1L9\nRE7El84igTXySY1A+4Trb2dN8SRdOqrDx1tV/1//jpC28BiaMTLLn9jW50/aWGb+\nK5/HSExij96X4LAPK2c=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 313,
+          "comment": "r = 1, x = n + 1 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000101fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "0401136164d3ebd0659e1a9755e0653035fdc254c8743fe93d472f6b0017aade3d08f29231d157d1f34941818c5e03e242d206dfff5c2f1ad82f3dbd71bd4855dcbe410074e5888b89845a1e2c2231d3c679cd2465d9b21cf5fae6b40e110151b5272bf821ba4fca66f52fc37f656670873f49d87e5a56e1d43d42bac6446f1f04fe48d982",
+        "wx": "01136164d3ebd0659e1a9755e0653035fdc254c8743fe93d472f6b0017aade3d08f29231d157d1f34941818c5e03e242d206dfff5c2f1ad82f3dbd71bd4855dcbe41",
+        "wy": "0074e5888b89845a1e2c2231d3c679cd2465d9b21cf5fae6b40e110151b5272bf821ba4fca66f52fc37f656670873f49d87e5a56e1d43d42bac6446f1f04fe48d982"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b81040023038186000401136164d3ebd0659e1a9755e0653035fdc254c8743fe93d472f6b0017aade3d08f29231d157d1f34941818c5e03e242d206dfff5c2f1ad82f3dbd71bd4855dcbe410074e5888b89845a1e2c2231d3c679cd2465d9b21cf5fae6b40e110151b5272bf821ba4fca66f52fc37f656670873f49d87e5a56e1d43d42bac6446f1f04fe48d982",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBE2Fk0+vQZZ4al1XgZTA1/cJUyHQ/\n6T1HL2sAF6rePQjykjHRV9HzSUGBjF4D4kLSBt//XC8a2C89vXG9SFXcvkEAdOWI\ni4mEWh4sIjHTxnnNJGXZshz1+ua0DhEBUbUnK/ghuk/KZvUvw39lZnCHP0nYflpW\n4dQ9QrrGRG8fBP5I2YI=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 314,
+          "comment": "r = 2, x = n + 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "04009eeb7f956230c3744ca5b683f413009363107aad18a027fa7af6ac07a699911e94143d3ef00c0062d4187c2ea74dc9322c05431a6b7fed51ee71b047ce3a0e967c007d2c089a6720f7c7886ce8aa6aeb9b821adde0eb025ef63c62d37c32b2d6823c857ce7743b8181c35c8f34e6aeb4487dd693e01d69dfe883c07c25ebe89bdc4d56",
+        "wx": "009eeb7f956230c3744ca5b683f413009363107aad18a027fa7af6ac07a699911e94143d3ef00c0062d4187c2ea74dc9322c05431a6b7fed51ee71b047ce3a0e967c",
+        "wy": "007d2c089a6720f7c7886ce8aa6aeb9b821adde0eb025ef63c62d37c32b2d6823c857ce7743b8181c35c8f34e6aeb4487dd693e01d69dfe883c07c25ebe89bdc4d56"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b810400230381860004009eeb7f956230c3744ca5b683f413009363107aad18a027fa7af6ac07a699911e94143d3ef00c0062d4187c2ea74dc9322c05431a6b7fed51ee71b047ce3a0e967c007d2c089a6720f7c7886ce8aa6aeb9b821adde0eb025ef63c62d37c32b2d6823c857ce7743b8181c35c8f34e6aeb4487dd693e01d69dfe883c07c25ebe89bdc4d56",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAnut/lWIww3RMpbaD9BMAk2MQeq0Y\noCf6evasB6aZkR6UFD0+8AwAYtQYfC6nTckyLAVDGmt/7VHucbBHzjoOlnwAfSwI\nmmcg98eIbOiqauubghrd4OsCXvY8YtN8MrLWgjyFfOd0O4GBw1yPNOautEh91pPg\nHWnf6IPAfCXr6JvcTVY=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 315,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000005ae79787c40d069948033feb708f65a2fc44a36477663b851449048e16ec79bf701fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "0401c643e4861ab549e1cf4e2ce619fce9c518269a06ab336dc9c9885d0cab4644933af7c0c4660151c1fbd7c5a9d90b21562261587318860beaa157c9450ed65ebca800841a2d9d631efe8e2cc98bf46d18056afa194b7a137698a7826b30fe19d1909b9475e298edc80e1d3aa70a9fb15b104c55050efd10cdab2d452f87dbf701c2ec88",
+        "wx": "01c643e4861ab549e1cf4e2ce619fce9c518269a06ab336dc9c9885d0cab4644933af7c0c4660151c1fbd7c5a9d90b21562261587318860beaa157c9450ed65ebca8",
+        "wy": "00841a2d9d631efe8e2cc98bf46d18056afa194b7a137698a7826b30fe19d1909b9475e298edc80e1d3aa70a9fb15b104c55050efd10cdab2d452f87dbf701c2ec88"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b81040023038186000401c643e4861ab549e1cf4e2ce619fce9c518269a06ab336dc9c9885d0cab4644933af7c0c4660151c1fbd7c5a9d90b21562261587318860beaa157c9450ed65ebca800841a2d9d631efe8e2cc98bf46d18056afa194b7a137698a7826b30fe19d1909b9475e298edc80e1d3aa70a9fb15b104c55050efd10cdab2d452f87dbf701c2ec88",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBxkPkhhq1SeHPTizmGfzpxRgmmgar\nM23JyYhdDKtGRJM698DEZgFRwfvXxanZCyFWImFYcxiGC+qhV8lFDtZevKgAhBot\nnWMe/o4syYv0bRgFavoZS3oTdpingmsw/hnRkJuUdeKY7cgOHTqnCp+xWxBMVQUO\n/RDNqy1FL4fb9wHC7Ig=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 316,
+          "comment": "r = 2^521 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^521 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000005ae79787c40d069948033feb708f65a2fc44a36477663b851449048e16ec79bf801fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result": "invalid"
+        }
+      ]
     }
   ]
 }

--- a/testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json
@@ -5850,7 +5850,7 @@
       }
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5880,7 +5880,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5910,7 +5910,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5940,7 +5940,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -5970,7 +5970,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6000,7 +6000,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6030,7 +6030,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"
@@ -6060,7 +6060,7 @@
       ]
     },
     {
-      "type": "EcdsaVerify",
+      "type": "EcdsaP1363Verify",
       "source": {
         "name": "github/davidben/ecdsa-r-s-edge-cases",
         "version": "0.1"


### PR DESCRIPTION
Commit 713daee9dd8a47892b521921e2b478c4a103e27e (from PR #206) added some ECDSA tests from David Benjamin, to cover a few edge cases, in particular when r is very slightly above p - n. David had submitted the tests on 23 curve/hash combinations, but only for the ASN.1/DER format for signature. This commit imports the same vectors but with signatures in IEEE p1363 format.

I am using the same script (reproduced below) with only the minute changes to get the encoding in the IEEE p1363 format (in function `add_test()`, around lines 545-549). Since the script is deterministic, all the mathematical values are the same, only the encoding is changed.

<details>
<summary>Test generation script (David's script with just a few changed)</summary>

```
import base64 
import hashlib 
import json 
import random 
 
# Go's crypto/elliptic would normally be easier for this, but it only supports 
# a = -3. We may as well get all the curves. No optimizations, except Jacobian 
# coordinates because the inversion is too expensive. 
 
# Too lazy to write % all the time. 
class ModP: 
    def __init__(self, value, p): 
        assert 0 <= value < p 
        assert p & 1 
        self.value = value 
        self.p = p 
 
    def inv(self): 
        if self.value == 0: 
            raise ZeroDivisionError() 
        return self ** (self.p - 2) 
 
    def _unpack(self, other): 
        assert other.p == self.p 
        return other.value 
 
    def __add__(self, other): 
        return ModP((self.value + self._unpack(other)) % self.p, self.p) 
 
    def __sub__(self, other): 
        return ModP((self.value - self._unpack(other)) % self.p, self.p) 
 
    def __mul__(self, other): 
        return ModP((self.value * self._unpack(other)) % self.p, self.p) 
 
    def __truediv__(self, other): 
        assert self.p == other.p 
        return self * other.inv() 
 
    def __neg__(self): 
        return ModP((-self.value) % self.p, self.p) 
 
    def __pow__(self, exp): 
        return ModP(pow(self.value, exp, self.p), self.p) 
 
    def __eq__(self, other): 
        assert self.p == other.p 
        return self.value == other.value 
 
    def has_sqrt(self): 
        if self.value == 0: 
            return True 
        # Euler's criterion 
        return pow(self.value, (self.p - 1) // 2, self.p) == 1 
 
    def sqrt(self): 
        assert self.has_sqrt() 
        # Tonelli–Shanks. For reasonable curves, square roots are much more 
        # straightforward, but P-224 is (uniquely) horrible, so just use the 
        # generic algorithm. 
        # https://en.wikipedia.org/wiki/Tonelli%E2%80%93Shanks_algorithm#The_algorithm 
        q, s = self.p - 1, 0 
        while q & 1 == 0: 
            q >>= 1 
            s += 1 
        # Find a quadratic non-residue. 
        while True: 
            z = ModP(random.randint(1, self.p - 1), self.p) 
            if not z.has_sqrt(): 
                break 
        m = s 
        c = z ** q 
        t = self ** q 
        r = self ** ((q + 1) // 2) 
        while True: 
            if t.value == 0: 
                assert self.value == 0 
                return ModP(0, self.p) 
            if t.value == 1: 
                assert r ** 2 == self 
                return r 
            # Find smallest i such that t**(2**i) == 1. 
            tmp = t 
            for i in range(1, m): 
                tmp *= tmp 
                if tmp.value == 1: 
                    break 
            assert tmp.value == 1 
            # b = c**(2**(m-i-1)), or square it m - i - 1 times. 
            b = c 
            for _ in range(m - i - 1): 
                b *= b 
            m = i 
            c = b * b 
            t *= c 
            r *= b 
 
class InvalidCompressedPoint(Exception): pass 
 
class Curve: 
    def __init__(self, name, p, a, b, gx, gy, n): 
        self.name = name 
        self.p = p 
        self.a = self.felem(a) 
        self.b = self.felem(b) 
        self.g = self.affine(gx, gy) 
        self.n = n 
 
    def felem(self, x): 
        return ModP(x, self.p) 
 
    def scalar(self, x): 
        return ModP(x, self.n) 
 
    def infinity(self): 
        return Point(self, self.felem(0), self.felem(0), self.felem(0)) 
 
    def affine(self, x, y): 
        return Point(self, self.felem(x), self.felem(y), self.felem(1)) 
 
    def compressed(self, x, y_bit=0): 
        assert y_bit in (0, 1) 
        x = self.felem(x) 
        y2 = (x**3 + self.a * x + self.b) 
        if not y2.has_sqrt(): 
            raise InvalidCompressedPoint() 
        y = y2.sqrt() 
        if y_bit != (y.value & 1): 
            y = -y 
        return Point(self, x, y, self.felem(1)) 
 
class Point: 
    def __init__(self, curve, x, y, z): 
        # (Y/Z^3)^2 = (X/Z^2)^3 + a(X/Z^2) + b 
        # Y^2 / Z^6 = X^3 / Z^6 + a X / Z^2 + b 
        # Y^2 = X^3 + a X Z^4 + b Z^6 
        assert z.value == 0 or y**2 == x**3 + curve.a * x * z**4 + curve.b * z**6 
        self.curve = curve 
        self.x = x 
        self.y = y 
        self.z = z 
 
    def __repr__(self): 
        if self.is_infinity(): 
            return f"{self.curve.name}.infinity()" 
        x, y = self.affine() 
        return f"{self.curve.name}.affine(0x{x.value:x}, 0x{y.value:x})" 
 
    def is_infinity(self): 
        return self.z.value == 0 
 
    def affine(self): 
        assert not self.is_infinity() 
        return self.x / self.z**2, self.y / self.z**3 
 
    def __add__(self, other): 
        assert isinstance(other, Point) 
        assert self.curve == other.curve 
        if self.is_infinity(): 
            return other 
        if other.is_infinity(): 
            return self 
        a = self.curve.a 
        # Point formulas are transcribed a little sloppily and should have some 
        # strength reductions. E.g. the constant multiplications should be 
        # additions. But this is fast enough for these purposes. 
        x1, y1, z1 = self.x, self.y, self.z 
        x2, y2, z2 = other.x, other.y, other.z 
        if x1 * z2 * z2 == x2 * z1 * z1: 
            # https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian.html#doubling-dbl-2007-bl 
            two = self.curve.felem(2) 
            three = self.curve.felem(3) 
            eight = self.curve.felem(8) 
            xx = x1*x1 
            yy = y1*y1 
            yyyy = yy*yy 
            zz = z1*z1 
            s = two*((x1+yy)**2-xx-yyyy) 
            m = three*xx+a*zz*zz 
            t = m*m-two*s 
            x3 = t 
            y3 = m*(s-t)-eight*yyyy 
            z3 = (y1+z1)**2-yy-zz 
            return Point(self.curve, x3, y3, z3) 
 
        # https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian.html#addition-add-2007-bl 
        two = self.curve.felem(2) 
        z1z1 = z1*z1 
        z2z2 = z2*z2 
        u1 = x1*z2z2 
        u2 = x2*z1z1 
        s1 = y1*z2*z2z2 
        s2 = y2*z1*z1z1 
        h = u2-u1 
        i = (two*h)**2 
        j = h*i 
        r = two*(s2-s1) 
        v = u1*i 
        x3 = r*r-j-two*v 
        y3 = r*(v-x3)-two*s1*j 
        z3 = ((z1+z2)**2-z1z1-z2z2)*h 
        return Point(self.curve, x3, y3, z3) 
 
    def __sub__(self, other): 
        return self + (-other) 
 
    def __neg__(self): 
        if self.is_infinity(): 
            return self 
        return Point(self.curve, self.x, -self.y, self.z) 
 
    def __mul__(self, scalar): 
        assert scalar.p == self.curve.n 
        scalar = scalar.value 
        ret = self.curve.infinity() 
        for i in reversed(range(scalar.bit_length())): 
            ret += ret 
            if scalar & (1 << i): 
                ret += self 
        return ret 
 
    def __eq__(self, other): 
        assert self.curve == other.curve 
        if self.is_infinity(): 
            return other.is_infinity() 
        if other.is_infinity(): 
            return False 
        x1, y1, z1 = self.x, self.y, self.z 
        x2, y2, z2 = other.x, other.y, other.z 
        z1z1 = z1 * z1 
        z2z2 = z2 * z2 
        return x1 * z2z2 == x2 * z1z1 and y1 * z2z2 * z2 == y2 * z1z1 * z1 
 
def ecdsa_digest_to_scalar(curve, digest): 
    e = int.from_bytes(digest, 'big') 
    n_bits = curve.n.bit_length() 
    if n_bits < len(digest) * 8: 
        # ECDSA takes the leftmost bits of the hash. Within a byte, the leftmost 
        # bit is the most-significant bit. 
        e >>= len(digest) * 8 - n_bits 
    assert e.bit_length() <= n_bits 
    # e may still need to be reduced. 
    return ModP(e % curve.n, curve.n) 
 
def ecdsa_pubkey_from_signature(point, digest, r, s): 
    curve = point.curve 
    r = ModP(r % curve.n, curve.n) 
    s = ModP(s % curve.n, curve.n) 
    e = ecdsa_digest_to_scalar(curve, digest) 
    u, v_inv = e / s, s / r 
    pub = (point - curve.g * u) * v_inv 
    return pub 
 
def ecdsa_verify(pub, digest, r, s): 
    curve = pub.curve 
    if not 0 < r < curve.n or not 0 < s < curve.n: 
        return False 
    r, s = ModP(r, curve.n), ModP(s, curve.n) 
    e = ecdsa_digest_to_scalar(curve, digest) 
    s_inv = s.inv() 
    u, v = e * s_inv, r * s_inv 
    point = curve.g * u + pub * v 
    if point.is_infinity(): 
        return False 
    r1, _ = point.affine() 
    return r.value == r1.value % curve.n 
 
#SEQUENCE = 0x30 
#INTEGER = 0x02 
 
#def encode_der(tag, body): 
#    ret = bytearray() 
#    ret.append(tag) 
#    if len(body) < 0x80: 
#        ret.append(len(body)) 
#    else: 
#        assert len(body) <= 0xff 
#        ret.append(0x81) 
#        ret.append(len(body)) 
#    ret.extend(body) 
#    return bytes(ret) 
 
#def encode_der_integer(v): 
#    l = (v.bit_length() + 7) // 8 
#    b = v.to_bytes(l, 'big') 
#    if b[0] & 0x80: 
#        b = b"\x00" + b 
#    return encode_der(INTEGER, b) 
 
#def encode_ecdsa_signature(r, s): 
#    return encode_der(SEQUENCE, encode_der_integer(r) + encode_der_integer(s)) 
 
# All curves supported by Wycheproof. 
brainpoolP224r1 = Curve( 
    name="brainpoolP224r1", 
    p= 0xd7c134aa264366862a18302575d1d787b09f075797da89f57ec8c0ff, 
    a= 0x68a5e62ca9ce6c1c299803a6c1530b514e182ad8b0042a59cad29f43, 
    b= 0x2580f63ccfe44138870713b1a92369e33e2135d266dbb372386c400b, 
    gx=0x0d9029ad2c7e5cf4340823b2a87dc68c9e4ce3174c1e6efdee12c07d, 
    gy=0x58aa56f772c0726f24c6b89e4ecdac24354b9e99caa3f6d3761402cd, 
    n= 0xd7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939f, 
) 
brainpoolP256r1 = Curve( 
    name="brainpoolP256r1", 
    p= 0xa9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377, 
    a= 0x7d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9, 
    b= 0x26dc5c6ce94a4b44f330b5d9bbd77cbf958416295cf7e1ce6bccdc18ff8c07b6, 
    gx=0x8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262, 
    gy=0x547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997, 
    n= 0xa9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a7, 
) 
brainpoolP320r1 = Curve( 
    name="brainpoolP320r1", 
    p= 0xd35e472036bc4fb7e13c785ed201e065f98fcfa6f6f40def4f92b9ec7893ec28fcd412b1f1b32e27, 
    a= 0x3ee30b568fbab0f883ccebd46d3f3bb8a2a73513f5eb79da66190eb085ffa9f492f375a97d860eb4, 
    b= 0x520883949dfdbc42d3ad198640688a6fe13f41349554b49acc31dccd884539816f5eb4ac8fb1f1a6, 
    gx=0x43bd7e9afb53d8b85289bcc48ee5bfe6f20137d10a087eb6e7871e2a10a599c710af8d0d39e20611, 
    gy=0x14fdd05545ec1cc8ab4093247f77275e0743ffed117182eaa9c77877aaac6ac7d35245d1692e8ee1, 
    n= 0xd35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c59311, 
) 
brainpoolP384r1 = Curve( 
    name="brainpoolP384r1", 
    p= 0x8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec53, 
    a= 0x7bc382c63d8c150c3c72080ace05afa0c2bea28e4fb22787139165efba91f90f8aa5814a503ad4eb04a8c7dd22ce2826, 
    b= 0x04a8c7dd22ce28268b39b55416f0447c2fb77de107dcd2a62e880ea53eeb62d57cb4390295dbc9943ab78696fa504c11, 
    gx=0x1d1c64f068cf45ffa2a63a81b7c13f6b8847a3e77ef14fe3db7fcafe0cbd10e8e826e03436d646aaef87b2e247d4af1e, 
    gy=0x8abe1d7520f9c2a45cb1eb8e95cfd55262b70b29feec5864e19c054ff99129280e4646217791811142820341263c5315, 
    n= 0x8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046565, 
) 
brainpoolP512r1 = Curve( 
    name="brainpoolP512r1", 
    p= 0xaadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca703308717d4d9b009bc66842aecda12ae6a380e62881ff2f2d82c68528aa6056583a48f3, 
    a= 0x7830a3318b603b89e2327145ac234cc594cbdd8d3df91610a83441caea9863bc2ded5d5aa8253aa10a2ef1c98b9ac8b57f1117a72bf2c7b9e7c1ac4d77fc94ca, 
    b= 0x3df91610a83441caea9863bc2ded5d5aa8253aa10a2ef1c98b9ac8b57f1117a72bf2c7b9e7c1ac4d77fc94cadc083e67984050b75ebae5dd2809bd638016f723, 
    gx=0x81aee4bdd82ed9645a21322e9c4c6a9385ed9f70b5d916c1b43b62eef4d0098eff3b1f78e2d0d48d50d1687b93b97d5f7c6d5047406a5e688b352209bcb9f822, 
    gy=0x7dde385d566332ecc0eabfa9cf7822fdf209f70024a57b1aa000c55b881f8111b2dcde494a5f485e5bca4bd88a2763aed1ca2b2fa8f0540678cd1e0f3ad80892, 
    n= 0xaadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90069, 
) 
secp160k1 = Curve( 
    name="secp160k1", 
    p= 0x00fffffffffffffffffffffffffffffffeffffac73, 
    a= 0x000000000000000000000000000000000000000000, 
    b= 0x000000000000000000000000000000000000000007, 
    gx=0x003b4c382ce37aa192a4019e763036f4f5dd4d7ebb, 
    gy=0x00938cf935318fdced6bc28286531733c3f03c4fee, 
    n= 0x0100000000000000000001b8fa16dfab9aca16b6b3, 
) 
secp160r1 = Curve( 
    name="secp160r1", 
    p= 0x00ffffffffffffffffffffffffffffffff7fffffff, 
    a= 0x00ffffffffffffffffffffffffffffffff7ffffffc, 
    b= 0x001c97befc54bd7a8b65acf89f81d4d4adc565fa45, 
    gx=0x004a96b5688ef573284664698968c38bb913cbfc82, 
    gy=0x0023a628553168947d59dcc912042351377ac5fb32, 
    n= 0x0100000000000000000001f4c8f927aed3ca752257, 
) 
secp160r2 = Curve( 
    name="secp160r2", 
    p= 0x00fffffffffffffffffffffffffffffffeffffac73, 
    a= 0x00fffffffffffffffffffffffffffffffeffffac70, 
    b= 0x00b4e134d3fb59eb8bab57274904664d5af50388ba, 
    gx=0x0052dcb034293a117e1f4ff11b30f7199d3144ce6d, 
    gy=0x00feaffef2e331f296e071fa0df9982cfea7d43f2e, 
    n= 0x0100000000000000000000351ee786a818f3a1a16b, 
) 
secp192k1 = Curve( 
    name="secp192k1", 
    p= 0xfffffffffffffffffffffffffffffffffffffffeffffee37, 
    a= 0x000000000000000000000000000000000000000000000000, 
    b= 0x000000000000000000000000000000000000000000000003, 
    gx=0xdb4ff10ec057e9ae26b07d0280b7f4341da5d1b1eae06c7d, 
    gy=0x9b2f2f6d9c5628a7844163d015be86344082aa88d95e2f9d, 
    n= 0xfffffffffffffffffffffffe26f2fc170f69466a74defd8d, 
) 
secp192r1 = Curve( 
    name="secp192r1", 
    p= 0xfffffffffffffffffffffffffffffffeffffffffffffffff, 
    a= 0xfffffffffffffffffffffffffffffffefffffffffffffffc, 
    b= 0x64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1, 
    gx=0x188da80eb03090f67cbf20eb43a18800f4ff0afd82ff1012, 
    gy=0x07192b95ffc8da78631011ed6b24cdd573f977a11e794811, 
    n= 0xffffffffffffffffffffffff99def836146bc9b1b4d22831, 
) 
secp224k1 = Curve( 
    name="secp224k1", 
    p= 0x00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56d, 
    a= 0x0000000000000000000000000000000000000000000000000000000000, 
    b= 0x0000000000000000000000000000000000000000000000000000000005, 
    gx=0x00a1455b334df099df30fc28a169a467e9e47075a90f7e650eb6b7a45c, 
    gy=0x007e089fed7fba344282cafbd6f7e319f7c0b0bd59e2ca4bdb556d61a5, 
    n= 0x10000000000000000000000000001dce8d2ec6184caf0a971769fb1f7, 
) 
secp224r1 = Curve( 
    name="secp224r1", 
    p= 0xffffffffffffffffffffffffffffffff000000000000000000000001, 
    a= 0xfffffffffffffffffffffffffffffffefffffffffffffffffffffffe, 
    b= 0xb4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4, 
    gx=0xb70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21, 
    gy=0xbd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34, 
    n= 0xffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d, 
) 
secp256k1 = Curve( 
    name="secp256k1", 
    p= 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f, 
    a= 0x0000000000000000000000000000000000000000000000000000000000000000, 
    b= 0x0000000000000000000000000000000000000000000000000000000000000007, 
    gx=0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798, 
    gy=0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8, 
    n= 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141, 
) 
secp256r1 = Curve( 
    name="secp256r1", 
    p= 0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff, 
    a= 0xffffffff00000001000000000000000000000000fffffffffffffffffffffffc, 
    b= 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b, 
    gx=0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296, 
    gy=0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5, 
    n= 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551, 
) 
secp384r1 = Curve( 
    name="secp384r1", 
    p= 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff, 
    a= 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc, 
    b= 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef, 
    gx=0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7, 
    gy=0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f, 
    n= 0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973, 
) 
secp521r1 = Curve( 
    name="secp521r1", 
    p= 0x01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 
    a= 0x01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc, 
    b= 0x0051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00, 
    gx=0x00c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66, 
    gy=0x011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650, 
    n= 0x01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409, 
) 
 
# Curve/hash combinations from Wycheproof. 
TESTS = [ 
    ("ecdsa_brainpoolP224r1_sha224_p1363_test.json", brainpoolP224r1, "SHA-224"), 
    ("ecdsa_brainpoolP256r1_sha256_p1363_test.json", brainpoolP256r1, "SHA-256"), 
    ("ecdsa_brainpoolP320r1_sha384_p1363_test.json", brainpoolP320r1, "SHA-384"), 
    ("ecdsa_brainpoolP384r1_sha384_p1363_test.json", brainpoolP384r1, "SHA-384"), 
    ("ecdsa_brainpoolP512r1_sha512_p1363_test.json", brainpoolP512r1, "SHA-512"), 
    ("ecdsa_secp160k1_sha256_p1363_test.json", secp160k1, "SHA-256"), 
    ("ecdsa_secp160r1_sha256_p1363_test.json", secp160r1, "SHA-256"), 
    ("ecdsa_secp160r2_sha256_p1363_test.json", secp160r2, "SHA-256"), 
    ("ecdsa_secp192k1_sha256_p1363_test.json", secp192k1, "SHA-256"), 
    ("ecdsa_secp192r1_sha256_p1363_test.json", secp192r1, "SHA-256"), 
    ("ecdsa_secp224k1_sha224_p1363_test.json", secp224k1, "SHA-224"), 
    ("ecdsa_secp224k1_sha256_p1363_test.json", secp224k1, "SHA-256"), 
    ("ecdsa_secp224r1_sha224_p1363_test.json", secp224r1, "SHA-224"), 
    ("ecdsa_secp224r1_sha256_p1363_test.json", secp224r1, "SHA-256"), 
    ("ecdsa_secp224r1_sha512_p1363_test.json", secp224r1, "SHA-512"), 
    ("ecdsa_secp256k1_sha256_p1363_test.json", secp256k1, "SHA-256"), 
    ("ecdsa_secp256k1_sha512_p1363_test.json", secp256k1, "SHA-512"), 
    ("ecdsa_secp256r1_sha256_p1363_test.json", secp256r1, "SHA-256"), 
    ("ecdsa_secp256r1_sha512_p1363_test.json", secp256r1, "SHA-512"), 
    ("ecdsa_secp384r1_sha384_p1363_test.json", secp384r1, "SHA-384"), 
    ("ecdsa_secp384r1_sha512_p1363_test.json", secp384r1, "SHA-512"), 
    ("ecdsa_secp521r1_sha512_p1363_test.json", secp521r1, "SHA-512"), 
] 
 
# Sanity-check 
x = 0xf3033d1e548d245b5e45ff1147db8cd44db8a1f2823c3c164125be88f9a982c2 
y = 0x3c078f6cee2f50e95e8916aa9c4e93de3fdf9b045abac6f707cfcb22d065638e 
pub = secp256r1.affine(x, y) 
assert pub == secp256r1.compressed(x, y & 1) 
digest = bytes.fromhex("e8d38e4c6a905a814b04c2841d898ed6da023c34") 
r = 0xd4255db86a416a5a688de4e238071ef16e5f2a20e31b9490c03dee9ae6164c34 
s = 0x4e0ac1e1a6725bf7c6bd207439b2d370c5f2dea1ff4decf1650ab84c7769efc0 
assert ecdsa_verify(pub, digest, r, s) 
 
x = 0x4a6f1e7f7268174d23993b8b58aa60c2a87b18de79b36a750ec86dd6f9e12227 
y = 0x572df22bd6487a863a51ca544b8c5de2b47f801372a881cb996a97d9a98aa825 
pub = secp256r1.affine(x, y) 
assert pub == secp256r1.compressed(x, y & 1) 
digest = bytes.fromhex("54e9a048559f370425e9c8e54a460ec91bcc930a") 
r = 0x4a800e24de65e5c57d4cab4dd1ef7b6c38a2f0aa5cfd3a571a4b552fb1993e69 
s = 0xd9c89fb983640a7e65edf632cacd1de0823b7efbc798fc1f7bbfacdda7398955 
assert not ecdsa_verify(pub, digest, r, s) 
 
# These tests exercise the final r == x comparison, where x is the x-coordinate 
# of uG + vQ. When testing boundary conditions, we would ideally use cases like 
# r = 1, x = 1 or r = 1 + n, x = 1. However, not all x-coordinates are on the 
# curve, so these helpers find a target x = ε or x = n - ε, for some ε > 0. 
 
def plus_epsilon(curve, x): 
    epsilon = 1 
    while True: 
        try: 
            return curve.compressed(x + epsilon), epsilon 
        except InvalidCompressedPoint: 
            epsilon += 1 
 
def minus_epsilon(curve, x): 
    epsilon = 1 
    while True: 
        try: 
            return curve.compressed(x - epsilon), epsilon 
        except InvalidCompressedPoint: 
            epsilon += 1 
 
def key_to_pem(key: bytes) -> str: 
    ret = "-----BEGIN PUBLIC KEY-----\n" 
    b64 = base64.b64encode(key).decode("ascii") 
    while b64: 
        l = min(len(b64), 64) 
        ret += b64[:l] 
        ret += "\n" 
        b64 = b64[l:] 
    ret += "-----END PUBLIC KEY-----\n" 
    return ret 
 
INPUT = b"hello, world" 
for (path, curve, hash_name) in TESTS: 
    print(path) 
    with open(path) as f: 
        data = json.load(f) 
 
    def add_test(comment, pub, digest, r, s, valid): 
        felem_bytes = (pub.curve.p.bit_length() + 7) // 8 
        x, y = pub.affine() 
        x_bytes = x.value.to_bytes(felem_bytes, "big") 
        y_bytes = y.value.to_bytes(felem_bytes, "big") 
        uncompressed = b"\x04" + x_bytes + y_bytes 
        if valid: 
            flags = ["ValidSignature"] 
            result = "valid" 
        else: 
            flags = ["ArithmeticError"] 
            result = "invalid" 
 
        # Reconstruct the SPKI encoding from the existing examples, rather than 
        # encoding an OID and everything. 
        sample_spki = bytes.fromhex(data["testGroups"][0]["publicKeyDer"]) 
        sample_uncompressed = bytes.fromhex(data["testGroups"][0]["publicKey"]["uncompressed"]) 
        assert sample_spki.endswith(sample_uncompressed) 
        assert key_to_pem(sample_spki) == data["testGroups"][0]["publicKeyPem"] 
        spki_prefix = sample_spki[:-len(sample_uncompressed)] 
 
        spki = spki_prefix + uncompressed 

        # Encode (r,s) in IEEE p1363 format.
        scalar_bytes = (pub.curve.n.bit_length() + 7) // 8
        r_bytes = r.to_bytes(scalar_bytes, "big")
        s_bytes = s.to_bytes(scalar_bytes, "big")
        sig = r_bytes + s_bytes
 
        group = { 
            "type": "EcdsaP1363Verify", 
            "source": { 
                "name" : "github/davidben/ecdsa-r-s-edge-cases", 
                "version" : "0.1" 
            }, 
            "publicKey": { 
                "type": "EcPublicKey", 
                "curve": pub.curve.name, 
                "keySize": pub.curve.p.bit_length(), 
                "uncompressed": uncompressed.hex(), 
                "wx": x_bytes.hex(), 
                "wy": y_bytes.hex(), 
            }, 
            "publicKeyDer": spki.hex(), 
            "publicKeyPem": key_to_pem(spki), 
            "sha": hash_name, 
            "tests": [ 
                { 
                    "tcId": data["numberOfTests"] + 1, 
                    "comment": comment, 
                    "flags": flags, 
                    "msg": INPUT.hex(), 
                    #"sig": encode_ecdsa_signature(r, s).hex(), 
                    "sig": sig.hex(), 
                    "result": result, 
                }, 
            ], 
        } 
 
        data["testGroups"].append(group) 
        data["numberOfTests"] += 1 
 
    def valid_test(comment, point, digest, r, s): 
        pub = ecdsa_pubkey_from_signature(point, digest, r, s) 
        assert ecdsa_verify(pub, digest, r, s) 
        add_test(comment, pub, digest, r, s, True) 
 
    def invalid_test(comment, point, digest, r, s): 
        pub = ecdsa_pubkey_from_signature(point, digest, r, s) 
        assert not ecdsa_verify(pub, digest, r, s) 
        add_test(comment, pub, digest, r, s, False) 
 
    h = hashlib.new(hash_name.replace("-", "")) 
    h.update(INPUT) 
    digest = h.digest() 
 
    # Arbitrarily use s = n - 3. 
    s = curve.n - 3 
 
    point, epsilon = plus_epsilon(curve, 0) 
    r = epsilon 
    valid_test(f"r = {epsilon}, x = {epsilon} is valid", point, digest, r, s) 
 
    r = epsilon + 1 
    invalid_test(f"r = {epsilon+1}, x = {epsilon} is invalid", point, digest, r, s) 
 
    r = epsilon + curve.n 
    invalid_test(f"r = {epsilon} + n, x = {epsilon} is invalid; r was not reduced mod n", point, digest, r, s) 
 
    if curve.p > curve.n: 
        print("  p > n") 
        # This is redundant with the existing "r,s are large" test. 
        # point, epsilon = minus_epsilon(curve, curve.n) 
        # r = curve.n - epsilon 
        # valid_test(f"r = n - {epsilon}, x = n - {epsilon} is the largest x without a reduction", point, digest, r, s) 
 
        point, epsilon = minus_epsilon(curve, curve.n) 
        r = curve.n - epsilon - 1 
        invalid_test(f"r = n - {epsilon+1}, x = n - {epsilon} is invalid", point, digest, r, s) 
 
        point, epsilon = plus_epsilon(curve, curve.n) 
        r = epsilon 
        valid_test(f"r = {epsilon}, x = n + {epsilon} is the smallest possible x with a reduction", point, digest, r, s) 
 
        r = epsilon + 1 
        invalid_test(f"r = {epsilon+1}, x = n + {epsilon} is invalid", point, digest, r, s) 
 
        # This is redundant with the existing "k*G has a large x-coordinate" test. 
        # point, epsilon = minus_epsilon(curve, curve.p) 
        # r = curve.p - epsilon - curve.n 
        # valid_test(f"r = p - {epsilon} - n, x = p - {epsilon} is the largest valid x", point, digest, r, s) 
 
        point, epsilon = plus_epsilon(curve, 0) 
        r = curve.p - curve.n + epsilon 
        invalid_test(f"r = p - n + {epsilon}, x = {epsilon} is invalid; r is too large to compare r + n with x", point, digest, r, s) 
 
        b = curve.n.bit_length() 
        r = (1<<b) - curve.n + epsilon 
        invalid_test(f"r = 2^{b} - n + {epsilon}, x = {epsilon} is invalid; r + n is too large to compare r + n with x, and overflows 2^{b} bits", point, digest, r, s) 
 
    else: 
        print("  n > p") 
        # Not as many cases to test. x is already reduced mod n. 
 
        # This is redundant with the existing "k*G has a large x-coordinate" test. 
        # point, epsilon = minus_epsilon(curve, curve.p) 
        # r = curve.p - epsilon 
        # valid_test(f"r = p - {epsilon}, x = p - {epsilon} is the largest valid r and x", point, digest, r, s) 
 
        point, epsilon = minus_epsilon(curve, curve.p) 
        r = curve.p - epsilon - 1 
        invalid_test(f"r = p - {epsilon+1}, x = p - {epsilon} is invalid", point, digest, r, s) 
 
        point, epsilon = plus_epsilon(curve, 0) 
        r = epsilon + curve.p 
        invalid_test(f"r = {epsilon} + p, x = {epsilon} is invalid; values only match mod p", point, digest, r, s) 
 
    with open(path, "w") as f: 
        json.dump(data, f, indent=2, separators=(',', ': '), ensure_ascii=False) 
        f.write("\n")
```
</details>