### PR TITLE
ecdsa: Add some tests for s being a large power of 2

### DIFF
--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha224_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 227,
+  "numberOfTests": 229,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4450,6 +4450,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "283ecb55d9bc9979d5e7cfda8a2f04672ee943b49221435c5a586c62d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "042c2fd58b6a82809af91a28225cf79e632472a1054d589de972f7dbd353ee4fb4dd0341e9b9b15d94e775c9f4d1b152c07abb0b6c40cee567",
+        "wx": "2c2fd58b6a82809af91a28225cf79e632472a1054d589de972f7dbd3",
+        "wy": "53ee4fb4dd0341e9b9b15d94e775c9f4d1b152c07abb0b6c40cee567"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a00042c2fd58b6a82809af91a28225cf79e632472a1054d589de972f7dbd353ee4fb4dd0341e9b9b15d94e775c9f4d1b152c07abb0b6c40cee567",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABCwv1YtqgoCa+RooIlz3nmMkcqEF\nTVid6XL329NT7k+03QNB6bmxXZTndcn00bFSwHq7C2xAzuVn\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 228,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "a1df7811e3bd627ed4838ce23b174aed337ef2867baeaa6e896587c300000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 229,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "a1df7811e3bd627ed4838ce23b174aed337ef2867baeaa6e896587c3d7c134aa264366862a18302475d0fb98d116bc4b6ddebca3a5a7939f",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP224r1_sha224_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP224r1_sha224_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 451,
+  "numberOfTests": 453,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6724,6 +6724,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "303d021c283ecb55d9bc9979d5e7cfda8a2f04672ee943b49221435c5a586c62021d00d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939c",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP224r1",
+        "keySize": 224,
+        "uncompressed": "042c2fd58b6a82809af91a28225cf79e632472a1054d589de972f7dbd353ee4fb4dd0341e9b9b15d94e775c9f4d1b152c07abb0b6c40cee567",
+        "wx": "2c2fd58b6a82809af91a28225cf79e632472a1054d589de972f7dbd3",
+        "wy": "53ee4fb4dd0341e9b9b15d94e775c9f4d1b152c07abb0b6c40cee567"
+      },
+      "publicKeyDer": "3052301406072a8648ce3d020106092b2403030208010105033a00042c2fd58b6a82809af91a28225cf79e632472a1054d589de972f7dbd353ee4fb4dd0341e9b9b15d94e775c9f4d1b152c07abb0b6c40cee567",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFIwFAYHKoZIzj0CAQYJKyQDAwIIAQEFAzoABCwv1YtqgoCa+RooIlz3nmMkcqEF\nTVid6XL329NT7k+03QNB6bmxXZTndcn00bFSwHq7C2xAzuVn\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 452,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3032021d00a1df7811e3bd627ed4838ce23b174aed337ef2867baeaa6e896587c302110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 453,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303e021d00a1df7811e3bd627ed4838ce23b174aed337ef2867baeaa6e896587c3021d00d7c134aa264366862a18302475d0fb98d116bc4b6ddebca3a5a7939f",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 259,
+  "numberOfTests": 261,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4849,6 +4849,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "5604a8245e115643c199f56f627c728e73c6855c4a9e59086fe1f17d68b7a95aa9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "048af1ec83704efa0f112abddf15b244adc4c90828c94139416787032dcf0c4e2572a3a31f95bb29003075ce39809c224458e128aa17acedde0cc4bd2988e5b8f7",
+        "wx": "8af1ec83704efa0f112abddf15b244adc4c90828c94139416787032dcf0c4e25",
+        "wy": "72a3a31f95bb29003075ce39809c224458e128aa17acedde0cc4bd2988e5b8f7"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b2403030208010107034200048af1ec83704efa0f112abddf15b244adc4c90828c94139416787032dcf0c4e2572a3a31f95bb29003075ce39809c224458e128aa17acedde0cc4bd2988e5b8f7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABIrx7INwTvoPESq93xWyRK3EyQgo\nyUE5QWeHAy3PDE4lcqOjH5W7KQAwdc45gJwiRFjhKKoXrO3eDMS9KYjluPc=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 260,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "82050aa6b1528c456650aa17bc396e8761baeef0dd085aa82b5e939e3b5cda790000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 261,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "82050aa6b1528c456650aa17bc396e8761baeef0dd085aa82b5e939e3b5cda79a9fb57dba1eea9bc3e660a909d838d708c397aa3b561a6f7901e0e82974856a7",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP256r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP256r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 483,
+  "numberOfTests": 485,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7118,6 +7118,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "304502205604a8245e115643c199f56f627c728e73c6855c4a9e59086fe1f17d68b7a95a022100a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a4",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP256r1",
+        "keySize": 256,
+        "uncompressed": "048af1ec83704efa0f112abddf15b244adc4c90828c94139416787032dcf0c4e2572a3a31f95bb29003075ce39809c224458e128aa17acedde0cc4bd2988e5b8f7",
+        "wx": "8af1ec83704efa0f112abddf15b244adc4c90828c94139416787032dcf0c4e25",
+        "wy": "72a3a31f95bb29003075ce39809c224458e128aa17acedde0cc4bd2988e5b8f7"
+      },
+      "publicKeyDer": "305a301406072a8648ce3d020106092b2403030208010107034200048af1ec83704efa0f112abddf15b244adc4c90828c94139416787032dcf0c4e2572a3a31f95bb29003075ce39809c224458e128aa17acedde0cc4bd2988e5b8f7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFowFAYHKoZIzj0CAQYJKyQDAwIIAQEHA0IABIrx7INwTvoPESq93xWyRK3EyQgo\nyUE5QWeHAy3PDE4lcqOjH5W7KQAwdc45gJwiRFjhKKoXrO3eDMS9KYjluPc=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 484,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303602210082050aa6b1528c456650aa17bc396e8761baeef0dd085aa82b5e939e3b5cda7902110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 485,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304602210082050aa6b1528c456650aa17bc396e8761baeef0dd085aa82b5e939e3b5cda79022100a9fb57dba1eea9bc3e660a909d838d708c397aa3b561a6f7901e0e82974856a7",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha384_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 263,
+  "numberOfTests": 265,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4730,6 +4730,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "2ca1b8dfc943b0481ec387a12dfe1f9a0670305a4970ed5cd2b7d1381179a716796eaaa4bb3a6cf0d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "043d5bc090eeead820960c0a90715c7a6cf4aabafe1000a29ef64de4b2a80cbbf26e145a74afb52b61c538505b4bf65f5da00c709302a4cf38b9018e126cea2b42714bd884dcdbf5a1051df44e948b20d9",
+        "wx": "3d5bc090eeead820960c0a90715c7a6cf4aabafe1000a29ef64de4b2a80cbbf26e145a74afb52b61",
+        "wy": "c538505b4bf65f5da00c709302a4cf38b9018e126cea2b42714bd884dcdbf5a1051df44e948b20d9"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b2403030208010109035200043d5bc090eeead820960c0a90715c7a6cf4aabafe1000a29ef64de4b2a80cbbf26e145a74afb52b61c538505b4bf65f5da00c709302a4cf38b9018e126cea2b42714bd884dcdbf5a1051df44e948b20d9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABD1bwJDu6tgglgwKkHFcemz0qrr+\nEACinvZN5LKoDLvybhRadK+1K2HFOFBbS/ZfXaAMcJMCpM84uQGOEmzqK0JxS9iE\n3Nv1oQUd9E6UiyDZ\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 264,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "981c72a30cd9547e7344f03ecca609c081ce92618e09d82fade07ae3804c8bf077eeffd6d6dfaebe00000000000000000000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 265,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "981c72a30cd9547e7344f03ecca609c081ce92618e09d82fade07ae3804c8bf077eeffd6d6dfaebed35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a22d482ec7ee8658e98691555b44c59311",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP320r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP320r1_sha384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 487,
+  "numberOfTests": 489,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7004,6 +7004,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "305502282ca1b8dfc943b0481ec387a12dfe1f9a0670305a4970ed5cd2b7d1381179a716796eaaa4bb3a6cf0022900d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c5930e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP320r1",
+        "keySize": 320,
+        "uncompressed": "043d5bc090eeead820960c0a90715c7a6cf4aabafe1000a29ef64de4b2a80cbbf26e145a74afb52b61c538505b4bf65f5da00c709302a4cf38b9018e126cea2b42714bd884dcdbf5a1051df44e948b20d9",
+        "wx": "3d5bc090eeead820960c0a90715c7a6cf4aabafe1000a29ef64de4b2a80cbbf26e145a74afb52b61",
+        "wy": "c538505b4bf65f5da00c709302a4cf38b9018e126cea2b42714bd884dcdbf5a1051df44e948b20d9"
+      },
+      "publicKeyDer": "306a301406072a8648ce3d020106092b2403030208010109035200043d5bc090eeead820960c0a90715c7a6cf4aabafe1000a29ef64de4b2a80cbbf26e145a74afb52b61c538505b4bf65f5da00c709302a4cf38b9018e126cea2b42714bd884dcdbf5a1051df44e948b20d9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMGowFAYHKoZIzj0CAQYJKyQDAwIIAQEJA1IABD1bwJDu6tgglgwKkHFcemz0qrr+\nEACinvZN5LKoDLvybhRadK+1K2HFOFBbS/ZfXaAMcJMCpM84uQGOEmzqK0JxS9iE\n3Nv1oQUd9E6UiyDZ\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 488,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303e022900981c72a30cd9547e7344f03ecca609c081ce92618e09d82fade07ae3804c8bf077eeffd6d6dfaebe02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 489,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3056022900981c72a30cd9547e7344f03ecca609c081ce92618e09d82fade07ae3804c8bf077eeffd6d6dfaebe022900d35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a22d482ec7ee8658e98691555b44c59311",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha384_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 290,
+  "numberOfTests": 292,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5182,6 +5182,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "7346e17d5cc792d7f0a29081af19be20ead08ef612aba94ce0e9919353fbda5830c5495094803cefc477cdfd16fb9a9c8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "042eab20120a069a394a2bbc79082f94221116cd9a49a68abec35a4d1cc4f3fa5b0ed06f01b19b8514ecdcf240492cd58656b0aa47d51c9c4047ce10428faaa67b132f161227e43287f1895f6f3e0f0afc74fc9c2479882d300212b6ad954506bb",
+        "wx": "2eab20120a069a394a2bbc79082f94221116cd9a49a68abec35a4d1cc4f3fa5b0ed06f01b19b8514ecdcf240492cd586",
+        "wy": "56b0aa47d51c9c4047ce10428faaa67b132f161227e43287f1895f6f3e0f0afc74fc9c2479882d300212b6ad954506bb"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200042eab20120a069a394a2bbc79082f94221116cd9a49a68abec35a4d1cc4f3fa5b0ed06f01b19b8514ecdcf240492cd58656b0aa47d51c9c4047ce10428faaa67b132f161227e43287f1895f6f3e0f0afc74fc9c2479882d300212b6ad954506bb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABC6rIBIKBpo5Siu8eQgvlCIRFs2a\nSaaKvsNaTRzE8/pbDtBvAbGbhRTs3PJASSzVhlawqkfVHJxAR84QQo+qpnsTLxYS\nJ+Qyh/GJX28+Dwr8dPycJHmILTACEratlUUGuw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 291,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "6068fc1ab386864f9dd260069c9549103c5cfe8e2a8fa5d8ff267ee7aafd5c2363b23a859b56064f541aac7b7bdfd120000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 292,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "6068fc1ab386864f9dd260069c9549103c5cfe8e2a8fa5d8ff267ee7aafd5c2363b23a859b56064f541aac7b7bdfd1208cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a6cf3ab6af6b7fc3103b883202e9046565",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP384r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP384r1_sha384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 514,
+  "numberOfTests": 516,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7451,6 +7451,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "306502307346e17d5cc792d7f0a29081af19be20ead08ef612aba94ce0e9919353fbda5830c5495094803cefc477cdfd16fb9a9c0231008cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046562",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP384r1",
+        "keySize": 384,
+        "uncompressed": "042eab20120a069a394a2bbc79082f94221116cd9a49a68abec35a4d1cc4f3fa5b0ed06f01b19b8514ecdcf240492cd58656b0aa47d51c9c4047ce10428faaa67b132f161227e43287f1895f6f3e0f0afc74fc9c2479882d300212b6ad954506bb",
+        "wx": "2eab20120a069a394a2bbc79082f94221116cd9a49a68abec35a4d1cc4f3fa5b0ed06f01b19b8514ecdcf240492cd586",
+        "wy": "56b0aa47d51c9c4047ce10428faaa67b132f161227e43287f1895f6f3e0f0afc74fc9c2479882d300212b6ad954506bb"
+      },
+      "publicKeyDer": "307a301406072a8648ce3d020106092b240303020801010b036200042eab20120a069a394a2bbc79082f94221116cd9a49a68abec35a4d1cc4f3fa5b0ed06f01b19b8514ecdcf240492cd58656b0aa47d51c9c4047ce10428faaa67b132f161227e43287f1895f6f3e0f0afc74fc9c2479882d300212b6ad954506bb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHowFAYHKoZIzj0CAQYJKyQDAwIIAQELA2IABC6rIBIKBpo5Siu8eQgvlCIRFs2a\nSaaKvsNaTRzE8/pbDtBvAbGbhRTs3PJASSzVhlawqkfVHJxAR84QQo+qpnsTLxYS\nJ+Qyh/GJX28+Dwr8dPycJHmILTACEratlUUGuw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 515,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502306068fc1ab386864f9dd260069c9549103c5cfe8e2a8fa5d8ff267ee7aafd5c2363b23a859b56064f541aac7b7bdfd12002110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 516,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "306502306068fc1ab386864f9dd260069c9549103c5cfe8e2a8fa5d8ff267ee7aafd5c2363b23a859b56064f541aac7b7bdfd1200231008cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a6cf3ab6af6b7fc3103b883202e9046565",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 335,
+  "numberOfTests": 337,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5692,6 +5692,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "5522624724163b74c02b1951cc3603f834cf724c4c362df1299c63358fccf78faac1a3beb356d9e6be799ee68053efb8e24e2c7ef7a225224a78697d6356ff9aaadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "04206b2ad718245aea23fcc88c8b1a199d56a20f6f10ce80a3816162fdebacde2d1e18ab725e5d01e36ec21844280ead44344eaafade7ffe47b71215e199a214eb4bef07b7b20d111b095e7f3a2299672a47db5145aa0d5ea8258458db3e16f948700b4fb5fce4b2098e95cd5965ad10ae012baad56222a435cd14842c55be4a5d",
+        "wx": "206b2ad718245aea23fcc88c8b1a199d56a20f6f10ce80a3816162fdebacde2d1e18ab725e5d01e36ec21844280ead44344eaafade7ffe47b71215e199a214eb",
+        "wy": "4bef07b7b20d111b095e7f3a2299672a47db5145aa0d5ea8258458db3e16f948700b4fb5fce4b2098e95cd5965ad10ae012baad56222a435cd14842c55be4a5d"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d0381820004206b2ad718245aea23fcc88c8b1a199d56a20f6f10ce80a3816162fdebacde2d1e18ab725e5d01e36ec21844280ead44344eaafade7ffe47b71215e199a214eb4bef07b7b20d111b095e7f3a2299672a47db5145aa0d5ea8258458db3e16f948700b4fb5fce4b2098e95cd5965ad10ae012baad56222a435cd14842c55be4a5d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEIGsq1xgkWuoj/MiMixoZnVai\nD28QzoCjgWFi/eus3i0eGKtyXl0B427CGEQoDq1ENE6q+t5//ke3EhXhmaIU60vv\nB7eyDREbCV5/OiKZZypH21FFqg1eqCWEWNs+FvlIcAtPtfzksgmOlc1ZZa0QrgEr\nqtViIqQ1zRSELFW+Sl0=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 336,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3ee7dc0a46270f29a56ad048a1fe21c5665bd8e75e7f79c3b4a64cb48b30ff5faeadfb34f6e579be828a5458723e2d1669af9b690e2542919c5cadabdde5943400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3ee7dc0a46270f29a56ad048a1fe21c5665bd8e75e7f79c3b4a64cb48b30ff5faeadfb34f6e579be828a5458723e2d1669af9b690e2542919c5cadabdde59434aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10461db1d381085ddaddb58796829ca90069",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_brainpoolP512r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_brainpoolP512r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 557,
+  "numberOfTests": 559,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7939,6 +7939,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "30818502405522624724163b74c02b1951cc3603f834cf724c4c362df1299c63358fccf78faac1a3beb356d9e6be799ee68053efb8e24e2c7ef7a225224a78697d6356ff9a024100aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90066",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "brainpoolP512r1",
+        "keySize": 512,
+        "uncompressed": "04206b2ad718245aea23fcc88c8b1a199d56a20f6f10ce80a3816162fdebacde2d1e18ab725e5d01e36ec21844280ead44344eaafade7ffe47b71215e199a214eb4bef07b7b20d111b095e7f3a2299672a47db5145aa0d5ea8258458db3e16f948700b4fb5fce4b2098e95cd5965ad10ae012baad56222a435cd14842c55be4a5d",
+        "wx": "206b2ad718245aea23fcc88c8b1a199d56a20f6f10ce80a3816162fdebacde2d1e18ab725e5d01e36ec21844280ead44344eaafade7ffe47b71215e199a214eb",
+        "wy": "4bef07b7b20d111b095e7f3a2299672a47db5145aa0d5ea8258458db3e16f948700b4fb5fce4b2098e95cd5965ad10ae012baad56222a435cd14842c55be4a5d"
+      },
+      "publicKeyDer": "30819b301406072a8648ce3d020106092b240303020801010d0381820004206b2ad718245aea23fcc88c8b1a199d56a20f6f10ce80a3816162fdebacde2d1e18ab725e5d01e36ec21844280ead44344eaafade7ffe47b71215e199a214eb4bef07b7b20d111b095e7f3a2299672a47db5145aa0d5ea8258458db3e16f948700b4fb5fce4b2098e95cd5965ad10ae012baad56222a435cd14842c55be4a5d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEIGsq1xgkWuoj/MiMixoZnVai\nD28QzoCjgWFi/eus3i0eGKtyXl0B427CGEQoDq1ENE6q+t5//ke3EhXhmaIU60vv\nB7eyDREbCV5/OiKZZypH21FFqg1eqCWEWNs+FvlIcAtPtfzksgmOlc1ZZa0QrgEr\nqtViIqQ1zRSELFW+Sl0=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 558,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "305502403ee7dc0a46270f29a56ad048a1fe21c5665bd8e75e7f79c3b4a64cb48b30ff5faeadfb34f6e579be828a5458723e2d1669af9b690e2542919c5cadabdde5943402110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 559,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "30818502403ee7dc0a46270f29a56ad048a1fe21c5665bd8e75e7f79c3b4a64cb48b30ff5faeadfb34f6e579be828a5458723e2d1669af9b690e2542919c5cadabdde59434024100aadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10461db1d381085ddaddb58796829ca90069",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160k1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 222,
+  "numberOfTests": 224,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4140,6 +4140,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "00fffffffffffffffffffffffffffffffeffffac760100000000000000000001b8fa16dfab9aca16b6b0",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160k1",
+        "keySize": 160,
+        "uncompressed": "04174b3c3ed740cbe3fa7a2768892cea6ab3e4ed9660aa24c7c452e5bf7f87a8dbff8e6ba585c0dce1",
+        "wx": "174b3c3ed740cbe3fa7a2768892cea6ab3e4ed96",
+        "wy": "60aa24c7c452e5bf7f87a8dbff8e6ba585c0dce1"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040009032a0004174b3c3ed740cbe3fa7a2768892cea6ab3e4ed9660aa24c7c452e5bf7f87a8dbff8e6ba585c0dce1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEF0s8PtdAy+P6eidoiSzqarPk7ZZgqiTH\nxFLlv3+HqNv/jmulhcDc4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00f64abe157132e614590c1f3dd573c6e9d6f24465000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 224,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00f64abe157132e614590c1f3dd573c6e9d6f2446500ffffffff000000000001b8fa16dfab9aca16b6b3",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160k1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 445,
+  "numberOfTests": 447,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6402,6 +6402,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "302e021500fffffffffffffffffffffffffffffffeffffac7602150100000000000000000001b8fa16dfab9aca16b6b0",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160k1",
+        "keySize": 160,
+        "uncompressed": "04174b3c3ed740cbe3fa7a2768892cea6ab3e4ed9660aa24c7c452e5bf7f87a8dbff8e6ba585c0dce1",
+        "wx": "174b3c3ed740cbe3fa7a2768892cea6ab3e4ed96",
+        "wy": "60aa24c7c452e5bf7f87a8dbff8e6ba585c0dce1"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040009032a0004174b3c3ed740cbe3fa7a2768892cea6ab3e4ed9660aa24c7c452e5bf7f87a8dbff8e6ba585c0dce1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAkDKgAEF0s8PtdAy+P6eidoiSzqarPk7ZZgqiTH\nxFLlv3+HqNv/jmulhcDc4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 446,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "302a021500f64abe157132e614590c1f3dd573c6e9d6f2446502110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 447,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "302e021500f64abe157132e614590c1f3dd573c6e9d6f24465021500ffffffff000000000001b8fa16dfab9aca16b6b3",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 226,
+  "numberOfTests": 228,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4243,6 +4243,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "00ffffffffffffffffffffffffffffffff800000030100000000000000000001f4c8f927aed3ca752254",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r1",
+        "keySize": 160,
+        "uncompressed": "0438e974e6806ed396b0ad08cbd1cd1d21f608857d21dd9d59b27af25a3766438589b60e44c9fee90b",
+        "wx": "38e974e6806ed396b0ad08cbd1cd1d21f608857d",
+        "wy": "21dd9d59b27af25a3766438589b60e44c9fee90b"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040008032a000438e974e6806ed396b0ad08cbd1cd1d21f608857d21dd9d59b27af25a3766438589b60e44c9fee90b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEOOl05oBu05awrQjL0c0dIfYIhX0h3Z1Z\nsnryWjdmQ4WJtg5Eyf7pCw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 227,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00484bca2a60bb74b76167ac65a841eab791d1cc4d000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 228,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00484bca2a60bb74b76167ac65a841eab791d1cc4d00ffffffff000000000001f4c8f927aed3ca752257",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 448,
+  "numberOfTests": 450,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6493,6 +6493,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "302e021500ffffffffffffffffffffffffffffffff8000000302150100000000000000000001f4c8f927aed3ca752254",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r1",
+        "keySize": 160,
+        "uncompressed": "0438e974e6806ed396b0ad08cbd1cd1d21f608857d21dd9d59b27af25a3766438589b60e44c9fee90b",
+        "wx": "38e974e6806ed396b0ad08cbd1cd1d21f608857d",
+        "wy": "21dd9d59b27af25a3766438589b60e44c9fee90b"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b81040008032a000438e974e6806ed396b0ad08cbd1cd1d21f608857d21dd9d59b27af25a3766438589b60e44c9fee90b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAAgDKgAEOOl05oBu05awrQjL0c0dIfYIhX0h3Z1Z\nsnryWjdmQ4WJtg5Eyf7pCw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 449,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "30290214484bca2a60bb74b76167ac65a841eab791d1cc4d02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 450,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "302d0214484bca2a60bb74b76167ac65a841eab791d1cc4d021500ffffffff000000000001f4c8f927aed3ca752257",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp160r2_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 225,
+  "numberOfTests": 227,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4211,6 +4211,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "00fffffffffffffffffffffffffffffffeffffac760100000000000000000000351ee786a818f3a1a168",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r2",
+        "keySize": 160,
+        "uncompressed": "042397d090791e06aec7ad8cb0d2f421150554fe5479359f128aad04e37527ef5a94b5cd2143136264",
+        "wx": "2397d090791e06aec7ad8cb0d2f421150554fe54",
+        "wy": "79359f128aad04e37527ef5a94b5cd2143136264"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b8104001e032a00042397d090791e06aec7ad8cb0d2f421150554fe5479359f128aad04e37527ef5a94b5cd2143136264",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAEI5fQkHkeBq7HrYyw0vQhFQVU/lR5NZ8S\niq0E43Un71qUtc0hQxNiZA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 226,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "007f5e5c0aa986dc72d367a45ae778902868d4053c000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 227,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "007f5e5c0aa986dc72d367a45ae778902868d4053c00ffffffff000000000000351ee786a818f3a1a16b",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp160r2_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp160r2_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 448,
+  "numberOfTests": 450,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6467,6 +6467,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "302e021500fffffffffffffffffffffffffffffffeffffac7602150100000000000000000000351ee786a818f3a1a168",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp160r2",
+        "keySize": 160,
+        "uncompressed": "042397d090791e06aec7ad8cb0d2f421150554fe5479359f128aad04e37527ef5a94b5cd2143136264",
+        "wx": "2397d090791e06aec7ad8cb0d2f421150554fe54",
+        "wy": "79359f128aad04e37527ef5a94b5cd2143136264"
+      },
+      "publicKeyDer": "303e301006072a8648ce3d020106052b8104001e032a00042397d090791e06aec7ad8cb0d2f421150554fe5479359f128aad04e37527ef5a94b5cd2143136264",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMD4wEAYHKoZIzj0CAQYFK4EEAB4DKgAEI5fQkHkeBq7HrYyw0vQhFQVU/lR5NZ8S\niq0E43Un71qUtc0hQxNiZA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 449,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "302902147f5e5c0aa986dc72d367a45ae778902868d4053c02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 450,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "302d02147f5e5c0aa986dc72d367a45ae778902868d4053c021500ffffffff000000000000351ee786a818f3a1a16b",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp192k1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 226,
+  "numberOfTests": 228,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4257,6 +4257,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "000000000000000000000001d90d03e8f096b9958b210274fffffffffffffffffffffffe26f2fc170f69466a74defd8a",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "04e906708f4863c277e7baae5e4c058a5a2d493dc4ebf12fe95960a352e9db79341ba8717b70800b09218735b056b393cd",
+        "wx": "e906708f4863c277e7baae5e4c058a5a2d493dc4ebf12fe9",
+        "wy": "5960a352e9db79341ba8717b70800b09218735b056b393cd"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f03320004e906708f4863c277e7baae5e4c058a5a2d493dc4ebf12fe95960a352e9db79341ba8717b70800b09218735b056b393cd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAE6QZwj0hjwnfnuq5eTAWKWi1JPcTr8S/p\nWWCjUunbeTQbqHF7cIALCSGHNbBWs5PN\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 227,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "b42a6ed648cd4dcbf4e9c13c80a2be64efbaeab31234e59d000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 228,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "b42a6ed648cd4dcbf4e9c13c80a2be64efbaeab31234e59dfffffffffffffffefffffffe26f2fc170f69466a74defd8d",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp192k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp192k1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 450,
+  "numberOfTests": 452,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6531,6 +6531,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "302a020d01d90d03e8f096b9958b210274021900fffffffffffffffffffffffe26f2fc170f69466a74defd8a",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192k1",
+        "keySize": 192,
+        "uncompressed": "04e906708f4863c277e7baae5e4c058a5a2d493dc4ebf12fe95960a352e9db79341ba8717b70800b09218735b056b393cd",
+        "wx": "e906708f4863c277e7baae5e4c058a5a2d493dc4ebf12fe9",
+        "wy": "5960a352e9db79341ba8717b70800b09218735b056b393cd"
+      },
+      "publicKeyDer": "3046301006072a8648ce3d020106052b8104001f03320004e906708f4863c277e7baae5e4c058a5a2d493dc4ebf12fe95960a352e9db79341ba8717b70800b09218735b056b393cd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEYwEAYHKoZIzj0CAQYFK4EEAB8DMgAE6QZwj0hjwnfnuq5eTAWKWi1JPcTr8S/p\nWWCjUunbeTQbqHF7cIALCSGHNbBWs5PN\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 451,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "302e021900b42a6ed648cd4dcbf4e9c13c80a2be64efbaeab31234e59d02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 452,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3036021900b42a6ed648cd4dcbf4e9c13c80a2be64efbaeab31234e59d021900fffffffffffffffefffffffe26f2fc170f69466a74defd8d",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp192r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 228,
+  "numberOfTests": 230,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4317,6 +4317,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "000000000000000000000000662107c9eb94364e4b2dd7d1ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "04995e741eafa84ed82e5bf223b8124d431294d2ac4c856eba326744dba99b536399b0af0150dc33d6f6152f181e2fedc7",
+        "wx": "995e741eafa84ed82e5bf223b8124d431294d2ac4c856eba",
+        "wy": "326744dba99b536399b0af0150dc33d6f6152f181e2fedc7"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d03010103320004995e741eafa84ed82e5bf223b8124d431294d2ac4c856eba326744dba99b536399b0af0150dc33d6f6152f181e2fedc7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEmV50Hq+oTtguW/IjuBJNQxKU0qxM\nhW66MmdE26mbU2OZsK8BUNwz1vYVLxgeL+3H\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 229,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "139b649957b7440f64f8d2b9806dbd492926d8d192122702000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 230,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "139b649957b7440f64f8d2b9806dbd492926d8d192122702fffffffffffffffeffffffff99def836146bc9b1b4d22831",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp192r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp192r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 452,
+  "numberOfTests": 454,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6591,6 +6591,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "3029020c662107c9eb94364e4b2dd7d1021900ffffffffffffffffffffffff99def836146bc9b1b4d2282e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp192r1",
+        "keySize": 192,
+        "uncompressed": "04995e741eafa84ed82e5bf223b8124d431294d2ac4c856eba326744dba99b536399b0af0150dc33d6f6152f181e2fedc7",
+        "wx": "995e741eafa84ed82e5bf223b8124d431294d2ac4c856eba",
+        "wy": "326744dba99b536399b0af0150dc33d6f6152f181e2fedc7"
+      },
+      "publicKeyDer": "3049301306072a8648ce3d020106082a8648ce3d03010103320004995e741eafa84ed82e5bf223b8124d431294d2ac4c856eba326744dba99b536399b0af0150dc33d6f6152f181e2fedc7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEmV50Hq+oTtguW/IjuBJNQxKU0qxM\nhW66MmdE26mbU2OZsK8BUNwz1vYVLxgeL+3H\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 453,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "302d0218139b649957b7440f64f8d2b9806dbd492926d8d19212270202110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 454,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "30350218139b649957b7440f64f8d2b9806dbd492926d8d192122702021900fffffffffffffffeffffffff99def836146bc9b1b4d22831",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha224_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 195,
+  "numberOfTests": 197,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -3870,6 +3870,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56f010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "041f6566bd4aeedc05dd2b4360418ae46cbb5ac03937fe4c5e1899c08a9f1f90867f4d868883a972bdb7ff1db0ef8b912e5348e560158eba30",
+        "wx": "1f6566bd4aeedc05dd2b4360418ae46cbb5ac03937fe4c5e1899c08a",
+        "wy": "9f1f90867f4d868883a972bdb7ff1db0ef8b912e5348e560158eba30"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a00041f6566bd4aeedc05dd2b4360418ae46cbb5ac03937fe4c5e1899c08a9f1f90867f4d868883a972bdb7ff1db0ef8b912e5348e560158eba30",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEH2VmvUru3AXdK0NgQYrkbLtawDk3/kxe\nGJnAip8fkIZ/TYaIg6lyvbf/HbDvi5EuU0jlYBWOujA=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 196,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00940de249aeb45e09d57af872c6cde336280fa2428bd01e25a139a32f0000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 197,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00940de249aeb45e09d57af872c6cde336280fa2428bd01e25a139a32f00ffffffffffffffffffffffff0001dce8d2ec6184caf0a971769fb1f7",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224k1_sha224_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha224_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 416,
+  "numberOfTests": 418,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6110,6 +6110,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "303e021d00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56f021d010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "041f6566bd4aeedc05dd2b4360418ae46cbb5ac03937fe4c5e1899c08a9f1f90867f4d868883a972bdb7ff1db0ef8b912e5348e560158eba30",
+        "wx": "1f6566bd4aeedc05dd2b4360418ae46cbb5ac03937fe4c5e1899c08a",
+        "wy": "9f1f90867f4d868883a972bdb7ff1db0ef8b912e5348e560158eba30"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a00041f6566bd4aeedc05dd2b4360418ae46cbb5ac03937fe4c5e1899c08a9f1f90867f4d868883a972bdb7ff1db0ef8b912e5348e560158eba30",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEH2VmvUru3AXdK0NgQYrkbLtawDk3/kxe\nGJnAip8fkIZ/TYaIg6lyvbf/HbDvi5EuU0jlYBWOujA=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 417,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3032021d00940de249aeb45e09d57af872c6cde336280fa2428bd01e25a139a32f02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 418,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303e021d00940de249aeb45e09d57af872c6cde336280fa2428bd01e25a139a32f021d00ffffffffffffffffffffffff0001dce8d2ec6184caf0a971769fb1f7",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 224,
+  "numberOfTests": 226,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4164,6 +4164,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56f010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "04bd3a5371b3c8b9b9a063acdcd192bfe81a8c13a6ad8af15f31ae49099ee1a1120f2321886e13399072becdb43da55f8a41fa070620da2813",
+        "wx": "bd3a5371b3c8b9b9a063acdcd192bfe81a8c13a6ad8af15f31ae4909",
+        "wy": "9ee1a1120f2321886e13399072becdb43da55f8a41fa070620da2813"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a0004bd3a5371b3c8b9b9a063acdcd192bfe81a8c13a6ad8af15f31ae49099ee1a1120f2321886e13399072becdb43da55f8a41fa070620da2813",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEvTpTcbPIubmgY6zc0ZK/6BqME6ativFf\nMa5JCZ7hoRIPIyGIbhM5kHK+zbQ9pV+KQfoHBiDaKBM=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00940de249aeb45e09d57af872c6cde336280fa2428bd01e25a139a32f0000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 226,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "00940de249aeb45e09d57af872c6cde336280fa2428bd01e25a139a32f00ffffffffffffffffffffffff0001dce8d2ec6184caf0a971769fb1f7",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp224k1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 446,
+  "numberOfTests": 448,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6414,6 +6414,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "303e021d00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56f021d010000000000000000000000000001dce8d2ec6184caf0a971769fb1f4",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224k1",
+        "keySize": 224,
+        "uncompressed": "04bd3a5371b3c8b9b9a063acdcd192bfe81a8c13a6ad8af15f31ae49099ee1a1120f2321886e13399072becdb43da55f8a41fa070620da2813",
+        "wx": "bd3a5371b3c8b9b9a063acdcd192bfe81a8c13a6ad8af15f31ae4909",
+        "wy": "9ee1a1120f2321886e13399072becdb43da55f8a41fa070620da2813"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040020033a0004bd3a5371b3c8b9b9a063acdcd192bfe81a8c13a6ad8af15f31ae49099ee1a1120f2321886e13399072becdb43da55f8a41fa070620da2813",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACADOgAEvTpTcbPIubmgY6zc0ZK/6BqME6ativFf\nMa5JCZ7hoRIPIyGIbhM5kHK+zbQ9pV+KQfoHBiDaKBM=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 447,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3032021d00940de249aeb45e09d57af872c6cde336280fa2428bd01e25a139a32f02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 448,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303e021d00940de249aeb45e09d57af872c6cde336280fa2428bd01e25a139a32f021d00ffffffffffffffffffffffff0001dce8d2ec6184caf0a971769fb1f7",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha224_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 227,
+  "numberOfTests": 229,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4452,6 +4452,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "0000000000000000000000000000e95d1f470fc1ec22d6baa3a3d5c6ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "043c1269b201b9e9bfa9a6b37275e18165deffaeecff3730dab7b76fd894547d7f70b65f2c53d2e8c2ef3d46124f589403abdf381b8399251b",
+        "wx": "3c1269b201b9e9bfa9a6b37275e18165deffaeecff3730dab7b76fd8",
+        "wy": "94547d7f70b65f2c53d2e8c2ef3d46124f589403abdf381b8399251b"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00043c1269b201b9e9bfa9a6b37275e18165deffaeecff3730dab7b76fd894547d7f70b65f2c53d2e8c2ef3d46124f589403abdf381b8399251b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEPBJpsgG56b+pprNydeGBZd7/ruz/NzDa\nt7dv2JRUfX9wtl8sU9Lowu89RhJPWJQDq984G4OZJRs=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 228,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "96cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e00000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 229,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "96cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7efffffffffffffffffffffffeffff16a2e0b8f03e13dd29455c5c2a3d",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha224_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha224_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 450,
+  "numberOfTests": 452,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6714,6 +6714,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "3030020f00e95d1f470fc1ec22d6baa3a3d5c6021d00ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "043c1269b201b9e9bfa9a6b37275e18165deffaeecff3730dab7b76fd894547d7f70b65f2c53d2e8c2ef3d46124f589403abdf381b8399251b",
+        "wx": "3c1269b201b9e9bfa9a6b37275e18165deffaeecff3730dab7b76fd8",
+        "wy": "94547d7f70b65f2c53d2e8c2ef3d46124f589403abdf381b8399251b"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a00043c1269b201b9e9bfa9a6b37275e18165deffaeecff3730dab7b76fd894547d7f70b65f2c53d2e8c2ef3d46124f589403abdf381b8399251b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEPBJpsgG56b+pprNydeGBZd7/ruz/NzDa\nt7dv2JRUfX9wtl8sU9Lowu89RhJPWJQDq984G4OZJRs=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-224",
+      "tests": [
+        {
+          "tcId": 451,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3032021d0096cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 452,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303e021d0096cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e021d00fffffffffffffffffffffffeffff16a2e0b8f03e13dd29455c5c2a3d",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 256,
+  "numberOfTests": 258,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -4746,6 +4746,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "0000000000000000000000000000e95d1f470fc1ec22d6baa3a3d5c6ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04fd24ceb6236d962f8e30f5874cd527ec548cd2e518d5ac4d3635b1457cdf47f994d1eb8f87577dd47b0726711e234996051ba3f074a322c7",
+        "wx": "fd24ceb6236d962f8e30f5874cd527ec548cd2e518d5ac4d3635b145",
+        "wy": "7cdf47f994d1eb8f87577dd47b0726711e234996051ba3f074a322c7"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004fd24ceb6236d962f8e30f5874cd527ec548cd2e518d5ac4d3635b1457cdf47f994d1eb8f87577dd47b0726711e234996051ba3f074a322c7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE/STOtiNtli+OMPWHTNUn7FSM0uUY1axN\nNjWxRXzfR/mU0euPh1d91HsHJnEeI0mWBRuj8HSjIsc=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 257,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "96cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e00000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 258,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "96cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7efffffffffffffffffffffffeffff16a2e0b8f03e13dd29455c5c2a3d",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 479,
+  "numberOfTests": 481,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7003,6 +7003,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "3030020f00e95d1f470fc1ec22d6baa3a3d5c6021d00ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04fd24ceb6236d962f8e30f5874cd527ec548cd2e518d5ac4d3635b1457cdf47f994d1eb8f87577dd47b0726711e234996051ba3f074a322c7",
+        "wx": "fd24ceb6236d962f8e30f5874cd527ec548cd2e518d5ac4d3635b145",
+        "wy": "7cdf47f994d1eb8f87577dd47b0726711e234996051ba3f074a322c7"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004fd24ceb6236d962f8e30f5874cd527ec548cd2e518d5ac4d3635b1457cdf47f994d1eb8f87577dd47b0726711e234996051ba3f074a322c7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAE/STOtiNtli+OMPWHTNUn7FSM0uUY1axN\nNjWxRXzfR/mU0euPh1d91HsHJnEeI0mWBRuj8HSjIsc=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 480,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3032021d0096cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 481,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303e021d0096cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e021d00fffffffffffffffffffffffeffff16a2e0b8f03e13dd29455c5c2a3d",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 325,
+  "numberOfTests": 327,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5436,6 +5436,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "0000000000000000000000000000e95d1f470fc1ec22d6baa3a3d5c6ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04c31a7b09080e7d8b6bdcd6635f8e8d032ff7167e6e0293518428a99c2634e41847b4c741b2a518f1de804fd2334193ab078609535662802f",
+        "wx": "c31a7b09080e7d8b6bdcd6635f8e8d032ff7167e6e0293518428a99c",
+        "wy": "2634e41847b4c741b2a518f1de804fd2334193ab078609535662802f"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004c31a7b09080e7d8b6bdcd6635f8e8d032ff7167e6e0293518428a99c2634e41847b4c741b2a518f1de804fd2334193ab078609535662802f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEwxp7CQgOfYtr3NZjX46NAy/3Fn5uApNR\nhCipnCY05BhHtMdBsqUY8d6AT9IzQZOrB4YJU1ZigC8=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 326,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "96cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e00000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "96cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7efffffffffffffffffffffffeffff16a2e0b8f03e13dd29455c5c2a3d",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp224r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp224r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 548,
+  "numberOfTests": 550,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7698,6 +7698,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "3030020f00e95d1f470fc1ec22d6baa3a3d5c6021d00ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3a",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp224r1",
+        "keySize": 224,
+        "uncompressed": "04c31a7b09080e7d8b6bdcd6635f8e8d032ff7167e6e0293518428a99c2634e41847b4c741b2a518f1de804fd2334193ab078609535662802f",
+        "wx": "c31a7b09080e7d8b6bdcd6635f8e8d032ff7167e6e0293518428a99c",
+        "wy": "2634e41847b4c741b2a518f1de804fd2334193ab078609535662802f"
+      },
+      "publicKeyDer": "304e301006072a8648ce3d020106052b81040021033a0004c31a7b09080e7d8b6bdcd6635f8e8d032ff7167e6e0293518428a99c2634e41847b4c741b2a518f1de804fd2334193ab078609535662802f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nME4wEAYHKoZIzj0CAQYFK4EEACEDOgAEwxp7CQgOfYtr3NZjX46NAy/3Fn5uApNR\nhCipnCY05BhHtMdBsqUY8d6AT9IzQZOrB4YJU1ZigC8=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 549,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3032021d0096cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e02110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 550,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303e021d0096cd1b74f0be055d2d35ba25d70b0f75a5ab5d3faee363652224cc7e021d00fffffffffffffffffffffffeffff16a2e0b8f03e13dd29455c5c2a3d",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 250,
+  "numberOfTests": 252,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5453,6 +5453,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "000000000000000000000000000000014551231950b75fc4402da1732fc9bec0fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04315971a60089e7749a8fa1d8374ecbaab259d773b3737e932bbaa960cdbf27f1bfe600bd60a91e650508eab795146b13c766195a447b24709df9d1c561e53dae",
+        "wx": "315971a60089e7749a8fa1d8374ecbaab259d773b3737e932bbaa960cdbf27f1",
+        "wy": "bfe600bd60a91e650508eab795146b13c766195a447b24709df9d1c561e53dae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004315971a60089e7749a8fa1d8374ecbaab259d773b3737e932bbaa960cdbf27f1bfe600bd60a91e650508eab795146b13c766195a447b24709df9d1c561e53dae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMVlxpgCJ53Saj6HYN07LqrJZ13Ozc36T\nK7qpYM2/J/G/5gC9YKkeZQUI6reVFGsTx2YZWkR7JHCd+dHFYeU9rg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 251,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "2b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef220000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 252,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "2b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef22fffffffffffffffffffffffffffffffdbaaedce6af48a03bbfd25e8cd0364141",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 474,
+  "numberOfTests": 476,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7034,6 +7034,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "30360211014551231950b75fc4402da1732fc9bec0022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04315971a60089e7749a8fa1d8374ecbaab259d773b3737e932bbaa960cdbf27f1bfe600bd60a91e650508eab795146b13c766195a447b24709df9d1c561e53dae",
+        "wx": "315971a60089e7749a8fa1d8374ecbaab259d773b3737e932bbaa960cdbf27f1",
+        "wy": "bfe600bd60a91e650508eab795146b13c766195a447b24709df9d1c561e53dae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004315971a60089e7749a8fa1d8374ecbaab259d773b3737e932bbaa960cdbf27f1bfe600bd60a91e650508eab795146b13c766195a447b24709df9d1c561e53dae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMVlxpgCJ53Saj6HYN07LqrJZ13Ozc36T\nK7qpYM2/J/G/5gC9YKkeZQUI6reVFGsTx2YZWkR7JHCd+dHFYeU9rg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 475,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303502202b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef2202110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 476,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502202b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef22022100fffffffffffffffffffffffffffffffdbaaedce6af48a03bbfd25e8cd0364141",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 320,
+  "numberOfTests": 322,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -6157,6 +6157,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "000000000000000000000000000000014551231950b75fc4402da1732fc9bec0fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9",
+        "wx": "935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e",
+        "wy": "3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk1q37bwhy0zLOv1rY9N0D2LZikGXXl5u\ng218mQ0Xen4+w9Y3fN0wIbYXbSbD0ZmdbY/o+5vXBRtJCNFgi5qxqQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 321,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "2b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef220000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "2b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef22fffffffffffffffffffffffffffffffdbaaedce6af48a03bbfd25e8cd0364141",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256k1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp256k1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 544,
+  "numberOfTests": 546,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7738,6 +7738,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "30360211014551231950b75fc4402da1732fc9bec0022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9",
+        "wx": "935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e",
+        "wy": "3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk1q37bwhy0zLOv1rY9N0D2LZikGXXl5u\ng218mQ0Xen4+w9Y3fN0wIbYXbSbD0ZmdbY/o+5vXBRtJCNFgi5qxqQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 545,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303502202b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef2202110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 546,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502202b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef22022100fffffffffffffffffffffffffffffffdbaaedce6af48a03bbfd25e8cd0364141",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha256_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 260,
+  "numberOfTests": 262,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5667,6 +5667,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "00000000ffffffff00000000000000004319055258e8617b0c46353d039cdab4ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046955a72c0dad4ed60356f7692649b951fa8ea474bf1cc9549b96c68de4782dfae012ffc24e92c72be71ff2622ee7e549dcb59e7b708f6921c4d4ea29512e2aba",
+        "wx": "6955a72c0dad4ed60356f7692649b951fa8ea474bf1cc9549b96c68de4782dfa",
+        "wy": "e012ffc24e92c72be71ff2622ee7e549dcb59e7b708f6921c4d4ea29512e2aba"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046955a72c0dad4ed60356f7692649b951fa8ea474bf1cc9549b96c68de4782dfae012ffc24e92c72be71ff2622ee7e549dcb59e7b708f6921c4d4ea29512e2aba",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaVWnLA2tTtYDVvdpJkm5UfqOpHS/\nHMlUm5bGjeR4LfrgEv/CTpLHK+cf8mIu5+VJ3LWee3CPaSHE1OopUS4qug==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 261,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "5f6d3aa0d327c13702513d4299f297ab182fcf670f96291fab19572e7a6e01c40000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 262,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "5f6d3aa0d327c13702513d4299f297ab182fcf670f96291fab19572e7a6e01c4ffffffff00000000fffffffffffffffebce6faada7179e84f3b9cac2fc632551",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 482,
+  "numberOfTests": 484,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7196,6 +7196,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "3042021d00ffffffff00000000000000004319055258e8617b0c46353d039cdab4022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "046955a72c0dad4ed60356f7692649b951fa8ea474bf1cc9549b96c68de4782dfae012ffc24e92c72be71ff2622ee7e549dcb59e7b708f6921c4d4ea29512e2aba",
+        "wx": "6955a72c0dad4ed60356f7692649b951fa8ea474bf1cc9549b96c68de4782dfa",
+        "wy": "e012ffc24e92c72be71ff2622ee7e549dcb59e7b708f6921c4d4ea29512e2aba"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d030107034200046955a72c0dad4ed60356f7692649b951fa8ea474bf1cc9549b96c68de4782dfae012ffc24e92c72be71ff2622ee7e549dcb59e7b708f6921c4d4ea29512e2aba",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaVWnLA2tTtYDVvdpJkm5UfqOpHS/\nHMlUm5bGjeR4LfrgEv/CTpLHK+cf8mIu5+VJ3LWee3CPaSHE1OopUS4qug==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 483,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303502205f6d3aa0d327c13702513d4299f297ab182fcf670f96291fab19572e7a6e01c402110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 484,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502205f6d3aa0d327c13702513d4299f297ab182fcf670f96291fab19572e7a6e01c4022100ffffffff00000000fffffffffffffffebce6faada7179e84f3b9cac2fc632551",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 330,
+  "numberOfTests": 332,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -6371,6 +6371,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "00000000ffffffff00000000000000004319055258e8617b0c46353d039cdab4ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0443ee8fee3c942a8a28caa347e532481778fef03835cbdbfcf20727f97ea8a30e8a1930ff6cd357b864a454b70c27989265da529a9e45623a9fa364b2bd21230e",
+        "wx": "43ee8fee3c942a8a28caa347e532481778fef03835cbdbfcf20727f97ea8a30e",
+        "wy": "8a1930ff6cd357b864a454b70c27989265da529a9e45623a9fa364b2bd21230e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000443ee8fee3c942a8a28caa347e532481778fef03835cbdbfcf20727f97ea8a30e8a1930ff6cd357b864a454b70c27989265da529a9e45623a9fa364b2bd21230e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQ+6P7jyUKoooyqNH5TJIF3j+8Dg1\ny9v88gcn+X6oow6KGTD/bNNXuGSkVLcMJ5iSZdpSmp5FYjqfo2SyvSEjDg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 331,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "5f6d3aa0d327c13702513d4299f297ab182fcf670f96291fab19572e7a6e01c40000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "5f6d3aa0d327c13702513d4299f297ab182fcf670f96291fab19572e7a6e01c4ffffffff00000000fffffffffffffffebce6faada7179e84f3b9cac2fc632551",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp256r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp256r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 552,
+  "numberOfTests": 554,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7900,6 +7900,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "3042021d00ffffffff00000000000000004319055258e8617b0c46353d039cdab4022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256r1",
+        "keySize": 256,
+        "uncompressed": "0443ee8fee3c942a8a28caa347e532481778fef03835cbdbfcf20727f97ea8a30e8a1930ff6cd357b864a454b70c27989265da529a9e45623a9fa364b2bd21230e",
+        "wx": "43ee8fee3c942a8a28caa347e532481778fef03835cbdbfcf20727f97ea8a30e",
+        "wy": "8a1930ff6cd357b864a454b70c27989265da529a9e45623a9fa364b2bd21230e"
+      },
+      "publicKeyDer": "3059301306072a8648ce3d020106082a8648ce3d0301070342000443ee8fee3c942a8a28caa347e532481778fef03835cbdbfcf20727f97ea8a30e8a1930ff6cd357b864a454b70c27989265da529a9e45623a9fa364b2bd21230e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQ+6P7jyUKoooyqNH5TJIF3j+8Dg1\ny9v88gcn+X6oow6KGTD/bNNXuGSkVLcMJ5iSZdpSmp5FYjqfo2SyvSEjDg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 553,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303502205f6d3aa0d327c13702513d4299f297ab182fcf670f96291fab19572e7a6e01c402110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 554,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502205f6d3aa0d327c13702513d4299f297ab182fcf670f96291fab19572e7a6e01c4022100ffffffff00000000fffffffffffffffebce6faada7179e84f3b9cac2fc632551",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha256_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha256_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 470,
+  "numberOfTests": 472,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -6914,6 +6914,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "304d0218389cb27e0bc8d220a7e5f24db74f58851313e695333ad68f023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "040e366e9880ccff2eb5c6c90dedefcaebb566d9fc3812045ffc3a6bab9a8f1c3f16709aeb4dfcc85f1513a0ef7b2ef7e15f6181d0b09a22a3721ad567b04866de93868677cef994b5a3f897756e68d798f797cdc15d337b6a368868b34f9b0e56",
+        "wx": "0e366e9880ccff2eb5c6c90dedefcaebb566d9fc3812045ffc3a6bab9a8f1c3f16709aeb4dfcc85f1513a0ef7b2ef7e1",
+        "wy": "5f6181d0b09a22a3721ad567b04866de93868677cef994b5a3f897756e68d798f797cdc15d337b6a368868b34f9b0e56"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200040e366e9880ccff2eb5c6c90dedefcaebb566d9fc3812045ffc3a6bab9a8f1c3f16709aeb4dfcc85f1513a0ef7b2ef7e15f6181d0b09a22a3721ad567b04866de93868677cef994b5a3f897756e68d798f797cdc15d337b6a368868b34f9b0e56",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEDjZumIDM/y61xskN7e/K67Vm2fw4EgRf\n/Dprq5qPHD8WcJrrTfzIXxUToO97LvfhX2GB0LCaIqNyGtVnsEhm3pOGhnfO+ZS1\no/iXdW5o15j3l83BXTN7ajaIaLNPmw5W\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-256",
+      "tests": [
+        {
+          "tcId": 471,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502304fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d702110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 472,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "306502304fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d7023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372dde581a0db248b0a77aecec196accc52973",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha384_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 278,
+  "numberOfTests": 280,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -5625,6 +5625,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "000000000000000000000000000000000000000000000000389cb27e0bc8d220a7e5f24db74f58851313e695333ad68fffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "040a2fc2edd21336babc59da04aa566dc9b6b068162f7970e311136883b61be8f894da03cc8e93a64803d4f4f83a19c1b973076220bf4d40aa9a41cacbafbd32d1f0bd183c327153cd6601bfa81d5e2ec21c0ecc517e004dd3fbedeca7f975a9ed",
+        "wx": "0a2fc2edd21336babc59da04aa566dc9b6b068162f7970e311136883b61be8f894da03cc8e93a64803d4f4f83a19c1b9",
+        "wy": "73076220bf4d40aa9a41cacbafbd32d1f0bd183c327153cd6601bfa81d5e2ec21c0ecc517e004dd3fbedeca7f975a9ed"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200040a2fc2edd21336babc59da04aa566dc9b6b068162f7970e311136883b61be8f894da03cc8e93a64803d4f4f83a19c1b973076220bf4d40aa9a41cacbafbd32d1f0bd183c327153cd6601bfa81d5e2ec21c0ecc517e004dd3fbedeca7f975a9ed",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECi/C7dITNrq8WdoEqlZtybawaBYveXDj\nERNog7Yb6PiU2gPMjpOmSAPU9Pg6GcG5cwdiIL9NQKqaQcrLr70y0fC9GDwycVPN\nZgG/qB1eLsIcDsxRfgBN0/vt7Kf5dant\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 279,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "4fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d7000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 280,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "4fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d7ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372dde581a0db248b0a77aecec196accc52973",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha384_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha384_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 502,
+  "numberOfTests": 504,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7234,6 +7234,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "304d0218389cb27e0bc8d220a7e5f24db74f58851313e695333ad68f023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "040a2fc2edd21336babc59da04aa566dc9b6b068162f7970e311136883b61be8f894da03cc8e93a64803d4f4f83a19c1b973076220bf4d40aa9a41cacbafbd32d1f0bd183c327153cd6601bfa81d5e2ec21c0ecc517e004dd3fbedeca7f975a9ed",
+        "wx": "0a2fc2edd21336babc59da04aa566dc9b6b068162f7970e311136883b61be8f894da03cc8e93a64803d4f4f83a19c1b9",
+        "wy": "73076220bf4d40aa9a41cacbafbd32d1f0bd183c327153cd6601bfa81d5e2ec21c0ecc517e004dd3fbedeca7f975a9ed"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b81040022036200040a2fc2edd21336babc59da04aa566dc9b6b068162f7970e311136883b61be8f894da03cc8e93a64803d4f4f83a19c1b973076220bf4d40aa9a41cacbafbd32d1f0bd183c327153cd6601bfa81d5e2ec21c0ecc517e004dd3fbedeca7f975a9ed",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECi/C7dITNrq8WdoEqlZtybawaBYveXDj\nERNog7Yb6PiU2gPMjpOmSAPU9Pg6GcG5cwdiIL9NQKqaQcrLr70y0fC9GDwycVPN\nZgG/qB1eLsIcDsxRfgBN0/vt7Kf5dant\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-384",
+      "tests": [
+        {
+          "tcId": 503,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502304fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d702110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 504,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "306502304fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d7023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372dde581a0db248b0a77aecec196accc52973",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 316,
+  "numberOfTests": 318,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -6009,6 +6009,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "000000000000000000000000000000000000000000000000389cb27e0bc8d220a7e5f24db74f58851313e695333ad68fffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04318a473b7655b4b3b72f79d95682c4e4b67b28b341a7bfb75bdcd61f116adcfe16793b7124959c28be8ee68e026c79226e08c57dc616c96c995167854ce73c845163f4dddea86fea7469cf632261793f7ba0681035bade21bbc3d45c32a5b7e8",
+        "wx": "318a473b7655b4b3b72f79d95682c4e4b67b28b341a7bfb75bdcd61f116adcfe16793b7124959c28be8ee68e026c7922",
+        "wy": "6e08c57dc616c96c995167854ce73c845163f4dddea86fea7469cf632261793f7ba0681035bade21bbc3d45c32a5b7e8"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004318a473b7655b4b3b72f79d95682c4e4b67b28b341a7bfb75bdcd61f116adcfe16793b7124959c28be8ee68e026c79226e08c57dc616c96c995167854ce73c845163f4dddea86fea7469cf632261793f7ba0681035bade21bbc3d45c32a5b7e8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEMYpHO3ZVtLO3L3nZVoLE5LZ7KLNBp7+3\nW9zWHxFq3P4WeTtxJJWcKL6O5o4CbHkibgjFfcYWyWyZUWeFTOc8hFFj9N3eqG/q\ndGnPYyJheT97oGgQNbreIbvD1Fwypbfo\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 317,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "4fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d7000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "4fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d7ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372dde581a0db248b0a77aecec196accc52973",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp384r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp384r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 540,
+  "numberOfTests": 542,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7618,6 +7618,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "304d0218389cb27e0bc8d220a7e5f24db74f58851313e695333ad68f023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp384r1",
+        "keySize": 384,
+        "uncompressed": "04318a473b7655b4b3b72f79d95682c4e4b67b28b341a7bfb75bdcd61f116adcfe16793b7124959c28be8ee68e026c79226e08c57dc616c96c995167854ce73c845163f4dddea86fea7469cf632261793f7ba0681035bade21bbc3d45c32a5b7e8",
+        "wx": "318a473b7655b4b3b72f79d95682c4e4b67b28b341a7bfb75bdcd61f116adcfe16793b7124959c28be8ee68e026c7922",
+        "wy": "6e08c57dc616c96c995167854ce73c845163f4dddea86fea7469cf632261793f7ba0681035bade21bbc3d45c32a5b7e8"
+      },
+      "publicKeyDer": "3076301006072a8648ce3d020106052b8104002203620004318a473b7655b4b3b72f79d95682c4e4b67b28b341a7bfb75bdcd61f116adcfe16793b7124959c28be8ee68e026c79226e08c57dc616c96c995167854ce73c845163f4dddea86fea7469cf632261793f7ba0681035bade21bbc3d45c32a5b7e8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEMYpHO3ZVtLO3L3nZVoLE5LZ7KLNBp7+3\nW9zWHxFq3P4WeTtxJJWcKL6O5o4CbHkibgjFfcYWyWyZUWeFTOc8hFFj9N3eqG/q\ndGnPYyJheT97oGgQNbreIbvD1Fwypbfo\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 541,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502304fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d702110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 542,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "306502304fd5dd99138e6f1002d2d23591b2f94071a7f5ad49ddb970dc859275bfe51f193470d443e793196901e88bbe749614d7023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372dde581a0db248b0a77aecec196accc52973",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha512_p1363_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_p1363_verify_schema_v1.json",
-  "numberOfTests": 316,
+  "numberOfTests": 318,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of IEEE P1363 encoded ECDSA signatures."
@@ -6086,6 +6086,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "00000000000000000000000000000000000000000000000000000000000000000005ae79787c40d069948033feb708f65a2fc44a36477663b851449048e16ec79bf801fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "0401977819459a734b2cbee8f467e149058cb475ae33635708cf0e84d36bb993d30d4c84b8fea8b268775d30fa709525ef2cebf2aabcc0bccc377044ce8b46a8ccb188012679a509aba331c3ffe21fcd804705cef2496c47a553e8d442ea4c4e057ba9f965cd5fbf139ecc09cbb52c4918a057e6a2ca0dfab9eaa94c00f5ac11899bf76108",
+        "wx": "01977819459a734b2cbee8f467e149058cb475ae33635708cf0e84d36bb993d30d4c84b8fea8b268775d30fa709525ef2cebf2aabcc0bccc377044ce8b46a8ccb188",
+        "wy": "012679a509aba331c3ffe21fcd804705cef2496c47a553e8d442ea4c4e057ba9f965cd5fbf139ecc09cbb52c4918a057e6a2ca0dfab9eaa94c00f5ac11899bf76108"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b81040023038186000401977819459a734b2cbee8f467e149058cb475ae33635708cf0e84d36bb993d30d4c84b8fea8b268775d30fa709525ef2cebf2aabcc0bccc377044ce8b46a8ccb188012679a509aba331c3ffe21fcd804705cef2496c47a553e8d442ea4c4e057ba9f965cd5fbf139ecc09cbb52c4918a057e6a2ca0dfab9eaa94c00f5ac11899bf76108",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBl3gZRZpzSyy+6PRn4UkFjLR1rjNj\nVwjPDoTTa7mT0w1MhLj+qLJod10w+nCVJe8s6/KqvMC8zDdwRM6LRqjMsYgBJnml\nCaujMcP/4h/NgEcFzvJJbEelU+jUQupMTgV7qfllzV+/E57MCcu1LEkYoFfmosoN\n+rnqqUwA9awRiZv3YQg=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 317,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "016566c3ecc96e5651b34620c2a91c28423affa5404f9e2d3d988834bbe09ee10feaaddd52e69303d0c9d4e2c86d2abdf112e848b95da38f504de67dba3fd89378d5000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "016566c3ecc96e5651b34620c2a91c28423affa5404f9e2d3d988834bbe09ee10feaaddd52e69303d0c9d4e2c86d2abdf112e848b95da38f504de67dba3fd89378d501fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5cf3bb5c9b8899c47aebb6fb71e91386409",
+          "result": "valid"
         }
       ]
     }

--- a/testvectors_v1/ecdsa_secp521r1_sha512_test.json
+++ b/testvectors_v1/ecdsa_secp521r1_sha512_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_verify_schema_v1.json",
-  "numberOfTests": 540,
+  "numberOfTests": 542,
   "header": [
     "Test vectors of type EcdsaVerify are meant for the verification",
     "of ASN encoded ECDSA signatures."
@@ -7669,6 +7669,46 @@
           "msg": "68656c6c6f2c20776f726c64",
           "sig": "3067022105ae79787c40d069948033feb708f65a2fc44a36477663b851449048e16ec79bf8024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
           "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp521r1",
+        "keySize": 521,
+        "uncompressed": "0401977819459a734b2cbee8f467e149058cb475ae33635708cf0e84d36bb993d30d4c84b8fea8b268775d30fa709525ef2cebf2aabcc0bccc377044ce8b46a8ccb188012679a509aba331c3ffe21fcd804705cef2496c47a553e8d442ea4c4e057ba9f965cd5fbf139ecc09cbb52c4918a057e6a2ca0dfab9eaa94c00f5ac11899bf76108",
+        "wx": "01977819459a734b2cbee8f467e149058cb475ae33635708cf0e84d36bb993d30d4c84b8fea8b268775d30fa709525ef2cebf2aabcc0bccc377044ce8b46a8ccb188",
+        "wy": "012679a509aba331c3ffe21fcd804705cef2496c47a553e8d442ea4c4e057ba9f965cd5fbf139ecc09cbb52c4918a057e6a2ca0dfab9eaa94c00f5ac11899bf76108"
+      },
+      "publicKeyDer": "30819b301006072a8648ce3d020106052b81040023038186000401977819459a734b2cbee8f467e149058cb475ae33635708cf0e84d36bb993d30d4c84b8fea8b268775d30fa709525ef2cebf2aabcc0bccc377044ce8b46a8ccb188012679a509aba331c3ffe21fcd804705cef2496c47a553e8d442ea4c4e057ba9f965cd5fbf139ecc09cbb52c4918a057e6a2ca0dfab9eaa94c00f5ac11899bf76108",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBl3gZRZpzSyy+6PRn4UkFjLR1rjNj\nVwjPDoTTa7mT0w1MhLj+qLJod10w+nCVJe8s6/KqvMC8zDdwRM6LRqjMsYgBJnml\nCaujMcP/4h/NgEcFzvJJbEelU+jUQupMTgV7qfllzV+/E57MCcu1LEkYoFfmosoN\n+rnqqUwA9awRiZv3YQg=\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 541,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "30570242016566c3ecc96e5651b34620c2a91c28423affa5404f9e2d3d988834bbe09ee10feaaddd52e69303d0c9d4e2c86d2abdf112e848b95da38f504de67dba3fd89378d502110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 542,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3081880242016566c3ecc96e5651b34620c2a91c28423affa5404f9e2d3d988834bbe09ee10feaaddd52e69303d0c9d4e2c86d2abdf112e848b95da38f504de67dba3fd89378d5024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5cf3bb5c9b8899c47aebb6fb71e91386409",
+          "result": "valid"
         }
       ]
     }


### PR DESCRIPTION
If you implement ECDSA verify with a binary extended Euclidean algorithm, large powers of 2 can be an interesting case.

Tests generated with the following script. (PS: @pornin I remembered to do P1363 this time. :wink: )

<details>
<summary>ecdsa_s_pow2.py</summary>

```
import base64
import hashlib
import json
import random

# Go's crypto/elliptic would normally be easier for this, but it only supports
# a = -3. We may as well get all the curves. No optimizations, except Jacobian
# coordinates because the inversion is too expensive.

# Too lazy to write % all the time.
class ModP:
    def __init__(self, value, p):
        assert 0 <= value < p
        assert p & 1
        self.value = value
        self.p = p

    def inv(self):
        if self.value == 0:
            raise ZeroDivisionError()
        return self ** (self.p - 2)

    def _unpack(self, other):
        assert other.p == self.p
        return other.value

    def __add__(self, other):
        return ModP((self.value + self._unpack(other)) % self.p, self.p)

    def __sub__(self, other):
        return ModP((self.value - self._unpack(other)) % self.p, self.p)

    def __mul__(self, other):
        return ModP((self.value * self._unpack(other)) % self.p, self.p)

    def __truediv__(self, other):
        assert self.p == other.p
        return self * other.inv()

    def __neg__(self):
        return ModP((-self.value) % self.p, self.p)

    def __pow__(self, exp):
        return ModP(pow(self.value, exp, self.p), self.p)

    def __eq__(self, other):
        assert self.p == other.p
        return self.value == other.value

    def has_sqrt(self):
        if self.value == 0:
            return True
        # Euler's criterion
        return pow(self.value, (self.p - 1) // 2, self.p) == 1

    def sqrt(self):
        assert self.has_sqrt()
        # Tonelli–Shanks. For reasonable curves, square roots are much more
        # straightforward, but P-224 is (uniquely) horrible, so just use the
        # generic algorithm.
        # https://en.wikipedia.org/wiki/Tonelli%E2%80%93Shanks_algorithm#The_algorithm
        q, s = self.p - 1, 0
        while q & 1 == 0:
            q >>= 1
            s += 1
        # Find a quadratic non-residue.
        while True:
            z = ModP(random.randint(1, self.p - 1), self.p)
            if not z.has_sqrt():
                break
        m = s
        c = z ** q
        t = self ** q
        r = self ** ((q + 1) // 2)
        while True:
            if t.value == 0:
                assert self.value == 0
                return ModP(0, self.p)
            if t.value == 1:
                assert r ** 2 == self
                return r
            # Find smallest i such that t**(2**i) == 1.
            tmp = t
            for i in range(1, m):
                tmp *= tmp
                if tmp.value == 1:
                    break
            assert tmp.value == 1
            # b = c**(2**(m-i-1)), or square it m - i - 1 times.
            b = c
            for _ in range(m - i - 1):
                b *= b
            m = i
            c = b * b
            t *= c
            r *= b

class InvalidCompressedPoint(Exception): pass

class Curve:
    def __init__(self, name, p, a, b, gx, gy, n):
        self.name = name
        self.p = p
        self.a = self.felem(a)
        self.b = self.felem(b)
        self.g = self.affine(gx, gy)
        self.n = n

    def felem(self, x):
        return ModP(x, self.p)

    def scalar(self, x):
        return ModP(x, self.n)

    def infinity(self):
        return Point(self, self.felem(0), self.felem(0), self.felem(0))

    def affine(self, x, y):
        return Point(self, self.felem(x), self.felem(y), self.felem(1))

    def compressed(self, x, y_bit=0):
        assert y_bit in (0, 1)
        x = self.felem(x)
        y2 = (x**3 + self.a * x + self.b)
        if not y2.has_sqrt():
            raise InvalidCompressedPoint()
        y = y2.sqrt()
        if y_bit != (y.value & 1):
            y = -y
        return Point(self, x, y, self.felem(1))

class Point:
    def __init__(self, curve, x, y, z):
        # (Y/Z^3)^2 = (X/Z^2)^3 + a(X/Z^2) + b
        # Y^2 / Z^6 = X^3 / Z^6 + a X / Z^2 + b
        # Y^2 = X^3 + a X Z^4 + b Z^6
        assert z.value == 0 or y**2 == x**3 + curve.a * x * z**4 + curve.b * z**6
        self.curve = curve
        self.x = x
        self.y = y
        self.z = z

    def __repr__(self):
        if self.is_infinity():
            return f"{self.curve.name}.infinity()"
        x, y = self.affine()
        return f"{self.curve.name}.affine(0x{x.value:x}, 0x{y.value:x})"

    def is_infinity(self):
        return self.z.value == 0

    def affine(self):
        assert not self.is_infinity()
        return self.x / self.z**2, self.y / self.z**3

    def __add__(self, other):
        assert isinstance(other, Point)
        assert self.curve == other.curve
        if self.is_infinity():
            return other
        if other.is_infinity():
            return self
        a = self.curve.a
        # Point formulas are transcribed a little sloppily and should have some
        # strength reductions. E.g. the constant multiplications should be
        # additions. But this is fast enough for these purposes.
        x1, y1, z1 = self.x, self.y, self.z
        x2, y2, z2 = other.x, other.y, other.z
        if x1 * z2 * z2 == x2 * z1 * z1:
            # https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian.html#doubling-dbl-2007-bl
            two = self.curve.felem(2)
            three = self.curve.felem(3)
            eight = self.curve.felem(8)
            xx = x1*x1
            yy = y1*y1
            yyyy = yy*yy
            zz = z1*z1
            s = two*((x1+yy)**2-xx-yyyy)
            m = three*xx+a*zz*zz
            t = m*m-two*s
            x3 = t
            y3 = m*(s-t)-eight*yyyy
            z3 = (y1+z1)**2-yy-zz
            return Point(self.curve, x3, y3, z3)

        # https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian.html#addition-add-2007-bl
        two = self.curve.felem(2)
        z1z1 = z1*z1
        z2z2 = z2*z2
        u1 = x1*z2z2
        u2 = x2*z1z1
        s1 = y1*z2*z2z2
        s2 = y2*z1*z1z1
        h = u2-u1
        i = (two*h)**2
        j = h*i
        r = two*(s2-s1)
        v = u1*i
        x3 = r*r-j-two*v
        y3 = r*(v-x3)-two*s1*j
        z3 = ((z1+z2)**2-z1z1-z2z2)*h
        return Point(self.curve, x3, y3, z3)

    def __sub__(self, other):
        return self + (-other)

    def __neg__(self):
        if self.is_infinity():
            return self
        return Point(self.curve, self.x, -self.y, self.z)

    def __mul__(self, scalar):
        assert scalar.p == self.curve.n
        scalar = scalar.value
        ret = self.curve.infinity()
        for i in reversed(range(scalar.bit_length())):
            ret += ret
            if scalar & (1 << i):
                ret += self
        return ret

    def __eq__(self, other):
        assert self.curve == other.curve
        if self.is_infinity():
            return other.is_infinity()
        if other.is_infinity():
            return False
        x1, y1, z1 = self.x, self.y, self.z
        x2, y2, z2 = other.x, other.y, other.z
        z1z1 = z1 * z1
        z2z2 = z2 * z2
        return x1 * z2z2 == x2 * z1z1 and y1 * z2z2 * z2 == y2 * z1z1 * z1

def ecdsa_digest_to_scalar(curve, digest):
    e = int.from_bytes(digest, 'big')
    n_bits = curve.n.bit_length()
    if n_bits < len(digest) * 8:
        # ECDSA takes the leftmost bits of the hash. Within a byte, the leftmost
        # bit is the most-significant bit.
        e >>= len(digest) * 8 - n_bits
    assert e.bit_length() <= n_bits
    # e may still need to be reduced.
    return ModP(e % curve.n, curve.n)

def ecdsa_verify(pub, digest, r, s):
    curve = pub.curve
    if not 0 < r < curve.n or not 0 < s < curve.n:
        return False
    r, s = ModP(r, curve.n), ModP(s, curve.n)
    e = ecdsa_digest_to_scalar(curve, digest)
    s_inv = s.inv()
    u, v = e * s_inv, r * s_inv
    point = curve.g * u + pub * v
    if point.is_infinity():
        return False
    r1, _ = point.affine()
    return r.value == r1.value % curve.n

SEQUENCE = 0x30
INTEGER = 0x02

def encode_der(tag, body):
    ret = bytearray()
    ret.append(tag)
    if len(body) < 0x80:
        ret.append(len(body))
    else:
        assert len(body) <= 0xff
        ret.append(0x81)
        ret.append(len(body))
    ret.extend(body)
    return bytes(ret)

def encode_der_integer(v):
    l = (v.bit_length() + 7) // 8
    b = v.to_bytes(l, 'big')
    if b[0] & 0x80:
        b = b"\x00" + b
    return encode_der(INTEGER, b)

def encode_ecdsa_signature(r, s):
    return encode_der(SEQUENCE, encode_der_integer(r) + encode_der_integer(s))

def encode_ecdsa_signature_p1363(curve, r, s):
    scalar_bytes = (curve.n.bit_length() + 7) // 8
    r_bytes = r.to_bytes(scalar_bytes, "big")
    s_bytes = s.to_bytes(scalar_bytes, "big")
    return r_bytes + s_bytes

# All curves supported by Wycheproof.
brainpoolP224r1 = Curve(
    name="brainpoolP224r1",
    p= 0xd7c134aa264366862a18302575d1d787b09f075797da89f57ec8c0ff,
    a= 0x68a5e62ca9ce6c1c299803a6c1530b514e182ad8b0042a59cad29f43,
    b= 0x2580f63ccfe44138870713b1a92369e33e2135d266dbb372386c400b,
    gx=0x0d9029ad2c7e5cf4340823b2a87dc68c9e4ce3174c1e6efdee12c07d,
    gy=0x58aa56f772c0726f24c6b89e4ecdac24354b9e99caa3f6d3761402cd,
    n= 0xd7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939f,
)
brainpoolP256r1 = Curve(
    name="brainpoolP256r1",
    p= 0xa9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377,
    a= 0x7d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9,
    b= 0x26dc5c6ce94a4b44f330b5d9bbd77cbf958416295cf7e1ce6bccdc18ff8c07b6,
    gx=0x8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262,
    gy=0x547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997,
    n= 0xa9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a7,
)
brainpoolP320r1 = Curve(
    name="brainpoolP320r1",
    p= 0xd35e472036bc4fb7e13c785ed201e065f98fcfa6f6f40def4f92b9ec7893ec28fcd412b1f1b32e27,
    a= 0x3ee30b568fbab0f883ccebd46d3f3bb8a2a73513f5eb79da66190eb085ffa9f492f375a97d860eb4,
    b= 0x520883949dfdbc42d3ad198640688a6fe13f41349554b49acc31dccd884539816f5eb4ac8fb1f1a6,
    gx=0x43bd7e9afb53d8b85289bcc48ee5bfe6f20137d10a087eb6e7871e2a10a599c710af8d0d39e20611,
    gy=0x14fdd05545ec1cc8ab4093247f77275e0743ffed117182eaa9c77877aaac6ac7d35245d1692e8ee1,
    n= 0xd35e472036bc4fb7e13c785ed201e065f98fcfa5b68f12a32d482ec7ee8658e98691555b44c59311,
)
brainpoolP384r1 = Curve(
    name="brainpoolP384r1",
    p= 0x8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b412b1da197fb71123acd3a729901d1a71874700133107ec53,
    a= 0x7bc382c63d8c150c3c72080ace05afa0c2bea28e4fb22787139165efba91f90f8aa5814a503ad4eb04a8c7dd22ce2826,
    b= 0x04a8c7dd22ce28268b39b55416f0447c2fb77de107dcd2a62e880ea53eeb62d57cb4390295dbc9943ab78696fa504c11,
    gx=0x1d1c64f068cf45ffa2a63a81b7c13f6b8847a3e77ef14fe3db7fcafe0cbd10e8e826e03436d646aaef87b2e247d4af1e,
    gy=0x8abe1d7520f9c2a45cb1eb8e95cfd55262b70b29feec5864e19c054ff99129280e4646217791811142820341263c5315,
    n= 0x8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046565,
)
brainpoolP512r1 = Curve(
    name="brainpoolP512r1",
    p= 0xaadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca703308717d4d9b009bc66842aecda12ae6a380e62881ff2f2d82c68528aa6056583a48f3,
    a= 0x7830a3318b603b89e2327145ac234cc594cbdd8d3df91610a83441caea9863bc2ded5d5aa8253aa10a2ef1c98b9ac8b57f1117a72bf2c7b9e7c1ac4d77fc94ca,
    b= 0x3df91610a83441caea9863bc2ded5d5aa8253aa10a2ef1c98b9ac8b57f1117a72bf2c7b9e7c1ac4d77fc94cadc083e67984050b75ebae5dd2809bd638016f723,
    gx=0x81aee4bdd82ed9645a21322e9c4c6a9385ed9f70b5d916c1b43b62eef4d0098eff3b1f78e2d0d48d50d1687b93b97d5f7c6d5047406a5e688b352209bcb9f822,
    gy=0x7dde385d566332ecc0eabfa9cf7822fdf209f70024a57b1aa000c55b881f8111b2dcde494a5f485e5bca4bd88a2763aed1ca2b2fa8f0540678cd1e0f3ad80892,
    n= 0xaadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90069,
)
secp160k1 = Curve(
    name="secp160k1",
    p= 0x00fffffffffffffffffffffffffffffffeffffac73,
    a= 0x000000000000000000000000000000000000000000,
    b= 0x000000000000000000000000000000000000000007,
    gx=0x003b4c382ce37aa192a4019e763036f4f5dd4d7ebb,
    gy=0x00938cf935318fdced6bc28286531733c3f03c4fee,
    n= 0x0100000000000000000001b8fa16dfab9aca16b6b3,
)
secp160r1 = Curve(
    name="secp160r1",
    p= 0x00ffffffffffffffffffffffffffffffff7fffffff,
    a= 0x00ffffffffffffffffffffffffffffffff7ffffffc,
    b= 0x001c97befc54bd7a8b65acf89f81d4d4adc565fa45,
    gx=0x004a96b5688ef573284664698968c38bb913cbfc82,
    gy=0x0023a628553168947d59dcc912042351377ac5fb32,
    n= 0x0100000000000000000001f4c8f927aed3ca752257,
)
secp160r2 = Curve(
    name="secp160r2",
    p= 0x00fffffffffffffffffffffffffffffffeffffac73,
    a= 0x00fffffffffffffffffffffffffffffffeffffac70,
    b= 0x00b4e134d3fb59eb8bab57274904664d5af50388ba,
    gx=0x0052dcb034293a117e1f4ff11b30f7199d3144ce6d,
    gy=0x00feaffef2e331f296e071fa0df9982cfea7d43f2e,
    n= 0x0100000000000000000000351ee786a818f3a1a16b,
)
secp192k1 = Curve(
    name="secp192k1",
    p= 0xfffffffffffffffffffffffffffffffffffffffeffffee37,
    a= 0x000000000000000000000000000000000000000000000000,
    b= 0x000000000000000000000000000000000000000000000003,
    gx=0xdb4ff10ec057e9ae26b07d0280b7f4341da5d1b1eae06c7d,
    gy=0x9b2f2f6d9c5628a7844163d015be86344082aa88d95e2f9d,
    n= 0xfffffffffffffffffffffffe26f2fc170f69466a74defd8d,
)
secp192r1 = Curve(
    name="secp192r1",
    p= 0xfffffffffffffffffffffffffffffffeffffffffffffffff,
    a= 0xfffffffffffffffffffffffffffffffefffffffffffffffc,
    b= 0x64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1,
    gx=0x188da80eb03090f67cbf20eb43a18800f4ff0afd82ff1012,
    gy=0x07192b95ffc8da78631011ed6b24cdd573f977a11e794811,
    n= 0xffffffffffffffffffffffff99def836146bc9b1b4d22831,
)
secp224k1 = Curve(
    name="secp224k1",
    p= 0x00fffffffffffffffffffffffffffffffffffffffffffffffeffffe56d,
    a= 0x0000000000000000000000000000000000000000000000000000000000,
    b= 0x0000000000000000000000000000000000000000000000000000000005,
    gx=0x00a1455b334df099df30fc28a169a467e9e47075a90f7e650eb6b7a45c,
    gy=0x007e089fed7fba344282cafbd6f7e319f7c0b0bd59e2ca4bdb556d61a5,
    n= 0x10000000000000000000000000001dce8d2ec6184caf0a971769fb1f7,
)
secp224r1 = Curve(
    name="secp224r1",
    p= 0xffffffffffffffffffffffffffffffff000000000000000000000001,
    a= 0xfffffffffffffffffffffffffffffffefffffffffffffffffffffffe,
    b= 0xb4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4,
    gx=0xb70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21,
    gy=0xbd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34,
    n= 0xffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d,
)
secp256k1 = Curve(
    name="secp256k1",
    p= 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f,
    a= 0x0000000000000000000000000000000000000000000000000000000000000000,
    b= 0x0000000000000000000000000000000000000000000000000000000000000007,
    gx=0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,
    gy=0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8,
    n= 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141,
)
secp256r1 = Curve(
    name="secp256r1",
    p= 0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff,
    a= 0xffffffff00000001000000000000000000000000fffffffffffffffffffffffc,
    b= 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b,
    gx=0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296,
    gy=0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5,
    n= 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551,
)
secp384r1 = Curve(
    name="secp384r1",
    p= 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff,
    a= 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc,
    b= 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef,
    gx=0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7,
    gy=0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f,
    n= 0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973,
)
secp521r1 = Curve(
    name="secp521r1",
    p= 0x01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
    a= 0x01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc,
    b= 0x0051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00,
    gx=0x00c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66,
    gy=0x011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650,
    n= 0x01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409,
)

# Curve/hash combinations from Wycheproof.
TESTS = [
    ("ecdsa_brainpoolP224r1_sha224_test.json", "ecdsa_brainpoolP224r1_sha224_p1363_test.json", brainpoolP224r1, "SHA-224"),
    ("ecdsa_brainpoolP256r1_sha256_test.json", "ecdsa_brainpoolP256r1_sha256_p1363_test.json", brainpoolP256r1, "SHA-256"),
    ("ecdsa_brainpoolP320r1_sha384_test.json", "ecdsa_brainpoolP320r1_sha384_p1363_test.json", brainpoolP320r1, "SHA-384"),
    ("ecdsa_brainpoolP384r1_sha384_test.json", "ecdsa_brainpoolP384r1_sha384_p1363_test.json", brainpoolP384r1, "SHA-384"),
    ("ecdsa_brainpoolP512r1_sha512_test.json", "ecdsa_brainpoolP512r1_sha512_p1363_test.json", brainpoolP512r1, "SHA-512"),
    ("ecdsa_secp160k1_sha256_test.json", "ecdsa_secp160k1_sha256_p1363_test.json", secp160k1, "SHA-256"),
    ("ecdsa_secp160r1_sha256_test.json", "ecdsa_secp160r1_sha256_p1363_test.json", secp160r1, "SHA-256"),
    ("ecdsa_secp160r2_sha256_test.json", "ecdsa_secp160r2_sha256_p1363_test.json", secp160r2, "SHA-256"),
    ("ecdsa_secp192k1_sha256_test.json", "ecdsa_secp192k1_sha256_p1363_test.json", secp192k1, "SHA-256"),
    ("ecdsa_secp192r1_sha256_test.json", "ecdsa_secp192r1_sha256_p1363_test.json", secp192r1, "SHA-256"),
    ("ecdsa_secp224k1_sha224_test.json", "ecdsa_secp224k1_sha224_p1363_test.json", secp224k1, "SHA-224"),
    ("ecdsa_secp224k1_sha256_test.json", "ecdsa_secp224k1_sha256_p1363_test.json", secp224k1, "SHA-256"),
    ("ecdsa_secp224r1_sha224_test.json", "ecdsa_secp224r1_sha224_p1363_test.json", secp224r1, "SHA-224"),
    ("ecdsa_secp224r1_sha256_test.json", "ecdsa_secp224r1_sha256_p1363_test.json", secp224r1, "SHA-256"),
    ("ecdsa_secp224r1_sha512_test.json", "ecdsa_secp224r1_sha512_p1363_test.json", secp224r1, "SHA-512"),
    ("ecdsa_secp256k1_sha256_test.json", "ecdsa_secp256k1_sha256_p1363_test.json", secp256k1, "SHA-256"),
    ("ecdsa_secp256k1_sha512_test.json", "ecdsa_secp256k1_sha512_p1363_test.json", secp256k1, "SHA-512"),
    ("ecdsa_secp256r1_sha256_test.json", "ecdsa_secp256r1_sha256_p1363_test.json", secp256r1, "SHA-256"),
    ("ecdsa_secp256r1_sha512_test.json", "ecdsa_secp256r1_sha512_p1363_test.json", secp256r1, "SHA-512"),
    ("ecdsa_secp384r1_sha256_test.json", None, secp384r1, "SHA-256"),
    ("ecdsa_secp384r1_sha384_test.json", "ecdsa_secp384r1_sha384_p1363_test.json", secp384r1, "SHA-384"),
    ("ecdsa_secp384r1_sha512_test.json", "ecdsa_secp384r1_sha512_p1363_test.json", secp384r1, "SHA-512"),
    ("ecdsa_secp521r1_sha512_test.json", "ecdsa_secp521r1_sha512_p1363_test.json", secp521r1, "SHA-512"),
]

# Sanity-check
x = 0xf3033d1e548d245b5e45ff1147db8cd44db8a1f2823c3c164125be88f9a982c2
y = 0x3c078f6cee2f50e95e8916aa9c4e93de3fdf9b045abac6f707cfcb22d065638e
pub = secp256r1.affine(x, y)
assert pub == secp256r1.compressed(x, y & 1)
digest = bytes.fromhex("e8d38e4c6a905a814b04c2841d898ed6da023c34")
r = 0xd4255db86a416a5a688de4e238071ef16e5f2a20e31b9490c03dee9ae6164c34
s = 0x4e0ac1e1a6725bf7c6bd207439b2d370c5f2dea1ff4decf1650ab84c7769efc0
assert ecdsa_verify(pub, digest, r, s)

x = 0x4a6f1e7f7268174d23993b8b58aa60c2a87b18de79b36a750ec86dd6f9e12227
y = 0x572df22bd6487a863a51ca544b8c5de2b47f801372a881cb996a97d9a98aa825
pub = secp256r1.affine(x, y)
assert pub == secp256r1.compressed(x, y & 1)
digest = bytes.fromhex("54e9a048559f370425e9c8e54a460ec91bcc930a")
r = 0x4a800e24de65e5c57d4cab4dd1ef7b6c38a2f0aa5cfd3a571a4b552fb1993e69
s = 0xd9c89fb983640a7e65edf632cacd1de0823b7efbc798fc1f7bbfacdda7398955
assert not ecdsa_verify(pub, digest, r, s)

def key_to_pem(key: bytes) -> str:
    ret = "-----BEGIN PUBLIC KEY-----\n"
    b64 = base64.b64encode(key).decode("ascii")
    while b64:
        l = min(len(b64), 64)
        ret += b64[:l]
        ret += "\n"
        b64 = b64[l:]
    ret += "-----END PUBLIC KEY-----\n"
    return ret

SOURCE = "github/davidben/ecdsa-s-pow2"
SOURCE_VERSION = "0.1"

INPUT = b"hello, world"
for (path_der, path_p1363, curve, hash_name) in TESTS:
    print(path_der)
    with open(path_der) as f:
        data_der = json.load(f)
    if path_p1363 is not None:
        with open(path_p1363) as f:
            data_p1363 = json.load(f)

    def add_test_for_format(data, p1363, comment, pub, digest, r, s, valid):
        felem_bytes = (pub.curve.p.bit_length() + 7) // 8
        x, y = pub.affine()
        x_bytes = x.value.to_bytes(felem_bytes, "big")
        y_bytes = y.value.to_bytes(felem_bytes, "big")
        uncompressed = b"\x04" + x_bytes + y_bytes
        if valid:
            flags = ["ValidSignature"]
            result = "valid"
        else:
            flags = ["ArithmeticError"]
            result = "invalid"

        # Reconstruct the SPKI encoding from the existing examples, rather than
        # encoding an OID and everything.
        sample_spki = bytes.fromhex(data["testGroups"][0]["publicKeyDer"])
        sample_uncompressed = bytes.fromhex(data["testGroups"][0]["publicKey"]["uncompressed"])
        assert sample_spki.endswith(sample_uncompressed)
        assert key_to_pem(sample_spki) == data["testGroups"][0]["publicKeyPem"]
        spki_prefix = sample_spki[:-len(sample_uncompressed)]

        spki = spki_prefix + uncompressed

        # See if we can append to the previous group.
        groups = data["testGroups"]
        if groups and \
            groups[-1]["source"]["name"] == SOURCE and \
            groups[-1]["source"]["version"] == SOURCE_VERSION and \
            groups[-1]["publicKeyDer"] == spki.hex() and \
            groups[-1]["sha"] == hash_name:
            group = groups[-1]
        else:
            group = {
                "type": "EcdsaP1363Verify" if p1363 else "EcdsaVerify",
                "source": {
                    "name" : SOURCE,
                    "version" : SOURCE_VERSION,
                },
                "publicKey": {
                    "type": "EcPublicKey",
                    "curve": pub.curve.name,
                    "keySize": pub.curve.p.bit_length(),
                    "uncompressed": uncompressed.hex(),
                    "wx": x_bytes.hex(),
                    "wy": y_bytes.hex(),
                },
                "publicKeyDer": spki.hex(),
                "publicKeyPem": key_to_pem(spki),
                "sha": hash_name,
                "tests": [],
            }
            data["testGroups"].append(group)

        group["tests"].append({
            "tcId": data["numberOfTests"] + 1,
            "comment": comment,
            "flags": flags,
            "msg": INPUT.hex(),
            "sig": encode_ecdsa_signature_p1363(curve, r, s).hex() if p1363 else encode_ecdsa_signature(r, s).hex(),
            "result": result,
        })
        data["numberOfTests"] += 1

    def add_test(comment, pub, digest, r, s, valid):
        add_test_for_format(data_der, False, comment, pub, digest, r, s, valid)
        if path_p1363 is not None:
            add_test_for_format(data_p1363, True, comment, pub, digest, r, s, valid)

    def valid_test(comment, pub, digest, r, s):
        assert ecdsa_verify(pub, digest, r, s)
        add_test(comment, pub, digest, r, s, True)

    def invalid_test(comment, pub, digest, r, s):
        assert not ecdsa_verify(pub, digest, r, s)
        add_test(comment, pub, digest, r, s, False)

    h = hashlib.new(hash_name.replace("-", ""))
    h.update(INPUT)
    digest = h.digest()
    z = ecdsa_digest_to_scalar(curve, digest)

    k = ModP(1234567890, curve.n)
    x, y = (curve.g * k).affine()
    r = ModP(x.value % curve.n, curve.n)
    s = ModP(2**128, curve.n)

    # Compute the private key that makes this signature check out.
    priv = (s * k - z) * r.inv()
    pub = curve.g * priv

    valid_test("s = 2^128", pub, digest, r.value, s.value)
    valid_test("s = n - 2^128", pub, digest, r.value, (-s).value)

    with open(path_der, "w") as f:
        json.dump(data_der, f, indent=2, separators=(',', ': '), ensure_ascii=False)
        f.write("\n")

    if path_p1363 is not None:
        with open(path_p1363, "w") as f:
            json.dump(data_p1363, f, indent=2, separators=(',', ': '), ensure_ascii=False)
            f.write("\n")
```

</details>