### PR TITLE
Fix aes_ff1_base85 alphabet errors

### DIFF
--- a/testvectors_v1/aes_ff1_base85_test.json
+++ b/testvectors_v1/aes_ff1_base85_test.json
@@ -42,7 +42,7 @@
   "schema": "fpe_str_test_schema.json",
   "testGroups": [
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 0,
       "radix": 85,
@@ -63,7 +63,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 1,
       "radix": 85,
@@ -84,7 +84,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 0,
       "radix": 85,
@@ -105,7 +105,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 1,
       "radix": 85,
@@ -126,7 +126,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 0,
       "radix": 85,
@@ -147,7 +147,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 1,
       "radix": 85,
@@ -161,14 +161,14 @@
           ],
           "key": "b8c800bed3286920bd1d9ad89a78808e9f815ec638663a725f256cc7078fdaf0",
           "tweak": "90120912eba3c19c",
-          "msg": "v",
+          "msg": "w",
           "ct": "",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 2,
       "radix": 85,
@@ -189,7 +189,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 3,
       "radix": 85,
@@ -210,7 +210,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 2,
       "radix": 85,
@@ -231,7 +231,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 3,
       "radix": 85,
@@ -246,13 +246,13 @@
           "key": "3c453964f4e42587db3a6de5de00673ede7e17672a4deb84",
           "tweak": "fe6290783f11946c",
           "msg": "fSB",
-          "ct": "Dtm",
+          "ct": "Dsm",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 2,
       "radix": 85,
@@ -273,7 +273,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 3,
       "radix": 85,
@@ -294,7 +294,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 4,
       "radix": 85,
@@ -321,7 +321,7 @@
           "key": "16e4e676552c2fef6f1942adef4c440a",
           "tweak": "aba4ba6db9422dc4",
           "msg": "0000",
-          "ct": "L|{_",
+          "ct": "L|{:",
           "result": "valid"
         },
         {
@@ -392,7 +392,7 @@
           ],
           "key": "16e4e676552c2fef6f1942adef4c440a",
           "tweak": "aba4ba6db9422dc4",
-          "msg": "nZvZ",
+          "msg": "nZwZ",
           "ct": "}~hF",
           "result": "valid"
         },
@@ -416,8 +416,8 @@
           ],
           "key": "16e4e676552c2fef6f1942adef4c440a",
           "tweak": "aba4ba6db9422dc4",
-          "msg": "lp>s",
-          "ct": "@A7t",
+          "msg": "lp>t",
+          "ct": "@A7u",
           "result": "valid"
         },
         {
@@ -440,7 +440,7 @@
           ],
           "key": "16e4e676552c2fef6f1942adef4c440a",
           "tweak": "aba4ba6db9422dc4",
-          "msg": "v?{X",
+          "msg": "w?{X",
           "ct": "cqJ>",
           "result": "valid"
         },
@@ -488,7 +488,7 @@
           ],
           "key": "16e4e676552c2fef6f1942adef4c440a",
           "tweak": "aba4ba6db9422dc4",
-          "msg": "vcsu",
+          "msg": "wctv",
           "ct": "mGmG",
           "result": "valid"
         },
@@ -500,7 +500,7 @@
           ],
           "key": "16e4e676552c2fef6f1942adef4c440a",
           "tweak": "aba4ba6db9422dc4",
-          "msg": "Rs}B",
+          "msg": "Rt}B",
           "ct": "mFmF",
           "result": "valid"
         },
@@ -512,7 +512,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "af155ee428253306500bacff92",
-          "msg": "va>H",
+          "msg": "wa>H",
           "ct": "@rDj",
           "result": "valid"
         },
@@ -548,7 +548,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "af155ee428253306500bacff92",
-          "msg": "tJKW",
+          "msg": "sJKW",
           "ct": "gEZ)",
           "result": "valid"
         },
@@ -561,7 +561,7 @@
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "05012370623144c69c01270346",
           "msg": "1O6B",
-          "ct": "01@t",
+          "ct": "01@u",
           "result": "valid"
         },
         {
@@ -584,8 +584,8 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "05012370623144c69c01270346",
-          "msg": "I;so",
-          "ct": "mHf_",
+          "msg": "I;to",
+          "ct": "mHf:",
           "result": "valid"
         },
         {
@@ -597,7 +597,7 @@
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "05012370623144c69c01270346",
           "msg": "CBc8",
-          "ct": "~~Hs",
+          "ct": "~~Ht",
           "result": "valid"
         },
         {
@@ -608,7 +608,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "05012370623144c69c01270346",
-          "msg": "EM7_",
+          "msg": "EM7:",
           "ct": "00m}",
           "result": "valid"
         },
@@ -620,7 +620,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "9fcc8b2a9bc1934fa8ed0cb08f",
-          "msg": "00t7",
+          "msg": "00s7",
           "ct": "FnIA",
           "result": "valid"
         },
@@ -632,8 +632,8 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "9fcc8b2a9bc1934fa8ed0cb08f",
-          "msg": "01t7",
-          "ct": "cht+",
+          "msg": "01s7",
+          "ct": "chu+",
           "result": "valid"
         },
         {
@@ -644,7 +644,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "9fcc8b2a9bc1934fa8ed0cb08f",
-          "msg": "mGt7",
+          "msg": "mGs7",
           "ct": "grQ*",
           "result": "valid"
         },
@@ -656,7 +656,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "9fcc8b2a9bc1934fa8ed0cb08f",
-          "msg": "y~t7",
+          "msg": "y~s7",
           "ct": "Rg<S",
           "result": "valid"
         },
@@ -668,7 +668,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "9fcc8b2a9bc1934fa8ed0cb08f",
-          "msg": "z0t7",
+          "msg": "z0s7",
           "ct": "_k>4",
           "result": "valid"
         },
@@ -680,7 +680,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "9fcc8b2a9bc1934fa8ed0cb08f",
-          "msg": "~~t7",
+          "msg": "~~s7",
           "ct": "lz&T",
           "result": "valid"
         },
@@ -693,7 +693,7 @@
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "b5c93d6da9df1abb68d1b4dd80",
           "msg": "ag*k",
-          "ct": "S_%%",
+          "ct": "S:%%",
           "result": "valid"
         },
         {
@@ -704,7 +704,7 @@
           ],
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "b5c93d6da9df1abb68d1b4dd80",
-          "msg": "Yt+~",
+          "msg": "Yu+~",
           "ct": "kUVh",
           "result": "valid"
         },
@@ -729,7 +729,7 @@
           "key": "a88f0018e583ed7310f3f5336e592a25",
           "tweak": "b5c93d6da9df1abb68d1b4dd80",
           "msg": "dCN{",
-          "ct": "xMu=",
+          "ct": "xMv=",
           "result": "valid"
         },
         {
@@ -752,7 +752,7 @@
           ],
           "key": "8a74f1cae832ef8d58c26b49157c187b",
           "tweak": "d7b8bdae53aba381",
-          "msg": "5.eU",
+          "msg": "5-eU",
           "ct": "*b|i",
           "result": "invalid"
         },
@@ -764,7 +764,7 @@
           ],
           "key": "8a74f1cae832ef8d58c26b49157c187b",
           "tweak": "d7b8bdae53aba381",
-          "msg": "5#e\\",
+          "msg": "5#e-",
           "ct": "If+x",
           "result": "invalid"
         },
@@ -776,7 +776,7 @@
           ],
           "key": "595a962ebac0eff084666b49bc4ae204",
           "tweak": "d74b46fa68e8e1a1",
-          "msg": "\u007ftD%",
+          "msg": "-sD%",
           "ct": "<4Kn",
           "result": "invalid"
         },
@@ -788,8 +788,8 @@
           ],
           "key": "595a962ebac0eff084666b49bc4ae204",
           "tweak": "d74b46fa68e8e1a1",
-          "msg": "X\u007fD%",
-          "ct": "U^_G",
+          "msg": "X-D%",
+          "ct": "U^:G",
           "result": "invalid"
         },
         {
@@ -800,14 +800,14 @@
           ],
           "key": "595a962ebac0eff084666b49bc4ae204",
           "tweak": "d74b46fa68e8e1a1",
-          "msg": "XtD\u007f",
+          "msg": "XsD-",
           "ct": "AC;g",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 5,
       "radix": 85,
@@ -821,7 +821,7 @@
           ],
           "key": "0319599d6c7ca301230ec2b06c681097",
           "tweak": "125fd8f86c787e2d",
-          "msg": "tXCmh",
+          "msg": "uXCmh",
           "ct": "!_!qH",
           "result": "valid"
         },
@@ -881,7 +881,7 @@
           ],
           "key": "ed3d0c6668748336d74abc8a161dea33",
           "tweak": "61a3e1c030481108",
-          "msg": "sG>PW",
+          "msg": "tG>PW",
           "ct": "&7Maz",
           "result": "valid"
         },
@@ -917,7 +917,7 @@
           ],
           "key": "ed3d0c6668748336d74abc8a161dea33",
           "tweak": "61a3e1c030481108",
-          "msg": "IuXmh",
+          "msg": "IvXmh",
           "ct": "H^zK3",
           "result": "valid"
         },
@@ -941,8 +941,8 @@
           ],
           "key": "ed3d0c6668748336d74abc8a161dea33",
           "tweak": "61a3e1c030481108",
-          "msg": "S$*__",
-          "ct": ")vD3V",
+          "msg": "S$*:_",
+          "ct": ")wD3V",
           "result": "valid"
         },
         {
@@ -953,7 +953,7 @@
           ],
           "key": "ed3d0c6668748336d74abc8a161dea33",
           "tweak": "61a3e1c030481108",
-          "msg": "_Kgct",
+          "msg": ":Kgcu",
           "ct": ">TmL|",
           "result": "valid"
         },
@@ -1049,8 +1049,8 @@
           ],
           "key": "2dcc7a48fa759e58062f64099e2654fb",
           "tweak": "17a382bb3efa41a48b0697ab",
-          "msg": "?pvml",
-          "ct": "zK_G;",
+          "msg": "?pwml",
+          "ct": "zK:G;",
           "result": "valid"
         },
         {
@@ -1062,7 +1062,7 @@
           "key": "2dcc7a48fa759e58062f64099e2654fb",
           "tweak": "17a382bb3efa41a48b0697ab",
           "msg": "IErJ6",
-          "ct": "bztxn",
+          "ct": "bzuxn",
           "result": "valid"
         },
         {
@@ -1097,8 +1097,8 @@
           ],
           "key": "2dcc7a48fa759e58062f64099e2654fb",
           "tweak": "d8bfed249746a3ffe6543a00",
-          "msg": "+uzG<",
-          "ct": "&v^n)",
+          "msg": "+vzG<",
+          "ct": "&w^n)",
           "result": "valid"
         },
         {
@@ -1169,7 +1169,7 @@
           ],
           "key": "2dcc7a48fa759e58062f64099e2654fb",
           "tweak": "9d5122d875de5a023d2216e2",
-          "msg": "Gkstt",
+          "msg": "Gktuu",
           "ct": "~}y%H",
           "result": "valid"
         },
@@ -1181,7 +1181,7 @@
           ],
           "key": "8d8a7cd63e6554b77d0345f3d799bfad",
           "tweak": "ea7fef1b2f555ad8",
-          "msg": "w_2EJ",
+          "msg": "-:2EJ",
           "ct": "1(}Wr",
           "result": "invalid"
         },
@@ -1205,7 +1205,7 @@
           ],
           "key": "8d8a7cd63e6554b77d0345f3d799bfad",
           "tweak": "ea7fef1b2f555ad8",
-          "msg": "#_2E/",
+          "msg": "#:2E-",
           "ct": "CL&q~",
           "result": "invalid"
         },
@@ -1217,7 +1217,7 @@
           ],
           "key": "4c21f6fea56458cd9fbec911583f228a",
           "tweak": "76fd0ebcce1d5691",
-          "msg": "\u007fhN{4",
+          "msg": "-hN{4",
           "ct": "bzEeR",
           "result": "invalid"
         },
@@ -1229,7 +1229,7 @@
           ],
           "key": "4c21f6fea56458cd9fbec911583f228a",
           "tweak": "76fd0ebcce1d5691",
-          "msg": "*\u007fN{4",
+          "msg": "*-N{4",
           "ct": "=SmDQ",
           "result": "invalid"
         },
@@ -1241,14 +1241,14 @@
           ],
           "key": "4c21f6fea56458cd9fbec911583f228a",
           "tweak": "76fd0ebcce1d5691",
-          "msg": "*hN{\u007f",
+          "msg": "*hN{-",
           "ct": "Oh}H(",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 6,
       "radix": 85,
@@ -1263,7 +1263,7 @@
           "key": "474bbf2aff5c252419c49a07d50e2bdf",
           "tweak": "d64296c362368a3d",
           "msg": "S5C6EB",
-          "ct": "y_0OuV",
+          "ct": "y:0OvV",
           "result": "valid"
         },
         {
@@ -1275,7 +1275,7 @@
           "key": "26dbd1998c3a046ac3ff11937079c034",
           "tweak": "5e551c3daad7e5fa",
           "msg": "000000",
-          "ct": "a*Fuxd",
+          "ct": "a*Fvxd",
           "result": "valid"
         },
         {
@@ -1370,7 +1370,7 @@
           ],
           "key": "26dbd1998c3a046ac3ff11937079c034",
           "tweak": "5e551c3daad7e5fa",
-          "msg": "sB@+%=",
+          "msg": "tB@+%=",
           "ct": "!+}+Pf",
           "result": "valid"
         },
@@ -1383,7 +1383,7 @@
           "key": "26dbd1998c3a046ac3ff11937079c034",
           "tweak": "5e551c3daad7e5fa",
           "msg": "9<KMcb",
-          "ct": "{$T~t?",
+          "ct": "{$T~s?",
           "result": "valid"
         },
         {
@@ -1394,7 +1394,7 @@
           ],
           "key": "26dbd1998c3a046ac3ff11937079c034",
           "tweak": "5e551c3daad7e5fa",
-          "msg": "B_lq0m",
+          "msg": "B:lq0m",
           "ct": "Hd7!3H",
           "result": "valid"
         },
@@ -1418,7 +1418,7 @@
           ],
           "key": "26dbd1998c3a046ac3ff11937079c034",
           "tweak": "5e551c3daad7e5fa",
-          "msg": "g>UsxZ",
+          "msg": "g>UtxZ",
           "ct": "000000",
           "result": "valid"
         },
@@ -1466,7 +1466,7 @@
           ],
           "key": "6a24278db37f29768c4263256ffbd956",
           "tweak": "822d7561c7542ad08fd97ee0",
-          "msg": "uFy@jy",
+          "msg": "vFy@jy",
           "ct": "ff1rPH",
           "result": "valid"
         },
@@ -1478,7 +1478,7 @@
           ],
           "key": "6a24278db37f29768c4263256ffbd956",
           "tweak": "822d7561c7542ad08fd97ee0",
-          "msg": "Q$v$e*",
+          "msg": "Q$w$e*",
           "ct": "@)QSkd",
           "result": "valid"
         },
@@ -1562,7 +1562,7 @@
           ],
           "key": "6a24278db37f29768c4263256ffbd956",
           "tweak": "c4727f3b2e4456b03149752c",
-          "msg": "%_Ptyu",
+          "msg": "%_Psyv",
           "ct": "*;8WxB",
           "result": "valid"
         },
@@ -1574,7 +1574,7 @@
           ],
           "key": "6a24278db37f29768c4263256ffbd956",
           "tweak": "c4727f3b2e4456b03149752c",
-          "msg": "_X|H|n",
+          "msg": ":X|H|n",
           "ct": "|N~O2W",
           "result": "valid"
         },
@@ -1598,7 +1598,7 @@
           ],
           "key": "6a24278db37f29768c4263256ffbd956",
           "tweak": "8807371d57db7ef67172f7f7",
-          "msg": "noZRsI",
+          "msg": "noZRtI",
           "ct": "Oo*000",
           "result": "valid"
         },
@@ -1610,7 +1610,7 @@
           ],
           "key": "6a24278db37f29768c4263256ffbd956",
           "tweak": "8807371d57db7ef67172f7f7",
-          "msg": "J$_Amu",
+          "msg": "J$:Amv",
           "ct": "Oo*;m7",
           "result": "valid"
         },
@@ -1634,7 +1634,7 @@
           ],
           "key": "ed4561abc903a9e722ddb8aa94cc662d",
           "tweak": "975f6d7701e004f7",
-          "msg": "]rTMS2",
+          "msg": "-rTMS2",
           "ct": "cF5Z86",
           "result": "invalid"
         },
@@ -1646,7 +1646,7 @@
           ],
           "key": "ed4561abc903a9e722ddb8aa94cc662d",
           "tweak": "975f6d7701e004f7",
-          "msg": "}r:MS2",
+          "msg": "}r-MS2",
           "ct": "R?F5=Q",
           "result": "invalid"
         },
@@ -1658,7 +1658,7 @@
           ],
           "key": "ed4561abc903a9e722ddb8aa94cc662d",
           "tweak": "975f6d7701e004f7",
-          "msg": "}rTMS]",
+          "msg": "}rTMS-",
           "ct": "5k(Y;i",
           "result": "invalid"
         },
@@ -1670,8 +1670,8 @@
           ],
           "key": "a1550333e29a30bee95f3364cf1e3401",
           "tweak": "9f1cdbefde36af08",
-          "msg": "\u007fiMI(h",
-          "ct": "~Xt06_",
+          "msg": "-iMI(h",
+          "ct": "~Xs06:",
           "result": "invalid"
         },
         {
@@ -1682,7 +1682,7 @@
           ],
           "key": "a1550333e29a30bee95f3364cf1e3401",
           "tweak": "9f1cdbefde36af08",
-          "msg": "!i\u007fI(h",
+          "msg": "!i-I(h",
           "ct": "ah|p}<",
           "result": "invalid"
         },
@@ -1694,14 +1694,14 @@
           ],
           "key": "a1550333e29a30bee95f3364cf1e3401",
           "tweak": "9f1cdbefde36af08",
-          "msg": "!iMI(\u007f",
+          "msg": "!iMI(-",
           "ct": "KNR9zR",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 7,
       "radix": 85,
@@ -1715,8 +1715,8 @@
           ],
           "key": "20b2c30d44c72c32a4564541332f45c3",
           "tweak": "3de9de4b8736f463",
-          "msg": "}|_eT^o",
-          "ct": "sRHA8vf",
+          "msg": "}|:eT^o",
+          "ct": "tRHA8wf",
           "result": "valid"
         },
         {
@@ -1728,7 +1728,7 @@
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
           "msg": "0000000",
-          "ct": "}sOQU|9",
+          "ct": "}tOQU|9",
           "result": "valid"
         },
         {
@@ -1751,7 +1751,7 @@
           ],
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
-          "msg": ";m8ttI2",
+          "msg": ";m8ssI2",
           "ct": "$U^CJO$",
           "result": "valid"
         },
@@ -1763,7 +1763,7 @@
           ],
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
-          "msg": ";m7ttI1",
+          "msg": ";m7ssI1",
           "ct": "(kB2g##",
           "result": "valid"
         },
@@ -1775,8 +1775,8 @@
           ],
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
-          "msg": "Zmmsq)<",
-          "ct": "jQVN_5X",
+          "msg": "Zmmtq)<",
+          "ct": "jQVN:5X",
           "result": "valid"
         },
         {
@@ -1787,8 +1787,8 @@
           ],
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
-          "msg": "V6((tc^",
-          "ct": "v#ih&__",
+          "msg": "V6((sc^",
+          "ct": "w#ih&::",
           "result": "valid"
         },
         {
@@ -1812,7 +1812,7 @@
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
           "msg": "RHHG0^_",
-          "ct": "2#V1sb7",
+          "ct": "2#V1tb7",
           "result": "valid"
         },
         {
@@ -1835,8 +1835,8 @@
           ],
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
-          "msg": ")0vUAAv",
-          "ct": "T^&<u!f",
+          "msg": ")0wUAAw",
+          "ct": "T^&<v!f",
           "result": "valid"
         },
         {
@@ -1848,7 +1848,7 @@
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
           "msg": "Cgm=HjK",
-          "ct": "0t;(#y>",
+          "ct": "0u;(#y>",
           "result": "valid"
         },
         {
@@ -1859,7 +1859,7 @@
           ],
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
-          "msg": "3#|GNtU",
+          "msg": "3#|GNsU",
           "ct": "Lni*0j>",
           "result": "valid"
         },
@@ -1871,7 +1871,7 @@
           ],
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
-          "msg": "EQvB_;d",
+          "msg": "EQwB:;d",
           "ct": "0000000",
           "result": "valid"
         },
@@ -1896,7 +1896,7 @@
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
           "msg": "kCzTT<U",
-          "ct": ";m8ttI2",
+          "ct": ";m8ssI2",
           "result": "valid"
         },
         {
@@ -1908,7 +1908,7 @@
           "key": "53b43d40c44c62982d5123e5716d25db",
           "tweak": "c34af5583d26dacc",
           "msg": "Ym_L(|k",
-          "ct": ";m7ttI1",
+          "ct": ";m7ssI1",
           "result": "valid"
         },
         {
@@ -1931,7 +1931,7 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "30fc02558228364741d7ba",
-          "msg": "4E^svxP",
+          "msg": "4E^twxP",
           "ct": "001jmh2",
           "result": "valid"
         },
@@ -1967,8 +1967,8 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "b3c5e4ae32874d413f4345",
-          "msg": "FtAqj_P",
-          "ct": "B`hHItL",
+          "msg": "FsAqj_P",
+          "ct": "B`hHIsL",
           "result": "valid"
         },
         {
@@ -1979,7 +1979,7 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "b3c5e4ae32874d413f4345",
-          "msg": "q|l1>8u",
+          "msg": "q|l1>8v",
           "ct": "xY7A(}>",
           "result": "valid"
         },
@@ -1991,8 +1991,8 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "b3c5e4ae32874d413f4345",
-          "msg": "PCNtWnG",
-          "ct": "}qu_)~U",
+          "msg": "PCNsWnG",
+          "ct": "}qv_)~U",
           "result": "valid"
         },
         {
@@ -2003,8 +2003,8 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "b3c5e4ae32874d413f4345",
-          "msg": "pF8Z__$",
-          "ct": "ACM`u3t",
+          "msg": "pF8Z::$",
+          "ct": "ACM`v3s",
           "result": "valid"
         },
         {
@@ -2016,7 +2016,7 @@
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "b3c5e4ae32874d413f4345",
           "msg": "P9ZFrxe",
-          "ct": "SN6ua=_",
+          "ct": "SN6va=:",
           "result": "valid"
         },
         {
@@ -2027,7 +2027,7 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "6647b43f722b12a81f072c",
-          "msg": "000t)R5",
+          "msg": "000u)R5",
           "ct": "L`<BWh;",
           "result": "valid"
         },
@@ -2039,7 +2039,7 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "6647b43f722b12a81f072c",
-          "msg": "001t)R5",
+          "msg": "001u)R5",
           "ct": "0Ij#&|p",
           "result": "valid"
         },
@@ -2051,8 +2051,8 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "6647b43f722b12a81f072c",
-          "msg": "2y~t)R5",
-          "ct": "sux?VA>",
+          "msg": "2y~u)R5",
+          "ct": "tvx?VA>",
           "result": "valid"
         },
         {
@@ -2063,8 +2063,8 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "6647b43f722b12a81f072c",
-          "msg": "2z0t)R5",
-          "ct": "Lty>>ty",
+          "msg": "2z0u)R5",
+          "ct": "Lsy>>sy",
           "result": "valid"
         },
         {
@@ -2075,7 +2075,7 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "6647b43f722b12a81f072c",
-          "msg": ";m8t)R5",
+          "msg": ";m8u)R5",
           "ct": "O_D?o8#",
           "result": "valid"
         },
@@ -2087,7 +2087,7 @@
           ],
           "key": "ad837c09903b33e60eecfa1d04308e32",
           "tweak": "6647b43f722b12a81f072c",
-          "msg": "~~~t)R5",
+          "msg": "~~~u)R5",
           "ct": "LWC5fL^",
           "result": "valid"
         },
@@ -2099,8 +2099,8 @@
           ],
           "key": "ea35a8f24783be82abd93cc74e4944cb",
           "tweak": "a704f808982bb10f",
-          "msg": ":xrI**H",
-          "ct": "t}>0)M9",
+          "msg": "-xrI**H",
+          "ct": "u}>0)M9",
           "result": "invalid"
         },
         {
@@ -2111,8 +2111,8 @@
           ],
           "key": "ea35a8f24783be82abd93cc74e4944cb",
           "tweak": "a704f808982bb10f",
-          "msg": "gx,I**H",
-          "ct": "_t<c<V8",
+          "msg": "gx-I**H",
+          "ct": ":u<c<V8",
           "result": "invalid"
         },
         {
@@ -2123,7 +2123,7 @@
           ],
           "key": "ea35a8f24783be82abd93cc74e4944cb",
           "tweak": "a704f808982bb10f",
-          "msg": "gxrI**,",
+          "msg": "gxrI**-",
           "ct": "X2o!LR=",
           "result": "invalid"
         },
@@ -2135,8 +2135,8 @@
           ],
           "key": "2172fb36a4ed06786fa3f06d3d5df882",
           "tweak": "18328eb43c95364e",
-          "msg": "\u007fFzUQmH",
-          "ct": "Is;Zf{T",
+          "msg": "-FzUQmH",
+          "ct": "It;Zf{T",
           "result": "invalid"
         },
         {
@@ -2147,7 +2147,7 @@
           ],
           "key": "2172fb36a4ed06786fa3f06d3d5df882",
           "tweak": "18328eb43c95364e",
-          "msg": "8F\u007fUQmH",
+          "msg": "8F-UQmH",
           "ct": "ZPr{e*e",
           "result": "invalid"
         },
@@ -2159,14 +2159,14 @@
           ],
           "key": "2172fb36a4ed06786fa3f06d3d5df882",
           "tweak": "18328eb43c95364e",
-          "msg": "8FzUQm\u007f",
-          "ct": "ueB(T7K",
+          "msg": "8FzUQm-",
+          "ct": "veB(T7K",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 8,
       "radix": 85,
@@ -2180,7 +2180,7 @@
           ],
           "key": "60d83b209822c0d9b7033dca86444fa1",
           "tweak": "23ef05b155a108c4",
-          "msg": "^>Lyt*O`",
+          "msg": "^>Lys*O`",
           "ct": "cq<g)>36",
           "result": "valid"
         },
@@ -2193,7 +2193,7 @@
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
           "msg": "00000000",
-          "ct": "QtX>Ty%x",
+          "ct": "QsX>Ty%x",
           "result": "valid"
         },
         {
@@ -2216,8 +2216,8 @@
           ],
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
-          "msg": "ttI2ttI2",
-          "ct": "dt?rZ_H%",
+          "msg": "ssI2ssI2",
+          "ct": "du?rZ_H%",
           "result": "valid"
         },
         {
@@ -2228,8 +2228,8 @@
           ],
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
-          "msg": "ttI1ttI1",
-          "ct": "NXkTvjdp",
+          "msg": "ssI1ssI1",
+          "ct": "NXkTwjdp",
           "result": "valid"
         },
         {
@@ -2240,8 +2240,8 @@
           ],
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
-          "msg": ";OjvV<zV",
-          "ct": "j`u0&#_V",
+          "msg": ";OjwV<zV",
+          "ct": "j`v0&#:V",
           "result": "valid"
         },
         {
@@ -2253,7 +2253,7 @@
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
           "msg": "nij~@(8F",
-          "ct": "J}#Z}Uqt",
+          "ct": "J}#Z}Uqu",
           "result": "valid"
         },
         {
@@ -2264,8 +2264,8 @@
           ],
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
-          "msg": "lvAtkc<V",
-          "ct": "vPPtGN2s",
+          "msg": "lwAukc<V",
+          "ct": "wPPsGN2t",
           "result": "valid"
         },
         {
@@ -2277,7 +2277,7 @@
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
           "msg": "LbnpBz7b",
-          "ct": "^OR^9Nb_",
+          "ct": "^OR^9Nb:",
           "result": "valid"
         },
         {
@@ -2288,8 +2288,8 @@
           ],
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
-          "msg": "TGv<nX_i",
-          "ct": "cU;0$fhv",
+          "msg": "TGw<nX:i",
+          "ct": "cU;0$fhw",
           "result": "valid"
         },
         {
@@ -2300,8 +2300,8 @@
           ],
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
-          "msg": "#TM1;t;t",
-          "ct": "GVoxtC$V",
+          "msg": "#TM1;u;s",
+          "ct": "GVoxsC$V",
           "result": "valid"
         },
         {
@@ -2325,7 +2325,7 @@
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
           "msg": "EI@`!F)@",
-          "ct": "+_(A>f?_",
+          "ct": "+:(A>f?:",
           "result": "valid"
         },
         {
@@ -2336,7 +2336,7 @@
           ],
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
-          "msg": "@1L^v8r#",
+          "msg": "@1L^w8r#",
           "ct": "00000000",
           "result": "valid"
         },
@@ -2361,7 +2361,7 @@
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
           "msg": "!#A<8>mZ",
-          "ct": "ttI2ttI2",
+          "ct": "ssI2ssI2",
           "result": "valid"
         },
         {
@@ -2373,7 +2373,7 @@
           "key": "3bfee9ab1eadaa8cff5b05281fcb0140",
           "tweak": "2024d5e34b3ba6a0",
           "msg": "AYR^{I*b",
-          "ct": "ttI1ttI1",
+          "ct": "ssI1ssI1",
           "result": "valid"
         },
         {
@@ -2384,8 +2384,8 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "32b28d175346d031ac52f7",
-          "msg": "l<yRMu7d",
-          "ct": "zCt;bqqL",
+          "msg": "l<yRMv7d",
+          "ct": "zCs;bqqL",
           "result": "valid"
         },
         {
@@ -2396,8 +2396,8 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "32b28d175346d031ac52f7",
-          "msg": "4zgtHVh&",
-          "ct": "Oeutsc5C",
+          "msg": "4zgsHVh&",
+          "ct": "Oevstc5C",
           "result": "valid"
         },
         {
@@ -2421,7 +2421,7 @@
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "32b28d175346d031ac52f7",
           "msg": "xHT%EDr_",
-          "ct": ")zR_;H7s",
+          "ct": ")zR:;H7t",
           "result": "valid"
         },
         {
@@ -2433,7 +2433,7 @@
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "0b77cb0d225aea97899aa9",
           "msg": "0000F2Xd",
-          "ct": "FTB4*Lt7",
+          "ct": "FTB4*Lu7",
           "result": "valid"
         },
         {
@@ -2445,7 +2445,7 @@
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "0b77cb0d225aea97899aa9",
           "msg": "0001F2Xd",
-          "ct": "$(<Cic_q",
+          "ct": "$(<Cic:q",
           "result": "valid"
         },
         {
@@ -2456,7 +2456,7 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "0b77cb0d225aea97899aa9",
-          "msg": "ttI2F2Xd",
+          "msg": "ssI2F2Xd",
           "ct": "!b749Dab",
           "result": "valid"
         },
@@ -2493,7 +2493,7 @@
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "e1bd244d89588401e339e7",
           "msg": "93W^ON)e",
-          "ct": "s6+jD2mN",
+          "ct": "t6+jD2mN",
           "result": "valid"
         },
         {
@@ -2528,7 +2528,7 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "e1bd244d89588401e339e7",
-          "msg": "&7te%6HZ",
+          "msg": "&7se%6HZ",
           "ct": "*Q`&opH1",
           "result": "valid"
         },
@@ -2540,8 +2540,8 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "e1bd244d89588401e339e7",
-          "msg": "U~MyG>8t",
-          "ct": "_#(>i;&i",
+          "msg": "U~MyG>8s",
+          "ct": ":#(>i;&i",
           "result": "valid"
         },
         {
@@ -2552,8 +2552,8 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "e1bd244d89588401e339e7",
-          "msg": "H~}_T3ga",
-          "ct": "V6@ov^I$",
+          "msg": "H~}:T3ga",
+          "ct": "V6@ow^I$",
           "result": "valid"
         },
         {
@@ -2565,7 +2565,7 @@
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "3fd1f7e5091007e0a9fd82",
           "msg": "r#fm0000",
-          "ct": "@PWY#_!u",
+          "ct": "@PWY#:!v",
           "result": "valid"
         },
         {
@@ -2576,8 +2576,8 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "3fd1f7e5091007e0a9fd82",
-          "msg": "?ss$0001",
-          "ct": "KI$fOt6i",
+          "msg": "?tt$0001",
+          "ct": "KI$fOs6i",
           "result": "valid"
         },
         {
@@ -2588,7 +2588,7 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "3fd1f7e5091007e0a9fd82",
-          "msg": "CT9IttI2",
+          "msg": "CT9IssI2",
           "ct": "aDk6$A3p",
           "result": "valid"
         },
@@ -2600,8 +2600,8 @@
           ],
           "key": "475b7573760904fa57ad2cb88ea52f32",
           "tweak": "3fd1f7e5091007e0a9fd82",
-          "msg": "8|_Z~~~~",
-          "ct": "?5VtE~>=",
+          "msg": "8|:Z~~~~",
+          "ct": "?5VsE~>=",
           "result": "valid"
         },
         {
@@ -2612,7 +2612,7 @@
           ],
           "key": "ebc261665fab01ae2bfe156e54de3006",
           "tweak": "5080dd547abdeddd",
-          "msg": ":6`}GDs&",
+          "msg": "-6`}GDt&",
           "ct": "E_&77KG~",
           "result": "invalid"
         },
@@ -2624,8 +2624,8 @@
           ],
           "key": "ebc261665fab01ae2bfe156e54de3006",
           "tweak": "5080dd547abdeddd",
-          "msg": "N6w}GDs&",
-          "ct": "IURsx>sD",
+          "msg": "N6-}GDt&",
+          "ct": "IURtx>tD",
           "result": "invalid"
         },
         {
@@ -2636,7 +2636,7 @@
           ],
           "key": "ebc261665fab01ae2bfe156e54de3006",
           "tweak": "5080dd547abdeddd",
-          "msg": "N6`}GDs'",
+          "msg": "N6`}GDt-",
           "ct": "E}CiGhDi",
           "result": "invalid"
         },
@@ -2648,7 +2648,7 @@
           ],
           "key": "6cb9784804579638c14b7e47a961bd04",
           "tweak": "111046603935363e",
-          "msg": "\u007fP|h)0Me",
+          "msg": "-P|h)0Me",
           "ct": ">xgpOpYH",
           "result": "invalid"
         },
@@ -2660,8 +2660,8 @@
           ],
           "key": "6cb9784804579638c14b7e47a961bd04",
           "tweak": "111046603935363e",
-          "msg": "BP\u007fh)0Me",
-          "ct": "sCz*yBki",
+          "msg": "BP-h)0Me",
+          "ct": "tCz*yBki",
           "result": "invalid"
         },
         {
@@ -2672,14 +2672,14 @@
           ],
           "key": "6cb9784804579638c14b7e47a961bd04",
           "tweak": "111046603935363e",
-          "msg": "BP|h)0M\u007f",
+          "msg": "BP|h)0M-",
           "ct": "CDZCV241",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 9,
       "radix": 85,
@@ -2693,7 +2693,7 @@
           ],
           "key": "2215b9528000f5f306fcdfe2969c6785",
           "tweak": "0539d85c7b076285",
-          "msg": "QE=E!UuS%",
+          "msg": "QE=E!UvS%",
           "ct": "T^xB<%?k~",
           "result": "valid"
         },
@@ -2706,7 +2706,7 @@
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
           "msg": "000000000",
-          "ct": "g_r}s+rNO",
+          "ct": "g_r}t+rNO",
           "result": "valid"
         },
         {
@@ -2729,7 +2729,7 @@
           ],
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
-          "msg": "ttI2|NtC1",
+          "msg": "ssI2|NsC1",
           "ct": "`_mM}Q!oF",
           "result": "valid"
         },
@@ -2741,7 +2741,7 @@
           ],
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
-          "msg": "ttI1|NtC0",
+          "msg": "ssI1|NsC0",
           "ct": "PB<@DF^e7",
           "result": "valid"
         },
@@ -2765,7 +2765,7 @@
           ],
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
-          "msg": "p_$Gh1!N+",
+          "msg": "p:$Gh1!N+",
           "ct": "K#xB}1o2H",
           "result": "valid"
         },
@@ -2778,7 +2778,7 @@
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
           "msg": "DyIQL&=Ua",
-          "ct": "jfnub~sHr",
+          "ct": "jfnvb~tHr",
           "result": "valid"
         },
         {
@@ -2789,7 +2789,7 @@
           ],
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
-          "msg": "dtezp6|?J",
+          "msg": "dsezp6|?J",
           "ct": "Q}~%o|c5=",
           "result": "valid"
         },
@@ -2801,7 +2801,7 @@
           ],
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
-          "msg": "cttzAJ+up",
+          "msg": "csuzAJ+vp",
           "ct": "g>FZU%>h|",
           "result": "valid"
         },
@@ -2814,7 +2814,7 @@
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
           "msg": "5I(lph?B2",
-          "ct": "_SfhaZt0H",
+          "ct": ":SfhaZu0H",
           "result": "valid"
         },
         {
@@ -2838,7 +2838,7 @@
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
           "msg": "`k@`LV`~6",
-          "ct": "^<~>ss}8j",
+          "ct": "^<~>tt}8j",
           "result": "valid"
         },
         {
@@ -2849,7 +2849,7 @@
           ],
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
-          "msg": "oyJt$XDxz",
+          "msg": "oyJu$XDxz",
           "ct": "000000000",
           "result": "valid"
         },
@@ -2873,8 +2873,8 @@
           ],
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
-          "msg": "ai_T<>tzW",
-          "ct": "ttI2|NtC1",
+          "msg": "ai:T<>uzW",
+          "ct": "ssI2|NsC1",
           "result": "valid"
         },
         {
@@ -2885,8 +2885,8 @@
           ],
           "key": "4c00ade3e32b12866bb56e736e18eaf4",
           "tweak": "3f0bf1e88240178e",
-          "msg": ";vLdoJ^YF",
-          "ct": "ttI1|NtC0",
+          "msg": ";wLdoJ^YF",
+          "ct": "ssI1|NsC0",
           "result": "valid"
         },
         {
@@ -2897,8 +2897,8 @@
           ],
           "key": "7fd4e71784e95a3dd0b41315a67131d2",
           "tweak": "47d48ea4716ab8df",
-          "msg": "[Cr^N1gnV",
-          "ct": "Ms&N1q`<e",
+          "msg": "-Cr^N1gnV",
+          "ct": "Mt&N1q`<e",
           "result": "invalid"
         },
         {
@@ -2909,7 +2909,7 @@
           ],
           "key": "7fd4e71784e95a3dd0b41315a67131d2",
           "tweak": "47d48ea4716ab8df",
-          "msg": "hCr:N1gnV",
+          "msg": "hCr-N1gnV",
           "ct": "o|EL+Z;)h",
           "result": "invalid"
         },
@@ -2921,8 +2921,8 @@
           ],
           "key": "7fd4e71784e95a3dd0b41315a67131d2",
           "tweak": "47d48ea4716ab8df",
-          "msg": "hCr^N1gn.",
-          "ct": "t7r5t)P>t",
+          "msg": "hCr^N1gn-",
+          "ct": "u7r5u)P>u",
           "result": "invalid"
         },
         {
@@ -2933,8 +2933,8 @@
           ],
           "key": "10af46b4f75183288f95e0e16a6dd195",
           "tweak": "b8dd0f629003f9e6",
-          "msg": "\u007fGg{6CgaT",
-          "ct": "3H{SNBa^s",
+          "msg": "-Gg{6CgaT",
+          "ct": "3H{SNBa^t",
           "result": "invalid"
         },
         {
@@ -2945,7 +2945,7 @@
           ],
           "key": "10af46b4f75183288f95e0e16a6dd195",
           "tweak": "b8dd0f629003f9e6",
-          "msg": "9Gg\u007f6CgaT",
+          "msg": "9Gg-6CgaT",
           "ct": "*yFMd$0n<",
           "result": "invalid"
         },
@@ -2957,14 +2957,14 @@
           ],
           "key": "10af46b4f75183288f95e0e16a6dd195",
           "tweak": "b8dd0f629003f9e6",
-          "msg": "9Gg{6Cga\u007f",
-          "ct": "_?Aoi46ar",
+          "msg": "9Gg{6Cga-",
+          "ct": ":?Aoi46ar",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 10,
       "radix": 85,
@@ -2978,7 +2978,7 @@
           ],
           "key": "5474525ca99fb5da2babdbd45c727d16",
           "tweak": "f2cb4d9ba04b81f8",
-          "msg": "5tSuxB|QLK",
+          "msg": "5sSvxB|QLK",
           "ct": "VcM3yhdZYA",
           "result": "valid"
         },
@@ -2991,7 +2991,7 @@
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
           "msg": "0000000000",
-          "ct": "8lsNQKT8|+",
+          "ct": "8ltNQKT8|+",
           "result": "valid"
         },
         {
@@ -3014,8 +3014,8 @@
           ],
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
-          "msg": "|NtC1|NtC1",
-          "ct": "uS?RBnY*=a",
+          "msg": "|NsC1|NsC1",
+          "ct": "vS?RBnY*=a",
           "result": "valid"
         },
         {
@@ -3026,7 +3026,7 @@
           ],
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
-          "msg": "|NtC0|NtC0",
+          "msg": "|NsC0|NsC0",
           "ct": "X<QMd)k7U*",
           "result": "valid"
         },
@@ -3038,8 +3038,8 @@
           ],
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
-          "msg": "YU;@vt_Dpz",
-          "ct": "jIiCsR2v7_",
+          "msg": "YU;@wu:Dpz",
+          "ct": "jIiCtR2w7:",
           "result": "valid"
         },
         {
@@ -3050,8 +3050,8 @@
           ],
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
-          "msg": "g*i#;%tP~Z",
-          "ct": "ggYs9z_zm=",
+          "msg": "g*i#;%uP~Z",
+          "ct": "ggYt9z_zm=",
           "result": "valid"
         },
         {
@@ -3063,7 +3063,7 @@
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
           "msg": "Tby$Z{b+*;",
-          "ct": "ty|)&BFHyQ",
+          "ct": "uy|)&BFHyQ",
           "result": "valid"
         },
         {
@@ -3074,7 +3074,7 @@
           ],
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
-          "msg": ";irj46v=3q",
+          "msg": ";irj46w=3q",
           "ct": "2mpg4}Fo{q",
           "result": "valid"
         },
@@ -3087,7 +3087,7 @@
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
           "msg": "q{^i0ao;$?",
-          "ct": "syB>4IQ==_",
+          "ct": "tyB>4IQ==_",
           "result": "valid"
         },
         {
@@ -3111,7 +3111,7 @@
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
           "msg": "{gY!Fe~3eZ",
-          "ct": "F%WNr_`fR5",
+          "ct": "F%WNr:`fR5",
           "result": "valid"
         },
         {
@@ -3146,7 +3146,7 @@
           ],
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
-          "msg": "+q5L~_b~v7",
+          "msg": "+q5L~_b~w7",
           "ct": "~~~~~~~~~~",
           "result": "valid"
         },
@@ -3158,8 +3158,8 @@
           ],
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
-          "msg": "l#3FO_WYyX",
-          "ct": "|NtC1|NtC1",
+          "msg": "l#3FO:WYyX",
+          "ct": "|NsC1|NsC1",
           "result": "valid"
         },
         {
@@ -3171,7 +3171,7 @@
           "key": "3e7ffa3f410e329464ad1d205799b3d5",
           "tweak": "0d5a58b58855ef5a",
           "msg": "$Z;WV{m$^{",
-          "ct": "|NtC0|NtC0",
+          "ct": "|NsC0|NsC0",
           "result": "valid"
         },
         {
@@ -3183,7 +3183,7 @@
           "key": "7b64450714b0a262376044de6e260f0a",
           "tweak": "df18d08c340846b22926",
           "msg": ">}2yFUhPe4",
-          "ct": "s06hL{zQM;",
+          "ct": "t06hL{zQM;",
           "result": "valid"
         },
         {
@@ -3194,8 +3194,8 @@
           ],
           "key": "7b64450714b0a262376044de6e260f0a",
           "tweak": "df18d08c340846b22926",
-          "msg": "nvPOF|`jBX",
-          "ct": "+yI_vL^dhC",
+          "msg": "nwPOF|`jBX",
+          "ct": "+yI_wL^dhC",
           "result": "valid"
         },
         {
@@ -3206,7 +3206,7 @@
           ],
           "key": "7b64450714b0a262376044de6e260f0a",
           "tweak": "df18d08c340846b22926",
-          "msg": "q|8PepCMvN",
+          "msg": "q|8PepCMwN",
           "ct": "ILW!G}{q|A",
           "result": "valid"
         },
@@ -3218,7 +3218,7 @@
           ],
           "key": "7b64450714b0a262376044de6e260f0a",
           "tweak": "df18d08c340846b22926",
-          "msg": "_9@~y>B*oC",
+          "msg": ":9@~y>B*oC",
           "ct": "OH*R+$WF0?",
           "result": "valid"
         },
@@ -3231,7 +3231,7 @@
           "key": "7b64450714b0a262376044de6e260f0a",
           "tweak": "df18d08c340846b22926",
           "msg": "gB*}@rRIfb",
-          "ct": "vmgeyxlJJ1",
+          "ct": "wmgeyxlJJ1",
           "result": "valid"
         },
         {
@@ -3243,7 +3243,7 @@
           "key": "7b64450714b0a262376044de6e260f0a",
           "tweak": "df18d08c340846b22926",
           "msg": "(n!Mde1K1o",
-          "ct": "l;zX%2_Ztg",
+          "ct": "l;zX%2:Zsg",
           "result": "valid"
         },
         {
@@ -3254,7 +3254,7 @@
           ],
           "key": "c2153daac19904cf16ea81dbc73a58dc",
           "tweak": "38b7196a238d3892",
-          "msg": "]!}%H4$p>>",
+          "msg": "-!}%H4$p>>",
           "ct": "@`6NIN&faY",
           "result": "invalid"
         },
@@ -3266,7 +3266,7 @@
           ],
           "key": "c2153daac19904cf16ea81dbc73a58dc",
           "tweak": "38b7196a238d3892",
-          "msg": "Z!}:H4$p>>",
+          "msg": "Z!}-H4$p>>",
           "ct": "!n?*iqS3AG",
           "result": "invalid"
         },
@@ -3278,8 +3278,8 @@
           ],
           "key": "c2153daac19904cf16ea81dbc73a58dc",
           "tweak": "38b7196a238d3892",
-          "msg": "Z!}%H4$p>/",
-          "ct": "5x5dtcZhG<",
+          "msg": "Z!}%H4$p>-",
+          "ct": "5x5dscZhG<",
           "result": "invalid"
         },
         {
@@ -3290,7 +3290,7 @@
           ],
           "key": "f7c3222a5fa86886cae44aa0929b9f00",
           "tweak": "1438411d3e200ede",
-          "msg": "\u007fa}(F57#LV",
+          "msg": "-a}(F57#LV",
           "ct": "Sa`oO;+Ldo",
           "result": "invalid"
         },
@@ -3302,8 +3302,8 @@
           ],
           "key": "f7c3222a5fa86886cae44aa0929b9f00",
           "tweak": "1438411d3e200ede",
-          "msg": "ta}\u007fF57#LV",
-          "ct": "?Cp3_}IE0v",
+          "msg": "ua}-F57#LV",
+          "ct": "?Cp3_}IE0w",
           "result": "invalid"
         },
         {
@@ -3314,14 +3314,14 @@
           ],
           "key": "f7c3222a5fa86886cae44aa0929b9f00",
           "tweak": "1438411d3e200ede",
-          "msg": "ta}(F57#L\u007f",
+          "msg": "ua}(F57#L-",
           "ct": "<8(9S2=gIZ",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 11,
       "radix": 85,
@@ -3336,7 +3336,7 @@
           "key": "63396f38c44f0c2d97468c4804b5d022",
           "tweak": "73068af95fd924fc",
           "msg": "m<~fBZE%Z36",
-          "ct": "++K!N0fFktG",
+          "ct": "++K!N0fFkuG",
           "result": "valid"
         },
         {
@@ -3360,7 +3360,7 @@
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
           "msg": "~~~~~~~~~~~",
-          "ct": "2g*KXD@t}*&",
+          "ct": "2g*KXD@s}*&",
           "result": "valid"
         },
         {
@@ -3371,7 +3371,7 @@
           ],
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
-          "msg": "|NtC1z`(%3$",
+          "msg": "|NsC1z`(%3$",
           "ct": "#8zIbQl704Y",
           "result": "valid"
         },
@@ -3383,7 +3383,7 @@
           ],
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
-          "msg": "|NtC0z`(%3#",
+          "msg": "|NsC0z`(%3#",
           "ct": "B)0S)@?0NI%",
           "result": "valid"
         },
@@ -3408,7 +3408,7 @@
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
           "msg": "cSfM+=#9cKd",
-          "ct": "u;bhD_#~lMt",
+          "ct": "v;bhD:#~lMs",
           "result": "valid"
         },
         {
@@ -3431,8 +3431,8 @@
           ],
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
-          "msg": "pxq9cndVdmt",
-          "ct": "I?Gp;m5t7{=",
+          "msg": "pxq9cndVdmu",
+          "ct": "I?Gp;m5s7{=",
           "result": "valid"
         },
         {
@@ -3467,8 +3467,8 @@
           ],
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
-          "msg": "G1jMytT*x6q",
-          "ct": "rR_LZ<*W4Vc",
+          "msg": "G1jMysT*x6q",
+          "ct": "rR:LZ<*W4Vc",
           "result": "valid"
         },
         {
@@ -3491,7 +3491,7 @@
           ],
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
-          "msg": "H=Gmt7DFG=Z",
+          "msg": "H=Gms7DFG=Z",
           "ct": "00000000000",
           "result": "valid"
         },
@@ -3503,7 +3503,7 @@
           ],
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
-          "msg": "QfxL>+0_(}>",
+          "msg": "QfxL>+0:(}>",
           "ct": "~~~~~~~~~~~",
           "result": "valid"
         },
@@ -3515,8 +3515,8 @@
           ],
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
-          "msg": "IU7P)P*hJ8t",
-          "ct": "|NtC1z`(%3$",
+          "msg": "IU7P)P*hJ8s",
+          "ct": "|NsC1z`(%3$",
           "result": "valid"
         },
         {
@@ -3528,7 +3528,7 @@
           "key": "cd69e5d5444781e0645ba24b2a32dee8",
           "tweak": "e1310d099e8e72c6",
           "msg": "}1y<!)pefN+",
-          "ct": "|NtC0z`(%3#",
+          "ct": "|NsC0z`(%3#",
           "result": "valid"
         },
         {
@@ -3552,7 +3552,7 @@
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "5daf59643f03d2b3c582",
           "msg": "00001NCCp!n",
-          "ct": "e)YeV_jyoP7",
+          "ct": "e)YeV:jyoP7",
           "result": "valid"
         },
         {
@@ -3563,8 +3563,8 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "5daf59643f03d2b3c582",
-          "msg": "|NtC1NCCp!n",
-          "ct": "UcuFZQd(M2{",
+          "msg": "|NsC1NCCp!n",
+          "ct": "UcvFZQd(M2{",
           "result": "valid"
         },
         {
@@ -3587,7 +3587,7 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "04ff1a1a2598995cf474",
-          "msg": "UuxQ^)UkMZn",
+          "msg": "UvxQ^)UkMZn",
           "ct": "=Z})*Gi@Ti<",
           "result": "valid"
         },
@@ -3599,7 +3599,7 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "04ff1a1a2598995cf474",
-          "msg": "zZ+)pt2a81>",
+          "msg": "zZ+)pu2a81>",
           "ct": "hKl1NZJ4~iH",
           "result": "valid"
         },
@@ -3623,7 +3623,7 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "04ff1a1a2598995cf474",
-          "msg": "n<8JMs@$Ce%",
+          "msg": "n<8JMt@$Ce%",
           "ct": "0K+yRm9M`in",
           "result": "valid"
         },
@@ -3635,8 +3635,8 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "04ff1a1a2598995cf474",
-          "msg": "M4Xt9sr)DC#",
-          "ct": "p>JSXBdR_d&",
+          "msg": "M4Xu9tr)DC#",
+          "ct": "p>JSXBdR:d&",
           "result": "valid"
         },
         {
@@ -3684,7 +3684,7 @@
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "ca0820c9389cf2296ac5",
           "msg": "e30n0aH2CJ^",
-          "ct": "8r9#__jVCPT",
+          "ct": "8r9#_:jVCPT",
           "result": "valid"
         },
         {
@@ -3695,7 +3695,7 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "ca0820c9389cf2296ac5",
-          "msg": "|NtC1aH2CJ^",
+          "msg": "|NsC1aH2CJ^",
           "ct": "k9)09%iM<!1",
           "result": "valid"
         },
@@ -3719,8 +3719,8 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "8d3a5dfc413dd2c9421f",
-          "msg": "000003_1yD@",
-          "ct": "Xo2_U0=;FEo",
+          "msg": "000003:1yD@",
+          "ct": "Xo2:U0=;FEo",
           "result": "valid"
         },
         {
@@ -3731,7 +3731,7 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "8d3a5dfc413dd2c9421f",
-          "msg": "000013_1yD@",
+          "msg": "000013:1yD@",
           "ct": "H=l5|%dN_5q",
           "result": "valid"
         },
@@ -3743,8 +3743,8 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "8d3a5dfc413dd2c9421f",
-          "msg": "|NtC13_1yD@",
-          "ct": "#?s^{^TnZrF",
+          "msg": "|NsC13:1yD@",
+          "ct": "#?t^{^TnZrF",
           "result": "valid"
         },
         {
@@ -3755,8 +3755,8 @@
           ],
           "key": "6c6ec910e1fcdff2f0df935de10d0560",
           "tweak": "8d3a5dfc413dd2c9421f",
-          "msg": "~~~~~3_1yD@",
-          "ct": "Nfu~eQJHriI",
+          "msg": "~~~~~3:1yD@",
+          "ct": "Nfv~eQJHriI",
           "result": "valid"
         },
         {
@@ -3767,8 +3767,8 @@
           ],
           "key": "0b55b77a1d06778b795b541037eabb26",
           "tweak": "3e26f18ba99add01",
-          "msg": ".y4~fOhLq5*",
-          "ct": "o(V>stf;p7m",
+          "msg": "-y4~fOhLq5*",
+          "ct": "o(V>tsf;p7m",
           "result": "invalid"
         },
         {
@@ -3779,8 +3779,8 @@
           ],
           "key": "0b55b77a1d06778b795b541037eabb26",
           "tweak": "3e26f18ba99add01",
-          "msg": "ly4,fOhLq5*",
-          "ct": "l9_*dq!_r*t",
+          "msg": "ly4-fOhLq5*",
+          "ct": "l9_*dq!_r*s",
           "result": "invalid"
         },
         {
@@ -3791,8 +3791,8 @@
           ],
           "key": "0b55b77a1d06778b795b541037eabb26",
           "tweak": "3e26f18ba99add01",
-          "msg": "ly4~fOhLq5[",
-          "ct": "sbkATpYDp6Q",
+          "msg": "ly4~fOhLq5-",
+          "ct": "tbkATpYDp6Q",
           "result": "invalid"
         },
         {
@@ -3803,7 +3803,7 @@
           ],
           "key": "a754f6fc7f0951eb0648539d6bda0bc0",
           "tweak": "32b0c3770e08d939",
-          "msg": "\u007fd+EY>Jx|Us",
+          "msg": "-d+EY>Jx|Ut",
           "ct": "gS_X!Blj_q&",
           "result": "invalid"
         },
@@ -3815,8 +3815,8 @@
           ],
           "key": "a754f6fc7f0951eb0648539d6bda0bc0",
           "tweak": "32b0c3770e08d939",
-          "msg": "ed+\u007fY>Jx|Us",
-          "ct": "ltbkN*S@r1$",
+          "msg": "ed+-Y>Jx|Ut",
+          "ct": "lsbkN*S@r1$",
           "result": "invalid"
         },
         {
@@ -3827,14 +3827,14 @@
           ],
           "key": "a754f6fc7f0951eb0648539d6bda0bc0",
           "tweak": "32b0c3770e08d939",
-          "msg": "ed+EY>Jx|U\u007f",
+          "msg": "ed+EY>Jx|U-",
           "ct": "7l^mIRl_)9S",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 12,
       "radix": 85,
@@ -3848,8 +3848,8 @@
           ],
           "key": "ddc31fc7751a2bf5c8d2d815035622e8",
           "tweak": "0e10628c19795c4e",
-          "msg": "8#?QM8fS!D_s",
-          "ct": "l^c_TP4i*7jx",
+          "msg": "8#?QM8fS!D_t",
+          "ct": "l^c:TP4i*7jx",
           "result": "valid"
         },
         {
@@ -3861,7 +3861,7 @@
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
           "msg": "000000000000",
-          "ct": "?cS(CH_cbFm;",
+          "ct": "?cS(CH:cbFm;",
           "result": "valid"
         },
         {
@@ -3885,7 +3885,7 @@
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
           "msg": "z`(%3$z`(%3$",
-          "ct": "X;5KW|txlLZD",
+          "ct": "X;5KW|sxlLZD",
           "result": "valid"
         },
         {
@@ -3897,7 +3897,7 @@
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
           "msg": "z`(%3#z`(%3#",
-          "ct": "tBp#}m;NQBuv",
+          "ct": "uBp#}m;NQBvw",
           "result": "valid"
         },
         {
@@ -3908,7 +3908,7 @@
           ],
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
-          "msg": "^+1D0vcyjWVe",
+          "msg": "^+1D0wcyjWVe",
           "ct": "_fnPO|b!%A0}",
           "result": "valid"
         },
@@ -3920,7 +3920,7 @@
           ],
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
-          "msg": "v$1~co2qt5a_",
+          "msg": "w$1~co2qs5a:",
           "ct": "rG%j0X$+^zCd",
           "result": "valid"
         },
@@ -3933,7 +3933,7 @@
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
           "msg": "xIxm3Bhgm&mk",
-          "ct": "Za)yt9{|7^T?",
+          "ct": "Za)ys9{|7^T?",
           "result": "valid"
         },
         {
@@ -3956,7 +3956,7 @@
           ],
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
-          "msg": "ERtSCM11l&t<",
+          "msg": "ERsSCM11l&u<",
           "ct": "O+rpjITl@F`|",
           "result": "valid"
         },
@@ -3981,7 +3981,7 @@
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
           "msg": "(kmTkO%W#K?+",
-          "ct": "%B_~Vgt|$TCn",
+          "ct": "%B:~Vgu|$TCn",
           "result": "valid"
         },
         {
@@ -3992,7 +3992,7 @@
           ],
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
-          "msg": "UMy_E?cuf>_)",
+          "msg": "UMy_E?cvf>_)",
           "ct": "2Eb<X6l)j41k",
           "result": "valid"
         },
@@ -4016,7 +4016,7 @@
           ],
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
-          "msg": "ZClp9Tfj9tMz",
+          "msg": "ZClp9Tfj9sMz",
           "ct": "~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -4040,7 +4040,7 @@
           ],
           "key": "d954ee3f3fabdcd92a2ad30b675ef74d",
           "tweak": "bb3a5b86df3e19bc",
-          "msg": "gnnXtdV~;4TZ",
+          "msg": "gnnXsdV~;4TZ",
           "ct": "z`(%3#z`(%3#",
           "result": "valid"
         },
@@ -4077,7 +4077,7 @@
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "78c72c59da58df9b303c",
           "msg": "z`(%3$j}0?lh",
-          "ct": "blOaisYsb58L",
+          "ct": "blOaitYtb58L",
           "result": "valid"
         },
         {
@@ -4089,7 +4089,7 @@
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "78c72c59da58df9b303c",
           "msg": "~~~~~~j}0?lh",
-          "ct": "hW0|t=D5Jsg(",
+          "ct": "hW0|s=D5Jtg(",
           "result": "valid"
         },
         {
@@ -4100,8 +4100,8 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "a20c8902ac38fecbd4e3",
-          "msg": "dc;K$3ks+?!_",
-          "ct": "Miv$HcZK{tlv",
+          "msg": "dc;K$3kt+?!:",
+          "ct": "Miw$HcZK{slw",
           "result": "valid"
         },
         {
@@ -4112,8 +4112,8 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "a20c8902ac38fecbd4e3",
-          "msg": "ny|5xt^1Ee@L",
-          "ct": "tXb>&#v7C}od",
+          "msg": "ny|5xu^1Ee@L",
+          "ct": "uXb>&#w7C}od",
           "result": "valid"
         },
         {
@@ -4124,8 +4124,8 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "a20c8902ac38fecbd4e3",
-          "msg": "c1BEZWtc6d#a",
-          "ct": "4G?+m#}=E{sG",
+          "msg": "c1BEZWuc6d#a",
+          "ct": "4G?+m#}=E{tG",
           "result": "valid"
         },
         {
@@ -4136,8 +4136,8 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "a20c8902ac38fecbd4e3",
-          "msg": "dTxbt4OP#?Tf",
-          "ct": "y^@9^Ht;Jp(s",
+          "msg": "dTxbs4OP#?Tf",
+          "ct": "y^@9^Hu;Jp(t",
           "result": "valid"
         },
         {
@@ -4148,7 +4148,7 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "a20c8902ac38fecbd4e3",
-          "msg": "VPUC31Wl_v9H",
+          "msg": "VPUC31Wl_w9H",
           "ct": "zH|x?!T1QC=y",
           "result": "valid"
         },
@@ -4160,7 +4160,7 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "e1fade2a313d8e1dbb61",
-          "msg": "h5fD%6Cttxa>",
+          "msg": "h5fD%6Cssxa>",
           "ct": "%7KFmlh3a)%f",
           "result": "valid"
         },
@@ -4172,7 +4172,7 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "e1fade2a313d8e1dbb61",
-          "msg": "rDKXSkdE)t{<",
+          "msg": "rDKXSkdE)s{<",
           "ct": "ITfY8ZKI6Uyg",
           "result": "valid"
         },
@@ -4185,7 +4185,7 @@
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "e1fade2a313d8e1dbb61",
           "msg": "ec_<FpWk`8Nq",
-          "ct": "Wgx+EN+Vt6eu",
+          "ct": "Wgx+EN+Vs6ev",
           "result": "valid"
         },
         {
@@ -4197,7 +4197,7 @@
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "e1fade2a313d8e1dbb61",
           "msg": "_<e%KLp#Qacm",
-          "ct": "a!Yso|bGxD?v",
+          "ct": "a!Yto|bGxD?w",
           "result": "valid"
         },
         {
@@ -4208,8 +4208,8 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "e1fade2a313d8e1dbb61",
-          "msg": "Dk&bS3yt3Q9Z",
-          "ct": "K4Pte0p@gtDC",
+          "msg": "Dk&bS3yu3Q9Z",
+          "ct": "K4Pue0p@guDC",
           "result": "valid"
         },
         {
@@ -4221,7 +4221,7 @@
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "e1fade2a313d8e1dbb61",
           "msg": "KOSeDT*{A;8<",
-          "ct": "rfLHD%oWm(7v",
+          "ct": "rfLHD%oWm(7w",
           "result": "valid"
         },
         {
@@ -4233,7 +4233,7 @@
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "106ce156060064d813fd",
           "msg": "Q;cN~D@HC6ec",
-          "ct": "dRBFFP<_c_>_",
+          "ct": "dRBFFP<_c:>:",
           "result": "valid"
         },
         {
@@ -4244,7 +4244,7 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "106ce156060064d813fd",
-          "msg": "|R!W(c{Kt50g",
+          "msg": "|R!W(c{Ku50g",
           "ct": "#gTb&IXd_d$m",
           "result": "valid"
         },
@@ -4257,7 +4257,7 @@
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "106ce156060064d813fd",
           "msg": "(6k$`gVk)8~?",
-          "ct": "B)Bt^6T#kX(M",
+          "ct": "B)Bu^6T#kX(M",
           "result": "valid"
         },
         {
@@ -4268,8 +4268,8 @@
           ],
           "key": "a3e590e923e5c47a216ec271e9da8180",
           "tweak": "106ce156060064d813fd",
-          "msg": "(_~WW_zE_`nv",
-          "ct": "bK!CI__VI>i)",
+          "msg": "(:~WW:zE_`nw",
+          "ct": "bK!CI:_VI>i)",
           "result": "valid"
         },
         {
@@ -4280,8 +4280,8 @@
           ],
           "key": "dbac185fba36fe7028184de1a577dbaa",
           "tweak": "6ba28735b4acc0ff",
-          "msg": "'O2huF#b2p}Q",
-          "ct": "p<X>FXgys%tn",
+          "msg": "-O2hvF#b2p}Q",
+          "ct": "p<X>FXgyt%sn",
           "result": "invalid"
         },
         {
@@ -4292,7 +4292,7 @@
           ],
           "key": "dbac185fba36fe7028184de1a577dbaa",
           "tweak": "6ba28735b4acc0ff",
-          "msg": "BO2h,F#b2p}Q",
+          "msg": "BO2h-F#b2p}Q",
           "ct": "lxg;E(Aze)11",
           "result": "invalid"
         },
@@ -4304,8 +4304,8 @@
           ],
           "key": "dbac185fba36fe7028184de1a577dbaa",
           "tweak": "6ba28735b4acc0ff",
-          "msg": "BO2huF#b2p}'",
-          "ct": "s#G`P8TFx!b?",
+          "msg": "BO2hvF#b2p}-",
+          "ct": "t#G`P8TFx!b?",
           "result": "invalid"
         },
         {
@@ -4316,8 +4316,8 @@
           ],
           "key": "ff48b85aef731a80f4d7d296403e3912",
           "tweak": "39f246baa909dee0",
-          "msg": "\u007f64);ixTiFm2",
-          "ct": "i)A_5}d+kt6b",
+          "msg": "-64);ixTiFm2",
+          "ct": "i)A:5}d+ks6b",
           "result": "invalid"
         },
         {
@@ -4328,8 +4328,8 @@
           ],
           "key": "ff48b85aef731a80f4d7d296403e3912",
           "tweak": "39f246baa909dee0",
-          "msg": "Z64)\u007fixTiFm2",
-          "ct": "PtB9kY0Xu*hM",
+          "msg": "Z64)-ixTiFm2",
+          "ct": "PsB9kY0Xv*hM",
           "result": "invalid"
         },
         {
@@ -4340,14 +4340,14 @@
           ],
           "key": "ff48b85aef731a80f4d7d296403e3912",
           "tweak": "39f246baa909dee0",
-          "msg": "Z64);ixTiFm\u007f",
-          "ct": "00=d|@P^>Ju5",
+          "msg": "Z64);ixTiFm-",
+          "ct": "00=d|@P^>Jv5",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 13,
       "radix": 85,
@@ -4361,7 +4361,7 @@
           ],
           "key": "d5e6c882f005525ce577f704ef6b525d",
           "tweak": "7ce1a7a4e6508c83",
-          "msg": "DtD}<gY}*$}(^",
+          "msg": "DsD}<gY}*$}(^",
           "ct": "DBqLr@nE+i*r}",
           "result": "valid"
         },
@@ -4374,7 +4374,7 @@
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
           "msg": "0000000000000",
-          "ct": "m1(xbSUtXA2Ap",
+          "ct": "m1(xbSUsXA2Ap",
           "result": "valid"
         },
         {
@@ -4397,7 +4397,7 @@
           ],
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
-          "msg": "z`(%3$kt_1|+G",
+          "msg": "z`(%3$ks:1|+G",
           "ct": "~q6d`UD2C!xP4",
           "result": "valid"
         },
@@ -4409,8 +4409,8 @@
           ],
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
-          "msg": "z`(%3#kt_1|+F",
-          "ct": "PBX7aK1$aEt<0",
+          "msg": "z`(%3#ks:1|+F",
+          "ct": "PBX7aK1$aEs<0",
           "result": "valid"
         },
         {
@@ -4421,7 +4421,7 @@
           ],
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
-          "msg": "Skb2`P6t~@_Z!",
+          "msg": "Skb2`P6u~@:Z!",
           "ct": "&e~2}kA78GPQX",
           "result": "valid"
         },
@@ -4433,8 +4433,8 @@
           ],
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
-          "msg": "840LrkAM(uNUk",
-          "ct": "N}K*n*x+Rb*Ds",
+          "msg": "840LrkAM(vNUk",
+          "ct": "N}K*n*x+Rb*Dt",
           "result": "valid"
         },
         {
@@ -4482,7 +4482,7 @@
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
           "msg": "BepYxIXxa1?)%",
-          "ct": "R#rXt>?_8C&z+",
+          "ct": "R#rXs>?:8C&z+",
           "result": "valid"
         },
         {
@@ -4493,8 +4493,8 @@
           ],
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
-          "msg": "sN;XUSB8sn+V@",
-          "ct": "ZDzsh%8cY494W",
+          "msg": "tN;XUSB8tn+V@",
+          "ct": "ZDzth%8cY494W",
           "result": "valid"
         },
         {
@@ -4505,8 +4505,8 @@
           ],
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
-          "msg": "^#vt;*P)tq54U",
-          "ct": "EElsbztci6!<N",
+          "msg": "^#ws;*P)sq54U",
+          "ct": "EEltbzuci6!<N",
           "result": "valid"
         },
         {
@@ -4529,7 +4529,7 @@
           ],
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
-          "msg": "_XmuJcrKoRI4N",
+          "msg": ":XmvJcrKoRI4N",
           "ct": "~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -4542,7 +4542,7 @@
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
           "msg": "+(2leHDd2?&xh",
-          "ct": "z`(%3$kt_1|+G",
+          "ct": "z`(%3$ks:1|+G",
           "result": "valid"
         },
         {
@@ -4553,8 +4553,8 @@
           ],
           "key": "bb7ca258d353deb4a4f52b08290ab6a1",
           "tweak": "a211ccbb8d59238e",
-          "msg": ")*VnlEqv5GJ<3",
-          "ct": "z`(%3#kt_1|+F",
+          "msg": ")*VnlEqw5GJ<3",
+          "ct": "z`(%3#ks:1|+F",
           "result": "valid"
         },
         {
@@ -4566,7 +4566,7 @@
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "0e0d4d470362e57d7d",
           "msg": "he0h$F=&Vxe%d",
-          "ct": "000000Z(OtX{x",
+          "ct": "000000Z(OuX{x",
           "result": "valid"
         },
         {
@@ -4577,8 +4577,8 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "0e0d4d470362e57d7d",
-          "msg": "`ME`P9`7F}sk9",
-          "ct": "0000016tNn(@X",
+          "msg": "`ME`P9`7F}tk9",
+          "ct": "0000016uNn(@X",
           "result": "valid"
         },
         {
@@ -4589,7 +4589,7 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "0e0d4d470362e57d7d",
-          "msg": "+4j3(_O}bgZ!Y",
+          "msg": "+4j3(:O}bgZ!Y",
           "ct": "z`(%3$Rb$|@J0",
           "result": "valid"
         },
@@ -4601,8 +4601,8 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "0e0d4d470362e57d7d",
-          "msg": "oB6x!2sJt?Ae9",
-          "ct": "~~~~~~RNCshSU",
+          "msg": "oB6x!2tJs?Ae9",
+          "ct": "~~~~~~RNCthSU",
           "result": "valid"
         },
         {
@@ -4613,8 +4613,8 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "9eb0d2215b31c5b1f6",
-          "msg": "4iZx&v3a$QtS3",
-          "ct": "*#RiQkNsW;PZ`",
+          "msg": "4iZx&w3a$QsS3",
+          "ct": "*#RiQkNtW;PZ`",
           "result": "valid"
         },
         {
@@ -4638,7 +4638,7 @@
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "9eb0d2215b31c5b1f6",
           "msg": "(}zU!LocF(8j_",
-          "ct": "+X%9(0N7t&tEX",
+          "ct": "+X%9(0N7s&uEX",
           "result": "valid"
         },
         {
@@ -4649,7 +4649,7 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "9eb0d2215b31c5b1f6",
-          "msg": "C}U|oBt9GGGfn",
+          "msg": "C}U|oBs9GGGfn",
           "ct": "bP9EU8pXN(0|Z",
           "result": "valid"
         },
@@ -4661,7 +4661,7 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "9eb0d2215b31c5b1f6",
-          "msg": "2HViEusT$_j#x",
+          "msg": "2HViEvtT$_j#x",
           "ct": ">{(#QUI+f%|@?",
           "result": "valid"
         },
@@ -4673,7 +4673,7 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "effae9b491b67ea0e6",
-          "msg": "|eK_oez=$^X1_",
+          "msg": "|eK:oez=$^X1_",
           "ct": "#i{~a04n9=n7%",
           "result": "valid"
         },
@@ -4686,7 +4686,7 @@
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "effae9b491b67ea0e6",
           "msg": "(WleZP3M84aW;",
-          "ct": "#i{~a1+ztqT3D",
+          "ct": "#i{~a1+zuqT3D",
           "result": "valid"
         },
         {
@@ -4698,7 +4698,7 @@
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "effae9b491b67ea0e6",
           "msg": "rYEyR&LI~~6Zj",
-          "ct": "~~~~~~7CO8t=A",
+          "ct": "~~~~~~7CO8u=A",
           "result": "valid"
         },
         {
@@ -4709,7 +4709,7 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "effae9b491b67ea0e6",
-          "msg": "a;UNfd;vDy>U!",
+          "msg": "a;UNfd;wDy>U!",
           "ct": "000000{bzEn@A",
           "result": "valid"
         },
@@ -4721,8 +4721,8 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "effae9b491b67ea0e6",
-          "msg": "7~<_bYF+_pO$!",
-          "ct": "ee$$d$m+_z)@O",
+          "msg": "7~<:bYF+:pO$!",
+          "ct": "ee$$d$m+:z)@O",
           "result": "valid"
         },
         {
@@ -4733,8 +4733,8 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "effae9b491b67ea0e6",
-          "msg": "V=^^A1KsUY68G",
-          "ct": "#i{~Z~c@D#;4t",
+          "msg": "V=^^A1KtUY68G",
+          "ct": "#i{~Z~c@D#;4u",
           "result": "valid"
         },
         {
@@ -4745,8 +4745,8 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "438f2178ec264492c2",
-          "msg": "(7euFX+58#CHO",
-          "ct": "{CArXquTiZKj$",
+          "msg": "(7evFX+58#CHO",
+          "ct": "{CArXqvTiZKj$",
           "result": "valid"
         },
         {
@@ -4781,8 +4781,8 @@
           ],
           "key": "002d4f865568a9c32a7edeb2b39d73d7",
           "tweak": "438f2178ec264492c2",
-          "msg": "!2(yo54n_sbjA",
-          "ct": "^?@v>)`2B&*W2",
+          "msg": "!2(yo54n_tbjA",
+          "ct": "^?@w>)`2B&*W2",
           "result": "valid"
         },
         {
@@ -4793,8 +4793,8 @@
           ],
           "key": "b8d9b3c80209587bbe3c0f7125eed049",
           "tweak": "522499e28e9e7712",
-          "msg": ",+#Z}@vxSz?o?",
-          "ct": "lmDLGxbGt}JkZ",
+          "msg": "-+#Z}@wxSz?o?",
+          "ct": "lmDLGxbGs}JkZ",
           "result": "invalid"
         },
         {
@@ -4805,7 +4805,7 @@
           ],
           "key": "b8d9b3c80209587bbe3c0f7125eed049",
           "tweak": "522499e28e9e7712",
-          "msg": "P+#Zw@vxSz?o?",
+          "msg": "P+#Z-@wxSz?o?",
           "ct": "7qreNKxqc>%Ko",
           "result": "invalid"
         },
@@ -4817,7 +4817,7 @@
           ],
           "key": "b8d9b3c80209587bbe3c0f7125eed049",
           "tweak": "522499e28e9e7712",
-          "msg": "P+#Z}@vxSz?o'",
+          "msg": "P+#Z}@wxSz?o-",
           "ct": "Nm%A$+Sf`q$!S",
           "result": "invalid"
         },
@@ -4829,8 +4829,8 @@
           ],
           "key": "5c5e833700f02242ede38a4b94dbf6bd",
           "tweak": "b6991bed3073a7ba",
-          "msg": "\u007f^>1<a2m>HP^=",
-          "ct": "Htp_5~APo2z3F",
+          "msg": "-^>1<a2m>HP^=",
+          "ct": "Hup_5~APo2z3F",
           "result": "invalid"
         },
         {
@@ -4841,7 +4841,7 @@
           ],
           "key": "5c5e833700f02242ede38a4b94dbf6bd",
           "tweak": "b6991bed3073a7ba",
-          "msg": "T^>1\u007fa2m>HP^=",
+          "msg": "T^>1-a2m>HP^=",
           "ct": "`p1rc#$eG}XXT",
           "result": "invalid"
         },
@@ -4853,14 +4853,14 @@
           ],
           "key": "5c5e833700f02242ede38a4b94dbf6bd",
           "tweak": "b6991bed3073a7ba",
-          "msg": "T^>1<a2m>HP^\u007f",
+          "msg": "T^>1<a2m>HP^-",
           "ct": "?$6%=@r;hyoYK",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 14,
       "radix": 85,
@@ -4874,8 +4874,8 @@
           ],
           "key": "7a1122636a4417351c97156308d4f6aa",
           "tweak": "a9508e64d1ab8e34",
-          "msg": "~K=p7_a==y*YP$",
-          "ct": "60t_rT$x43N#?v",
+          "msg": "~K=p7:a==y*YP$",
+          "ct": "60u:rT$x43N#?w",
           "result": "valid"
         },
         {
@@ -4887,7 +4887,7 @@
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
           "msg": "00000000000000",
-          "ct": "4{)`>+s@y4_jh9",
+          "ct": "4{)`>+t@y4_jh9",
           "result": "valid"
         },
         {
@@ -4899,7 +4899,7 @@
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
           "msg": "~~~~~~~~~~~~~~",
-          "ct": ";mxBu|!^nO7I?u",
+          "ct": ";mxBv|!^nO7I?v",
           "result": "valid"
         },
         {
@@ -4910,7 +4910,7 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "kt_1|+Gkt_1|+G",
+          "msg": "ks:1|+Gks:1|+G",
           "ct": "30SiHhQT+X5j4y",
           "result": "valid"
         },
@@ -4922,7 +4922,7 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "kt_1|+Fkt_1|+F",
+          "msg": "ks:1|+Fks:1|+F",
           "ct": "|2mXG8o8<i?~$8",
           "result": "valid"
         },
@@ -4934,7 +4934,7 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "DmJ#ul$fopfCY8",
+          "msg": "DmJ#vl$fopfCY8",
           "ct": "}LGGJ?P$RV`qdM",
           "result": "valid"
         },
@@ -4946,7 +4946,7 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "+2r7tMp4}<y~@B",
+          "msg": "+2r7sMp4}<y~@B",
           "ct": ";MiQd;h8fp4=WA",
           "result": "valid"
         },
@@ -4970,8 +4970,8 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "UIrHdXvS7bu4lS",
-          "ct": "f^_^Lt_Fk=@WB6",
+          "msg": "UIrHdXwS7bv4lS",
+          "ct": "f^_^Lu_Fk=@WB6",
           "result": "valid"
         },
         {
@@ -4982,8 +4982,8 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "$0oZT!6t>U$4?4",
-          "ct": "!8Ssakb4OJAH{0",
+          "msg": "$0oZT!6s>U$4?4",
+          "ct": "!8Stakb4OJAH{0",
           "result": "valid"
         },
         {
@@ -4995,7 +4995,7 @@
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
           "msg": "_XQp5cN5SYM|xk",
-          "ct": "alkdn7Ic_0XpRp",
+          "ct": "alkdn7Ic:0XpRp",
           "result": "valid"
         },
         {
@@ -5006,7 +5006,7 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "nJ<`c}yi*~u<=x",
+          "msg": "nJ<`c}yi*~v<=x",
           "ct": "WyDR@ne9}p*Ll(",
           "result": "valid"
         },
@@ -5018,8 +5018,8 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "s2^#?IPvAO*eHL",
-          "ct": "_X#IRzt2#OL`)Q",
+          "msg": "t2^#?IPwAO*eHL",
+          "ct": "_X#IRzs2#OL`)Q",
           "result": "valid"
         },
         {
@@ -5030,7 +5030,7 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": ">Xnz68zT_6TeHl",
+          "msg": ">Xnz68zT:6TeHl",
           "ct": "00000000000000",
           "result": "valid"
         },
@@ -5054,8 +5054,8 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "G+H#Ou!D=r%OmI",
-          "ct": "kt_1|+Gkt_1|+G",
+          "msg": "G+H#Ov!D=r%OmI",
+          "ct": "ks:1|+Gks:1|+G",
           "result": "valid"
         },
         {
@@ -5066,8 +5066,8 @@
           ],
           "key": "8a9c22148e4fed1fc918f33eba1f06cc",
           "tweak": "c37a26d7ade80ea1",
-          "msg": "td9%BOGIP0);fV",
-          "ct": "kt_1|+Fkt_1|+F",
+          "msg": "ud9%BOGIP0);fV",
+          "ct": "ks:1|+Fks:1|+F",
           "result": "valid"
         },
         {
@@ -5079,7 +5079,7 @@
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "d17581b5ca51d224c1",
           "msg": "0$iB#jnhqnG_Qz",
-          "ct": "0000000tM<dtt$",
+          "ct": "0000000sM<dss$",
           "result": "valid"
         },
         {
@@ -5102,8 +5102,8 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "d17581b5ca51d224c1",
-          "msg": "Z$F+#~dNh4IsdP",
-          "ct": "kt_1|+G}DBs1;P",
+          "msg": "Z$F+#~dNh4ItdP",
+          "ct": "ks:1|+G}DBt1;P",
           "result": "valid"
         },
         {
@@ -5115,7 +5115,7 @@
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "d17581b5ca51d224c1",
           "msg": "@ljj$@fo&;z0MZ",
-          "ct": "~~~~~~~_bHs*B_",
+          "ct": "~~~~~~~_bHt*B:",
           "result": "valid"
         },
         {
@@ -5138,7 +5138,7 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "d37f56ece0a2fe91c5",
-          "msg": "n;dt>lKE)Q6ht<",
+          "msg": "n;ds>lKE)Q6hu<",
           "ct": "0000002|A>#d|6",
           "result": "valid"
         },
@@ -5150,8 +5150,8 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "d37f56ece0a2fe91c5",
-          "msg": "~|u=u#31$lX?y@",
-          "ct": "kt_1|+H_(|xCmZ",
+          "msg": "~|v=v#31$lX?y@",
+          "ct": "ks:1|+H:(|xCmZ",
           "result": "valid"
         },
         {
@@ -5162,7 +5162,7 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "d37f56ece0a2fe91c5",
-          "msg": "ZAe>6ZG$nfNvbi",
+          "msg": "ZAe>6ZG$nfNwbi",
           "ct": "~~~~~~~}Lf8WBN",
           "result": "valid"
         },
@@ -5174,8 +5174,8 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "d37f56ece0a2fe91c5",
-          "msg": "@3_`Fky_^*pLN9",
-          "ct": "0000000J%|#M>s",
+          "msg": "@3:`Fky_^*pLN9",
+          "ct": "0000000J%|#M>t",
           "result": "valid"
         },
         {
@@ -5198,7 +5198,7 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "67451dfbe3cc868dc6",
-          "msg": "XAt(tkL1(nVcDi",
+          "msg": "XAs(skL1(nVcDi",
           "ct": "oxP;fC^4BV+53^",
           "result": "valid"
         },
@@ -5222,7 +5222,7 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "67451dfbe3cc868dc6",
-          "msg": "Ik9RQ?WT;mQs@Z",
+          "msg": "Ik9RQ?WT;mQt@Z",
           "ct": "}!SeU)0TxVySg0",
           "result": "valid"
         },
@@ -5246,8 +5246,8 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "67451dfbe3cc868dc6",
-          "msg": "qR}p>f~_5d>FE4",
-          "ct": "tU_ev_CgV`;cQj",
+          "msg": "qR}p>f~:5d>FE4",
+          "ct": "sU_ew:CgV`;cQj",
           "result": "valid"
         },
         {
@@ -5258,8 +5258,8 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "fd8f80ff92d18abf5d",
-          "msg": "RoMn7qqu&rE13<",
-          "ct": "<(&G`R?Xmtu4e~",
+          "msg": "RoMn7qqv&rE13<",
+          "ct": "<(&G`R?Xmuv4e~",
           "result": "valid"
         },
         {
@@ -5270,8 +5270,8 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "fd8f80ff92d18abf5d",
-          "msg": "!xkTfl2M+_OpM0",
-          "ct": "h_<x%7_$m@=%Th",
+          "msg": "!xkTfl2M+:OpM0",
+          "ct": "h:<x%7:$m@=%Th",
           "result": "valid"
         },
         {
@@ -5283,7 +5283,7 @@
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "fd8f80ff92d18abf5d",
           "msg": "SFG6pIIFAVDB9F",
-          "ct": "XFtsS;2}+Ce?3+",
+          "ct": "XFstS;2}+Ce?3+",
           "result": "valid"
         },
         {
@@ -5294,8 +5294,8 @@
           ],
           "key": "4dfedd6f97765da94b445cc712ea4e7f",
           "tweak": "fd8f80ff92d18abf5d",
-          "msg": "A{<N?ISnuXoQbj",
-          "ct": "k4;d=9)>6_*h<n",
+          "msg": "A{<N?ISnvXoQbj",
+          "ct": "k4;d=9)>6:*h<n",
           "result": "valid"
         },
         {
@@ -5318,7 +5318,7 @@
           ],
           "key": "3a6e047dffbfcdaf0ee7e0c93fc4c0e0",
           "tweak": "0e5628b6bce472c6",
-          "msg": "&{TU[o>zfFEd=~",
+          "msg": "&{TU-o>zfFEd=~",
           "ct": "&bj9geO@RV2*V`",
           "result": "invalid"
         },
@@ -5342,8 +5342,8 @@
           ],
           "key": "ffc854633e5caab4f4a9b5234a849ab3",
           "tweak": "7907414657d8c61f",
-          "msg": "\u007f?=mlz{Pa5^JTO",
-          "ct": "2uB$4WH5_Rf`h{",
+          "msg": "-?=mlz{Pa5^JTO",
+          "ct": "2vB$4WH5_Rf`h{",
           "result": "invalid"
         },
         {
@@ -5354,8 +5354,8 @@
           ],
           "key": "ffc854633e5caab4f4a9b5234a849ab3",
           "tweak": "7907414657d8c61f",
-          "msg": ")?=m\u007fz{Pa5^JTO",
-          "ct": "hdI?;F<L2iQ@s9",
+          "msg": ")?=m-z{Pa5^JTO",
+          "ct": "hdI?;F<L2iQ@t9",
           "result": "invalid"
         },
         {
@@ -5366,14 +5366,14 @@
           ],
           "key": "ffc854633e5caab4f4a9b5234a849ab3",
           "tweak": "7907414657d8c61f",
-          "msg": ")?=mlz{Pa5^JT\u007f",
+          "msg": ")?=mlz{Pa5^JT-",
           "ct": "C{0{Z~@&zR!Chc",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 15,
       "radix": 85,
@@ -5387,8 +5387,8 @@
           ],
           "key": "7b0c5d430ef9383b04b2691ce3402a9a",
           "tweak": "ec71532112064259",
-          "msg": "m2tu}&(i~RpWtf2",
-          "ct": "?}>@_rHT9t}9V;1",
+          "msg": "m2sv}&(i~RpWsf2",
+          "ct": "?}>@:rHT9u}9V;1",
           "result": "valid"
         },
         {
@@ -5400,7 +5400,7 @@
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
           "msg": "000000000000000",
-          "ct": "aBaS_`qv&DH8bMo",
+          "ct": "aBaS_`qw&DH8bMo",
           "result": "valid"
         },
         {
@@ -5423,8 +5423,8 @@
           ],
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
-          "msg": "kt_1|+G+Km`|zx8",
-          "ct": "$Eht?6SUl~1M<&R",
+          "msg": "ks:1|+G+Km`|zx8",
+          "ct": "$Ehu?6SUl~1M<&R",
           "result": "valid"
         },
         {
@@ -5435,7 +5435,7 @@
           ],
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
-          "msg": "kt_1|+F+Km`|zx7",
+          "msg": "ks:1|+F+Km`|zx7",
           "ct": "3WXblMe3L1H#o9#",
           "result": "valid"
         },
@@ -5459,8 +5459,8 @@
           ],
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
-          "msg": "u5p}ApVsegr?Z9d",
-          "ct": "`|#g^io9+=^_>4t",
+          "msg": "v5p}ApVtegr?Z9d",
+          "ct": "`|#g^io9+=^_>4s",
           "result": "valid"
         },
         {
@@ -5472,7 +5472,7 @@
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
           "msg": "e*hED{<!V{WWHZL",
-          "ct": "xv8_hXnA=2cqed>",
+          "ct": "xw8_hXnA=2cqed>",
           "result": "valid"
         },
         {
@@ -5483,8 +5483,8 @@
           ],
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
-          "msg": "gL@<C94*1FMyv()",
-          "ct": "=GPmNxqBED@pn_@",
+          "msg": "gL@<C94*1FMyw()",
+          "ct": "=GPmNxqBED@pn:@",
           "result": "valid"
         },
         {
@@ -5507,8 +5507,8 @@
           ],
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
-          "msg": "|vAO&o4LfRQ=rr`",
-          "ct": "ZS|E+z%ft_b2c%G",
+          "msg": "|wAO&o4LfRQ=rr`",
+          "ct": "ZS|E+z%fs:b2c%G",
           "result": "valid"
         },
         {
@@ -5519,7 +5519,7 @@
           ],
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
-          "msg": "zD<Tn<}JeAW_aF9",
+          "msg": "zD<Tn<}JeAW:aF9",
           "ct": "M?P10}|nPzLeda3",
           "result": "valid"
         },
@@ -5555,7 +5555,7 @@
           ],
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
-          "msg": "I_ans3l}N*dXXgt",
+          "msg": "I:ant3l}N*dXXgs",
           "ct": "~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -5567,8 +5567,8 @@
           ],
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
-          "msg": "z>s6u@seS>#+@tg",
-          "ct": "kt_1|+G+Km`|zx8",
+          "msg": "z>t6v@teS>#+@sg",
+          "ct": "ks:1|+G+Km`|zx8",
           "result": "valid"
         },
         {
@@ -5580,7 +5580,7 @@
           "key": "bd2dc7f87af6e676fa6bf4e92c43f183",
           "tweak": "71e1ede1a7e70a42",
           "msg": "6A_g0KA5U)2+VnV",
-          "ct": "kt_1|+F+Km`|zx7",
+          "ct": "ks:1|+F+Km`|zx7",
           "result": "valid"
         },
         {
@@ -5592,7 +5592,7 @@
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "c171c07fb966d7ec",
           "msg": "0000000QA${NR{|",
-          "ct": "5!ZYs_>Q78$`ItL",
+          "ct": "5!ZYt:>Q78$`IsL",
           "result": "valid"
         },
         {
@@ -5604,7 +5604,7 @@
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "c171c07fb966d7ec",
           "msg": "0000001QA${NR{|",
-          "ct": "?Cm~*iVt&=>0*%D",
+          "ct": "?Cm~*iVs&=>0*%D",
           "result": "valid"
         },
         {
@@ -5615,8 +5615,8 @@
           ],
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "c171c07fb966d7ec",
-          "msg": "kt_1|+GQA${NR{|",
-          "ct": "3N#6_?$}Xv*0b2_",
+          "msg": "ks:1|+GQA${NR{|",
+          "ct": "3N#6_?$}Xw*0b2_",
           "result": "valid"
         },
         {
@@ -5628,7 +5628,7 @@
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "c171c07fb966d7ec",
           "msg": "~~~~~~~QA${NR{|",
-          "ct": "Ws;zWOpQWA9N;IE",
+          "ct": "Wt;zWOpQWA9N;IE",
           "result": "valid"
         },
         {
@@ -5652,7 +5652,7 @@
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "e911920044011a7c",
           "msg": "?8{!69E)z4~~(a<",
-          "ct": "IyOAIore_1_i8iO",
+          "ct": "IyOAIore_1:i8iO",
           "result": "valid"
         },
         {
@@ -5664,7 +5664,7 @@
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "e911920044011a7c",
           "msg": "@Ym3i5meiGhjb=<",
-          "ct": "Nir+Fz!Av?`fpxB",
+          "ct": "Nir+Fz!Aw?`fpxB",
           "result": "valid"
         },
         {
@@ -5675,8 +5675,8 @@
           ],
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "e911920044011a7c",
-          "msg": "9KthsqB<Ftduf;2",
-          "ct": "yu<NT!vBIB@vB^7",
+          "msg": "9KshtqB<Fsdvf;2",
+          "ct": "yv<NT!wBIB@wB^7",
           "result": "valid"
         },
         {
@@ -5687,8 +5687,8 @@
           ],
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "e911920044011a7c",
-          "msg": "}{f1tcH)CDb&(+m",
-          "ct": "T#jisJm0;V3tYNa",
+          "msg": "}{f1scH)CDb&(+m",
+          "ct": "T#jitJm0;V3sYNa",
           "result": "valid"
         },
         {
@@ -5699,7 +5699,7 @@
           ],
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "f29bd15c959752db",
-          "msg": "0;5MtiLfi2(Va+k",
+          "msg": "0;5MuiLfi2(Va+k",
           "ct": "~~~~~~~`P@K&}DD",
           "result": "valid"
         },
@@ -5711,7 +5711,7 @@
           ],
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "f29bd15c959752db",
-          "msg": "abz3)Mzu3?}9_61",
+          "msg": "abz3)Mzv3?}9:61",
           "ct": "00000000D$G436y",
           "result": "valid"
         },
@@ -5723,8 +5723,8 @@
           ],
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "f29bd15c959752db",
-          "msg": "{JRu!cZpDm6|7r1",
-          "ct": "kt_1|+F_fO+15sW",
+          "msg": "{JRv!cZpDm6|7r1",
+          "ct": "ks:1|+F:fO+15tW",
           "result": "valid"
         },
         {
@@ -5736,7 +5736,7 @@
           "key": "b4aac83ef6dc59fd0ab9a7692e6ef3c4",
           "tweak": "f29bd15c959752db",
           "msg": "I%e{D%U2!hJ7e{e",
-          "ct": "~~~~~~}3I@=tXig",
+          "ct": "~~~~~~}3I@=sXig",
           "result": "valid"
         },
         {
@@ -5747,7 +5747,7 @@
           ],
           "key": "18f316e92e027b0d4d068bb94f8dd864",
           "tweak": "17d37026864474b3",
-          "msg": "w6Fxg^M`b`Pb<M7",
+          "msg": "-6Fxg^M`b`Pb<M7",
           "ct": "#8`J>_j7^adjBA_",
           "result": "invalid"
         },
@@ -5759,8 +5759,8 @@
           ],
           "key": "18f316e92e027b0d4d068bb94f8dd864",
           "tweak": "17d37026864474b3",
-          "msg": "s6Fxg/M`b`Pb<M7",
-          "ct": "roIWS3=B_oh}_l9",
+          "msg": "t6Fxg-M`b`Pb<M7",
+          "ct": "roIWS3=B:oh}_l9",
           "result": "invalid"
         },
         {
@@ -5771,8 +5771,8 @@
           ],
           "key": "18f316e92e027b0d4d068bb94f8dd864",
           "tweak": "17d37026864474b3",
-          "msg": "s6Fxg^M`b`Pb<M'",
-          "ct": "a6;i9}{tAR56=(Q",
+          "msg": "t6Fxg^M`b`Pb<M-",
+          "ct": "a6;i9}{uAR56=(Q",
           "result": "invalid"
         },
         {
@@ -5783,8 +5783,8 @@
           ],
           "key": "b3561c3b9c0eb1856d9549791056ca3c",
           "tweak": "6eb52db288622550",
-          "msg": "\u007fxf1_3Q=cdM~%jq",
-          "ct": "y7iBXbDuN=NE_`5",
+          "msg": "-xf1:3Q=cdM~%jq",
+          "ct": "y7iBXbDvN=NE:`5",
           "result": "invalid"
         },
         {
@@ -5795,8 +5795,8 @@
           ],
           "key": "b3561c3b9c0eb1856d9549791056ca3c",
           "tweak": "6eb52db288622550",
-          "msg": "Oxf1_\u007fQ=cdM~%jq",
-          "ct": "0Asm3JRDhz8L$hh",
+          "msg": "Oxf1:-Q=cdM~%jq",
+          "ct": "0Atm3JRDhz8L$hh",
           "result": "invalid"
         },
         {
@@ -5807,14 +5807,14 @@
           ],
           "key": "b3561c3b9c0eb1856d9549791056ca3c",
           "tweak": "6eb52db288622550",
-          "msg": "Oxf1_3Q=cdM~%j\u007f",
-          "ct": "aC_u&d&bEma)GBO",
+          "msg": "Oxf1:3Q=cdM~%j-",
+          "ct": "aC_v&d&bEma)GBO",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 16,
       "radix": 85,
@@ -5828,8 +5828,8 @@
           ],
           "key": "48f0d03e41cc55c4b58f737b5acdea32",
           "tweak": "30944debca89ca90",
-          "msg": "Nj}i>4I`uB+uPJ_4",
-          "ct": "{R{d4Ktv%5lR@G6e",
+          "msg": "Nj}i>4I`vB+vPJ_4",
+          "ct": "{R{d4Ksw%5lR@G6e",
           "result": "valid"
         },
         {
@@ -5841,7 +5841,7 @@
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
           "msg": "0000000000000000",
-          "ct": "kIdJ3sv%~>t^UGR0",
+          "ct": "kIdJ3tw%~>s^UGR0",
           "result": "valid"
         },
         {
@@ -5877,7 +5877,7 @@
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
           "msg": "+Km`|zx7+Km`|zx7",
-          "ct": ">s39gYa?lL)Xb=*q",
+          "ct": ">t39gYa?lL)Xb=*q",
           "result": "valid"
         },
         {
@@ -5888,8 +5888,8 @@
           ],
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
-          "msg": "kPvfcX^a(ffnxxr#",
-          "ct": "vX+CUGEB+QNl31}h",
+          "msg": "kPwfcX^a(ffnxxr#",
+          "ct": "wX+CUGEB+QNl31}h",
           "result": "valid"
         },
         {
@@ -5900,7 +5900,7 @@
           ],
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
-          "msg": "dHTFsrF|3;jhLgXt",
+          "msg": "dHTFtrF|3;jhLgXs",
           "ct": "UB7Y0AJ_|Xkpk4f%",
           "result": "valid"
         },
@@ -5912,8 +5912,8 @@
           ],
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
-          "msg": "9Q(M#M02cvt+}rI|",
-          "ct": "4~2TTN_$*`rCM%Ex",
+          "msg": "9Q(M#M02cwu+}rI|",
+          "ct": "4~2TTN:$*`rCM%Ex",
           "result": "valid"
         },
         {
@@ -5925,7 +5925,7 @@
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
           "msg": "b~V_QNBCGh<HP&TQ",
-          "ct": "f)Q<s;`g4A|;aPXl",
+          "ct": "f)Q<t;`g4A|;aPXl",
           "result": "valid"
         },
         {
@@ -5937,7 +5937,7 @@
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
           "msg": "~iM4S7Pfb9#0R%IH",
-          "ct": "Y1?T^>vWogCVcb(m",
+          "ct": "Y1?T^>wWogCVcb(m",
           "result": "valid"
         },
         {
@@ -5948,8 +5948,8 @@
           ],
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
-          "msg": "B4Nbpu@}dC_BCrL(",
-          "ct": "KXYerSGb_iULfh&j",
+          "msg": "B4Nbpv@}dC_BCrL(",
+          "ct": "KXYerSGb:iULfh&j",
           "result": "valid"
         },
         {
@@ -5960,7 +5960,7 @@
           ],
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
-          "msg": "2u94^tJD50dB=gZI",
+          "msg": "2v94^uJD50dB=gZI",
           "ct": "!XQdY@lE~Qfi7G&o",
           "result": "valid"
         },
@@ -5973,7 +5973,7 @@
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
           "msg": "of7!3jUar?@;Ac&Y",
-          "ct": "g8XMUL+O2Au_*#A1",
+          "ct": "g8XMUL+O2Av:*#A1",
           "result": "valid"
         },
         {
@@ -6008,7 +6008,7 @@
           ],
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
-          "msg": "J_FnttgSj>tVA*Io",
+          "msg": "J_FnuugSj>sVA*Io",
           "ct": "+Km`|zx8+Km`|zx8",
           "result": "valid"
         },
@@ -6020,7 +6020,7 @@
           ],
           "key": "58a68a9bf81642540bcff165563af592",
           "tweak": "a4a9513e222fab29",
-          "msg": "q_3nIV|7_k=V2CXK",
+          "msg": "q:3nIV|7:k=V2CXK",
           "ct": "+Km`|zx7+Km`|zx7",
           "result": "valid"
         },
@@ -6032,8 +6032,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "265d02df9e53e514",
-          "msg": "u=fdS54?D(HGshpb",
-          "ct": "}a=7;+n+Gu#z=jsL",
+          "msg": "v=fdS54?D(HGthpb",
+          "ct": "}a=7;+n+Gv#z=jtL",
           "result": "valid"
         },
         {
@@ -6056,7 +6056,7 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "265d02df9e53e514",
-          "msg": "JStu~(ITE}xIH0MI",
+          "msg": "JSuv~(ITE}xIH0MI",
           "ct": "gyj+*n?6p{^6HA%Y",
           "result": "valid"
         },
@@ -6068,7 +6068,7 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "265d02df9e53e514",
-          "msg": "9&t~2Lz3tC`Bz3_R",
+          "msg": "9&u~2Lz3uC`Bz3:R",
           "ct": "CkcE+OI+{bSl~$xL",
           "result": "valid"
         },
@@ -6081,7 +6081,7 @@
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "9aed0a545dfe58aa",
           "msg": "%meCc@(n_|?$eQFJ",
-          "ct": "Yt0YNW_aorF{~Qt%",
+          "ct": "Yu0YNW:aorF{~Qs%",
           "result": "valid"
         },
         {
@@ -6092,8 +6092,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "9aed0a545dfe58aa",
-          "msg": "}Dh)zuAbavvR9tnu",
-          "ct": "2?`Wn`#DW1m!(v_b",
+          "msg": "}Dh)zvAbawwR9snv",
+          "ct": "2?`Wn`#DW1m!(w:b",
           "result": "valid"
         },
         {
@@ -6104,7 +6104,7 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "9aed0a545dfe58aa",
-          "msg": "7u35Qu&j8cKr(kg=",
+          "msg": "7v35Qv&j8cKr(kg=",
           "ct": "?_gnUpN;_1nJK=2R",
           "result": "valid"
         },
@@ -6116,8 +6116,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "9aed0a545dfe58aa",
-          "msg": "AjUW8dsFs#e!(iRt",
-          "ct": "OTGrOlAuF4Ax=xvJ",
+          "msg": "AjUW8dtFt#e!(iRu",
+          "ct": "OTGrOlAvF4Ax=xwJ",
           "result": "valid"
         },
         {
@@ -6128,8 +6128,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "9aed0a545dfe58aa",
-          "msg": "udjf`fH8_W+g$Q%s",
-          "ct": "}0no|x@6s0_0hA`!",
+          "msg": "vdjf`fH8_W+g$Q%t",
+          "ct": "}0no|x@6t0:0hA`!",
           "result": "valid"
         },
         {
@@ -6141,7 +6141,7 @@
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "374513cc8a0f162a",
           "msg": ">ZJM7T|*AO<edG#T",
-          "ct": "J)rRnQ1!R~gt)_~~",
+          "ct": "J)rRnQ1!R~gs):~~",
           "result": "valid"
         },
         {
@@ -6153,7 +6153,7 @@
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "374513cc8a0f162a",
           "msg": "B&OWR_+MXYlNf=iC",
-          "ct": "UP%Q%u3G`tGgi>X#",
+          "ct": "UP%Q%v3G`uGgi>X#",
           "result": "valid"
         },
         {
@@ -6164,7 +6164,7 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "374513cc8a0f162a",
-          "msg": "fb0)i1kMVPsddiy)",
+          "msg": "fb0)i1kMVPtddiy)",
           "ct": "CEOf(gES_P76b8g<",
           "result": "valid"
         },
@@ -6176,8 +6176,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "374513cc8a0f162a",
-          "msg": "~cd9AnqHW0pumn++",
-          "ct": "0a9$%I5~utf(VG)?",
+          "msg": "~cd9AnqHW0pvmn++",
+          "ct": "0a9$%I5~vsf(VG)?",
           "result": "valid"
         },
         {
@@ -6189,7 +6189,7 @@
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "374513cc8a0f162a",
           "msg": "2ISir!yRDl5pU_J3",
-          "ct": "hgZ2@jUOf^v%@In=",
+          "ct": "hgZ2@jUOf^w%@In=",
           "result": "valid"
         },
         {
@@ -6200,8 +6200,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "374513cc8a0f162a",
-          "msg": "C+duoAkBMGPb}lNT",
-          "ct": "%Yzrgajb!B3ntZtU",
+          "msg": "C+dvoAkBMGPb}lNT",
+          "ct": "%Yzrgajb!B3nuZsU",
           "result": "valid"
         },
         {
@@ -6212,8 +6212,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "b659fc7dc3b46fb7",
-          "msg": "GN)t!uhCE~0<)Qot",
-          "ct": "o$ByFoQt%#n<G8@Z",
+          "msg": "GN)u!vhCE~0<)Qou",
+          "ct": "o$ByFoQu%#n<G8@Z",
           "result": "valid"
         },
         {
@@ -6224,7 +6224,7 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "b659fc7dc3b46fb7",
-          "msg": "{*l)}}k2s`ZvTL>U",
+          "msg": "{*l)}}k2t`ZwTL>U",
           "ct": "m>d88ZROP1@#L<nq",
           "result": "valid"
         },
@@ -6236,8 +6236,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "b659fc7dc3b46fb7",
-          "msg": "t@g4H+m9qrxrlIjZ",
-          "ct": "ztNjuFbC8kULagvX",
+          "msg": "u@g4H+m9qrxrlIjZ",
+          "ct": "zsNjvFbC8kULagwX",
           "result": "valid"
         },
         {
@@ -6248,8 +6248,8 @@
           ],
           "key": "ce2295b38289779ad19a532cd6be845b",
           "tweak": "b659fc7dc3b46fb7",
-          "msg": "~Eu;l_!Hby}!+pGk",
-          "ct": "?qUJA<&)o#+_k?A3",
+          "msg": "~Ev;l_!Hby}!+pGk",
+          "ct": "?qUJA<&)o#+:k?A3",
           "result": "valid"
         },
         {
@@ -6260,8 +6260,8 @@
           ],
           "key": "c3a8f68c88eeea1a255db6a7e012ec22",
           "tweak": "a841e8a1819dfb69",
-          "msg": "]IaRZ1fHWzlsZKaS",
-          "ct": "MsxeE8zSe77G%aCn",
+          "msg": "-IaRZ1fHWzltZKaS",
+          "ct": "MtxeE8zSe77G%aCn",
           "result": "invalid"
         },
         {
@@ -6272,8 +6272,8 @@
           ],
           "key": "c3a8f68c88eeea1a255db6a7e012ec22",
           "tweak": "a841e8a1819dfb69",
-          "msg": "gIaRZ.fHWzlsZKaS",
-          "ct": "Yt?m63d~D_kVB0`a",
+          "msg": "gIaRZ-fHWzltZKaS",
+          "ct": "Ys?m63d~D_kVB0`a",
           "result": "invalid"
         },
         {
@@ -6284,7 +6284,7 @@
           ],
           "key": "c3a8f68c88eeea1a255db6a7e012ec22",
           "tweak": "a841e8a1819dfb69",
-          "msg": "gIaRZ1fHWzlsZKa]",
+          "msg": "gIaRZ1fHWzltZKa-",
           "ct": "?((MG;L;y<0IE#@4",
           "result": "invalid"
         },
@@ -6296,8 +6296,8 @@
           ],
           "key": "30af095690a2f3d944cc254e64acd8f2",
           "tweak": "ac1248e7f1960aa8",
-          "msg": "\u007fTrra0>8ArE|c<2^",
-          "ct": ")g6^RCTPnNLJFtU5",
+          "msg": "-Trra0>8ArE|c<2^",
+          "ct": ")g6^RCTPnNLJFuU5",
           "result": "invalid"
         },
         {
@@ -6308,7 +6308,7 @@
           ],
           "key": "30af095690a2f3d944cc254e64acd8f2",
           "tweak": "ac1248e7f1960aa8",
-          "msg": "+Trra\u007f>8ArE|c<2^",
+          "msg": "+Trra->8ArE|c<2^",
           "ct": "+G<nbO*BUnyZL}+@",
           "result": "invalid"
         },
@@ -6320,14 +6320,14 @@
           ],
           "key": "30af095690a2f3d944cc254e64acd8f2",
           "tweak": "ac1248e7f1960aa8",
-          "msg": "+Trra0>8ArE|c<2\u007f",
-          "ct": "d=C$bv=lKx3;C=FP",
+          "msg": "+Trra0>8ArE|c<2-",
+          "ct": "d=C$bw=lKx3;C=FP",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 17,
       "radix": 85,
@@ -6341,7 +6341,7 @@
           ],
           "key": "22351a53774415942eb879b483eda9a2",
           "tweak": "b4a5dce9958d53fc",
-          "msg": "Va?KVCzZuX4r4oz0g",
+          "msg": "Va?KVCzZvX4r4oz0g",
           "ct": "<n`M|HbdO86kC6xnX",
           "result": "valid"
         },
@@ -6354,7 +6354,7 @@
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
           "msg": "00000000000000000",
-          "ct": "7S$uOo^qef=HpliO%",
+          "ct": "7S$vOo^qef=HpliO%",
           "result": "valid"
         },
         {
@@ -6366,7 +6366,7 @@
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
           "msg": "~~~~~~~~~~~~~~~~~",
-          "ct": "!ueu_@b(*7cJY5&x<",
+          "ct": "!vev_@b(*7cJY5&x<",
           "result": "valid"
         },
         {
@@ -6378,7 +6378,7 @@
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
           "msg": "+Km`|zx8q>f;|Ocg2",
-          "ct": "{>KF>7h`kc1P&t3QT",
+          "ct": "{>KF>7h`kc1P&s3QT",
           "result": "valid"
         },
         {
@@ -6390,7 +6390,7 @@
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
           "msg": "+Km`|zx7q>f;|Ocg1",
-          "ct": "WDt=%~i@t}LlGs}_7",
+          "ct": "WDu=%~i@s}LlGt}_7",
           "result": "valid"
         },
         {
@@ -6402,7 +6402,7 @@
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
           "msg": "dp&ME$1AraSxXX4%o",
-          "ct": "s0QqnF_zApA`@dVV6",
+          "ct": "t0QqnF:zApA`@dVV6",
           "result": "valid"
         },
         {
@@ -6413,8 +6413,8 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": "o7h)yXJ25J}S_#_I7",
-          "ct": "tm4J)&x9>}vP;Xxk(",
+          "msg": "o7h)yXJ25J}S:#:I7",
+          "ct": "um4J)&x9>}wP;Xxk(",
           "result": "valid"
         },
         {
@@ -6425,7 +6425,7 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": "d4?h)STv_!e6*IK7H",
+          "msg": "d4?h)STw_!e6*IK7H",
           "ct": "OdB(}VdR1g(ki58F!",
           "result": "valid"
         },
@@ -6437,8 +6437,8 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": "i^^2s$p<_j_Mn{H)%",
-          "ct": ";pZCAF1~zOJ3a9ovN",
+          "msg": "i^^2t$p<_j_Mn{H)%",
+          "ct": ";pZCAF1~zOJ3a9owN",
           "result": "valid"
         },
         {
@@ -6461,8 +6461,8 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": "gtf7P%tzi^sUm~Oxo",
-          "ct": "u)BnuKfR65u7^`FQA",
+          "msg": "gsf7P%szi^tUm~Oxo",
+          "ct": "v)BnvKfR65v7^`FQA",
           "result": "valid"
         },
         {
@@ -6474,7 +6474,7 @@
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
           "msg": "3p3%52M1O&XzFfSz2",
-          "ct": ">!+C&5yt=R;9B9V{;",
+          "ct": ">!+C&5yu=R;9B9V{;",
           "result": "valid"
         },
         {
@@ -6485,8 +6485,8 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": "MP_2tAR5*Kh7D~hYJ",
-          "ct": "KN9s@VuxopfaORe)(",
+          "msg": "MP_2uAR5*Kh7D~hYJ",
+          "ct": "KN9t@VvxopfaORe)(",
           "result": "valid"
         },
         {
@@ -6497,7 +6497,7 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": "F46t~*Es;c+(rjo`s",
+          "msg": "F46s~*Et;c+(rjo`t",
           "ct": "00000000000000000",
           "result": "valid"
         },
@@ -6509,7 +6509,7 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": "8izGPMtp1+4JvPjk9",
+          "msg": "8izGPMup1+4JwPjk9",
           "ct": "~~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -6521,7 +6521,7 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": "_3_Iqd#ku3XJ7BmsG",
+          "msg": ":3:Iqd#kv3XJ7BmtG",
           "ct": "+Km`|zx8q>f;|Ocg2",
           "result": "valid"
         },
@@ -6533,7 +6533,7 @@
           ],
           "key": "586c34235df3fd6ed8995a643fd52d41",
           "tweak": "c41f1671a352a8fb",
-          "msg": ">f~vZet|B4b*Y@V*}",
+          "msg": ">f~wZes|B4b*Y@V*}",
           "ct": "+Km`|zx7q>f;|Ocg1",
           "result": "valid"
         },
@@ -6545,8 +6545,8 @@
           ],
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "5f7c2511aab983",
-          "msg": "mNf{NfgPyFOs**P_C",
-          "ct": "ha8tNBO@^s7Ed5={b",
+          "msg": "mNf{NfgPyFOt**P_C",
+          "ct": "ha8sNBO@^t7Ed5={b",
           "result": "valid"
         },
         {
@@ -6557,8 +6557,8 @@
           ],
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "5f7c2511aab983",
-          "msg": "5d!fcH?`!LWZD+_JQ",
-          "ct": "R?)}H8Y}B_fqt>V>F",
+          "msg": "5d!fcH?`!LWZD+:JQ",
+          "ct": "R?)}H8Y}B:fqu>V>F",
           "result": "valid"
         },
         {
@@ -6569,8 +6569,8 @@
           ],
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "5f7c2511aab983",
-          "msg": "DsSrC^bvEB)&#7f{!",
-          "ct": "<UL`*@f}U0Us_f~fo",
+          "msg": "DtSrC^bwEB)&#7f{!",
+          "ct": "<UL`*@f}U0Ut_f~fo",
           "result": "valid"
         },
         {
@@ -6593,8 +6593,8 @@
           ],
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "5f7c2511aab983",
-          "msg": "<bW9Z%CA96b5ZO&Ku",
-          "ct": "CFqv(i;V2KY?ymg13",
+          "msg": "<bW9Z%CA96b5ZO&Kv",
+          "ct": "CFqw(i;V2KY?ymg13",
           "result": "valid"
         },
         {
@@ -6606,7 +6606,7 @@
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "5f7c2511aab983",
           "msg": "Sb06iYHx9CLR=GfKf",
-          "ct": "=4f!g^1L9nytVXAx7",
+          "ct": "=4f!g^1L9nyuVXAx7",
           "result": "valid"
         },
         {
@@ -6617,8 +6617,8 @@
           ],
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "d32e7d84f9a25b",
-          "msg": "Y1WAPqs=^4`_8uz5P",
-          "ct": "+riH#h2^j4);oysiy",
+          "msg": "Y1WAPqt=^4`_8vz5P",
+          "ct": "+riH#h2^j4);oytiy",
           "result": "valid"
         },
         {
@@ -6629,8 +6629,8 @@
           ],
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "d32e7d84f9a25b",
-          "msg": "ysqs4JZEKrJpl&i+_",
-          "ct": "6(sdQ$gNyu6%7PY))",
+          "msg": "ytqt4JZEKrJpl&i+:",
+          "ct": "6(tdQ$gNyv6%7PY))",
           "result": "valid"
         },
         {
@@ -6642,7 +6642,7 @@
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "d32e7d84f9a25b",
           "msg": "R&)DgSe{=W9E}=6N#",
-          "ct": "$n3$Vb^Ab*nB<E;tT",
+          "ct": "$n3$Vb^Ab*nB<E;uT",
           "result": "valid"
         },
         {
@@ -6653,8 +6653,8 @@
           ],
           "key": "47b31cab4872b3dfea0ebed259ac5cb7",
           "tweak": "d32e7d84f9a25b",
-          "msg": "d^i`cGCr+p9mb#AtS",
-          "ct": "O^f419)ZfFFKDvEkf",
+          "msg": "d^i`cGCr+p9mb#AuS",
+          "ct": "O^f419)ZfFFKDwEkf",
           "result": "valid"
         },
         {
@@ -6665,8 +6665,8 @@
           ],
           "key": "2ec80962dad2bf783abd539d85a7c8d6",
           "tweak": "1a36d2cb8088c664",
-          "msg": ",e%Gfq(q%z<?m1806",
-          "ct": "OtdB7^gME=&7Yhlur",
+          "msg": "-e%Gfq(q%z<?m1806",
+          "ct": "OudB7^gME=&7Yhlvr",
           "result": "invalid"
         },
         {
@@ -6677,8 +6677,8 @@
           ],
           "key": "2ec80962dad2bf783abd539d85a7c8d6",
           "tweak": "1a36d2cb8088c664",
-          "msg": "@e%Gfw(q%z<?m1806",
-          "ct": "$KE0T7Hu)#Xd!dt5R",
+          "msg": "@e%Gf-(q%z<?m1806",
+          "ct": "$KE0T7Hv)#Xd!ds5R",
           "result": "invalid"
         },
         {
@@ -6690,7 +6690,7 @@
           "key": "2ec80962dad2bf783abd539d85a7c8d6",
           "tweak": "1a36d2cb8088c664",
           "msg": "@e%Gfq(q%z<?m180-",
-          "ct": "8supU}aJt9&A$_>1D",
+          "ct": "8tvpU}aJs9&A$:>1D",
           "result": "invalid"
         },
         {
@@ -6701,7 +6701,7 @@
           ],
           "key": "686ea9217bb0367e5a2330edbae3eae3",
           "tweak": "6c21c99e0acacfa0",
-          "msg": "\u007f%?nvOgF3lLt&UVG7",
+          "msg": "-%?nwOgF3lLu&UVG7",
           "ct": "1*%(e5<5N^DKp`MgF",
           "result": "invalid"
         },
@@ -6713,8 +6713,8 @@
           ],
           "key": "686ea9217bb0367e5a2330edbae3eae3",
           "tweak": "6c21c99e0acacfa0",
-          "msg": "~%?nv\u007fgF3lLt&UVG7",
-          "ct": "LHLO9M;zt)#dErt1_",
+          "msg": "~%?nw-gF3lLu&UVG7",
+          "ct": "LHLO9M;zs)#dErs1:",
           "result": "invalid"
         },
         {
@@ -6725,14 +6725,14 @@
           ],
           "key": "686ea9217bb0367e5a2330edbae3eae3",
           "tweak": "6c21c99e0acacfa0",
-          "msg": "~%?nvOgF3lLt&UVG\u007f",
-          "ct": "+5UYCP*_DulP0cWg%",
+          "msg": "~%?nwOgF3lLu&UVG-",
+          "ct": "+5UYCP*_DvlP0cWg%",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 18,
       "radix": 85,
@@ -6746,8 +6746,8 @@
           ],
           "key": "40dcd7ccae73e5e9bba5523fbab77a3c",
           "tweak": "60ddd7c8df1437cf",
-          "msg": "){bgY!D#xzkkSZtTq*",
-          "ct": "mU;j@cPvemrheWNC>J",
+          "msg": "){bgY!D#xzkkSZsTq*",
+          "ct": "mU;j@cPwemrheWNC>J",
           "result": "valid"
         },
         {
@@ -6771,7 +6771,7 @@
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
           "msg": "~~~~~~~~~~~~~~~~~~",
-          "ct": "v@W{Apo4J_2t?XiS_+",
+          "ct": "w@W{Apo4J:2u?XiS:+",
           "result": "valid"
         },
         {
@@ -6783,7 +6783,7 @@
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
           "msg": "q>f;|Ocg2q>f;|Ocg2",
-          "ct": ";zun}Lk5G_5&iuW)#J",
+          "ct": ";zvn}Lk5G_5&ivW)#J",
           "result": "valid"
         },
         {
@@ -6806,7 +6806,7 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": "x{*|N~vAr0v94)}C}i",
+          "msg": "x{*|N~wAr0w94)}C}i",
           "ct": "#dOGKzPPEcqBg~ndZK",
           "result": "valid"
         },
@@ -6818,8 +6818,8 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": "2d&erIXzgc$sb72$~N",
-          "ct": "fD34_3?5}r~{Jm&)*@",
+          "msg": "2d&erIXzgc$tb72$~N",
+          "ct": "fD34:3?5}r~{Jm&)*@",
           "result": "valid"
         },
         {
@@ -6842,7 +6842,7 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": "<8OUY^+?$1sah7q{Hx",
+          "msg": "<8OUY^+?$1tah7q{Hx",
           "ct": "gFUSEX>U?%$ynK*pH_",
           "result": "valid"
         },
@@ -6866,8 +6866,8 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": ")Nn%z|quhl8J(}Jy9u",
-          "ct": "MV_t$!Pc)v2HJ35l3n",
+          "msg": ")Nn%z|qvhl8J(}Jy9v",
+          "ct": "MV:s$!Pc)w2HJ35l3n",
           "result": "valid"
         },
         {
@@ -6879,7 +6879,7 @@
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
           "msg": "KUgm@jW3j+cEOTc3~r",
-          "ct": "z@!A*bjc9btK(fSdv_",
+          "ct": "z@!A*bjc9buK(fSdw:",
           "result": "valid"
         },
         {
@@ -6890,8 +6890,8 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": "WRYF&`W$Nhp_tB8{Wg",
-          "ct": "t1*@}!SPub|_FtjBg=",
+          "msg": "WRYF&`W$Nhp_sB8{Wg",
+          "ct": "u1*@}!SPvb|:FsjBg=",
           "result": "valid"
         },
         {
@@ -6902,7 +6902,7 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": "iEhl!W?M|pnDj+_5f`",
+          "msg": "iEhl!W?M|pnDj+:5f`",
           "ct": "000000000000000000",
           "result": "valid"
         },
@@ -6914,7 +6914,7 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": "ZIWsrQ&G}5<}9~A)_*",
+          "msg": "ZIWtrQ&G}5<}9~A):*",
           "ct": "~~~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -6926,7 +6926,7 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": "Oxq(C{K_V5BxPsEWzi",
+          "msg": "Oxq(C{K:V5BxPtEWzi",
           "ct": "q>f;|Ocg2q>f;|Ocg2",
           "result": "valid"
         },
@@ -6938,7 +6938,7 @@
           ],
           "key": "fbe6a74c32f28d6fcb00598b1d6c531a",
           "tweak": "308cfb8c6402c842",
-          "msg": "osiVS@DLU|jS`oI@6&",
+          "msg": "otiVS@DLU|jS`oI@6&",
           "ct": "q>f;|Ocg1q>f;|Ocg1",
           "result": "valid"
         },
@@ -6950,8 +6950,8 @@
           ],
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "d62f57746bd340",
-          "msg": "|gyZtX|95000000000",
-          "ct": ";9LO+#~uMPnX1_0ziV",
+          "msg": "|gyZsX|95000000000",
+          "ct": ";9LO+#~vMPnX1:0ziV",
           "result": "valid"
         },
         {
@@ -6975,7 +6975,7 @@
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "d62f57746bd340",
           "msg": "Mf4LeQNV{q>f;|Ocg2",
-          "ct": "sAq<lJxk|*iNBtG?H;",
+          "ct": "tAq<lJxk|*iNBsG?H;",
           "result": "valid"
         },
         {
@@ -6987,7 +6987,7 @@
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "d62f57746bd340",
           "msg": "dpKzLc5&+~~~~~~~~}",
-          "ct": "v>AW81$`j#*C~I;idV",
+          "ct": "w>AW81$`j#*C~I;idV",
           "result": "valid"
         },
         {
@@ -6998,8 +6998,8 @@
           ],
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "d62f57746bd340",
-          "msg": "j@v(_NBz?~~~~~~~~~",
-          "ct": "t)k=ylM7+oVH$U)?#t",
+          "msg": "j@w(_NBz?~~~~~~~~~",
+          "ct": "u)k=ylM7+oVH$U)?#s",
           "result": "valid"
         },
         {
@@ -7010,8 +7010,8 @@
           ],
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "08dc8204f3b8c5",
-          "msg": "m%aq_@$~qmBD(a77yS",
-          "ct": "K;t!K~eZcqBGvsQUeg",
+          "msg": "m%aq:@$~qmBD(a77yS",
+          "ct": "K;u!K~eZcqBGwtQUeg",
           "result": "valid"
         },
         {
@@ -7023,7 +7023,7 @@
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "08dc8204f3b8c5",
           "msg": "f(1I%8E;g4Rq`2x<|k",
-          "ct": "txn6JIyY7FlV;qT)KV",
+          "ct": "sxn6JIyY7FlV;qT)KV",
           "result": "valid"
         },
         {
@@ -7034,7 +7034,7 @@
           ],
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "08dc8204f3b8c5",
-          "msg": "MxFv5lS*gm1k?i4qKP",
+          "msg": "MxFw5lS*gm1k?i4qKP",
           "ct": "RbK0z^U1_rAy%4r#yI",
           "result": "valid"
         },
@@ -7046,8 +7046,8 @@
           ],
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "08dc8204f3b8c5",
-          "msg": "EO=_3|stmxsM`V?iN=",
-          "ct": ")BbtkCc^vP#D}}2|_Z",
+          "msg": "EO=_3|tumxtM`V?iN=",
+          "ct": ")BbskCc^wP#D}}2|:Z",
           "result": "valid"
         },
         {
@@ -7058,7 +7058,7 @@
           ],
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "08dc8204f3b8c5",
-          "msg": "=s}TzEOf3OBFFJu`cG",
+          "msg": "=t}TzEOf3OBFFJv`cG",
           "ct": "%j`y>f}2DLUrnUZ%ZD",
           "result": "valid"
         },
@@ -7070,8 +7070,8 @@
           ],
           "key": "93f59a2f91ad3ca69e10b50b2ada2f7f",
           "tweak": "08dc8204f3b8c5",
-          "msg": "O`~|C@dHzVS^V7YtNy",
-          "ct": "BRiK``d)p$gI3LR_pi",
+          "msg": "O`~|C@dHzVS^V7YsNy",
+          "ct": "BRiK``d)p$gI3LR:pi",
           "result": "valid"
         },
         {
@@ -7082,8 +7082,8 @@
           ],
           "key": "8f3a40ed121d763ce94121d1a884ac4f",
           "tweak": "5e37cf940f79d378",
-          "msg": "]|;rk&PVS@cjc>+@t_",
-          "ct": "Z;2JTQX$zvIg;x6t6k",
+          "msg": "-|;rk&PVS@cjc>+@s:",
+          "ct": "Z;2JTQX$zwIg;x6u6k",
           "result": "invalid"
         },
         {
@@ -7094,8 +7094,8 @@
           ],
           "key": "8f3a40ed121d763ce94121d1a884ac4f",
           "tweak": "5e37cf940f79d378",
-          "msg": "+|;rk&'VS@cjc>+@t_",
-          "ct": "M*s)&S5mcxvJpt~g=1",
+          "msg": "+|;rk&-VS@cjc>+@s:",
+          "ct": "M*t)&S5mcxwJpu~g=1",
           "result": "invalid"
         },
         {
@@ -7106,7 +7106,7 @@
           ],
           "key": "8f3a40ed121d763ce94121d1a884ac4f",
           "tweak": "5e37cf940f79d378",
-          "msg": "+|;rk&PVS@cjc>+@t]",
+          "msg": "+|;rk&PVS@cjc>+@s-",
           "ct": "lmKF{JQiJ@?#>rx_1X",
           "result": "invalid"
         },
@@ -7118,8 +7118,8 @@
           ],
           "key": "78697ffbb38f9e3abeb9b3ef7e0a18bd",
           "tweak": "75425b9396cd9121",
-          "msg": "\u007fD~$kLU<hG1X9g^|#t",
-          "ct": "JB0xa@#qcRP^Y|I*t^",
+          "msg": "-D~$kLU<hG1X9g^|#u",
+          "ct": "JB0xa@#qcRP^Y|I*u^",
           "result": "invalid"
         },
         {
@@ -7130,8 +7130,8 @@
           ],
           "key": "78697ffbb38f9e3abeb9b3ef7e0a18bd",
           "tweak": "75425b9396cd9121",
-          "msg": "zD~$kL\u007f<hG1X9g^|#t",
-          "ct": "h^^W#+&#jxc~zgs++#",
+          "msg": "zD~$kL-<hG1X9g^|#u",
+          "ct": "h^^W#+&#jxc~zgt++#",
           "result": "invalid"
         },
         {
@@ -7142,14 +7142,14 @@
           ],
           "key": "78697ffbb38f9e3abeb9b3ef7e0a18bd",
           "tweak": "75425b9396cd9121",
-          "msg": "zD~$kLU<hG1X9g^|#\u007f",
-          "ct": "f@5M7fgM*f_SJ1f?c8",
+          "msg": "zD~$kLU<hG1X9g^|#-",
+          "ct": "f@5M7fgM*f:SJ1f?c8",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 19,
       "radix": 85,
@@ -7163,8 +7163,8 @@
           ],
           "key": "3591cc97af4a5d1492305f87269ee691",
           "tweak": "13786144a50ef10a",
-          "msg": "5T=znz^B_<>pC1<&ueP",
-          "ct": "7$_)YT*OzlVR}Z=J?+=",
+          "msg": "5T=znz^B_<>pC1<&veP",
+          "ct": "7$:)YT*OzlVR}Z=J?+=",
           "result": "valid"
         },
         {
@@ -7176,7 +7176,7 @@
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
           "msg": "0000000000000000000",
-          "ct": "=l{NWY$t^^(@J@NI34Z",
+          "ct": "=l{NWY$u^^(@J@NI34Z",
           "result": "valid"
         },
         {
@@ -7188,7 +7188,7 @@
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
           "msg": "~~~~~~~~~~~~~~~~~~~",
-          "ct": "<ir8?8MZS$Rlf;s0EEq",
+          "ct": "<ir8?8MZS$Rlf;t0EEq",
           "result": "valid"
         },
         {
@@ -7199,8 +7199,8 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "q>f;|Ocg2_tv2=@*|O1",
-          "ct": "}+ja~#AfJ$5Yy_TF_mX",
+          "msg": "q>f;|Ocg2_sw2=@*|O1",
+          "ct": "}+ja~#AfJ$5Yy:TF:mX",
           "result": "valid"
         },
         {
@@ -7211,7 +7211,7 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "q>f;|Ocg1_tv2=@*|O0",
+          "msg": "q>f;|Ocg1_sw2=@*|O0",
           "ct": "3%gi3TZ!#H^EoXnJrFa",
           "result": "valid"
         },
@@ -7247,8 +7247,8 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "aGN&gci_|CSpPPv;8xn",
-          "ct": "dTpgS&oPs?7Vnu8n%!4",
+          "msg": "aGN&gci:|CSpPPw;8xn",
+          "ct": "dTpgS&oPt?7Vnv8n%!4",
           "result": "valid"
         },
         {
@@ -7259,8 +7259,8 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "KWsTaC1(@3!zd15I@je",
-          "ct": "!pDT#v0sLiA`Np+ML^n",
+          "msg": "KWtTaC1(@3!zd15I@je",
+          "ct": "!pDT#w0tLiA`Np+ML^n",
           "result": "valid"
         },
         {
@@ -7295,8 +7295,8 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "ZItz%d!b_!Z5;<cp3B0",
-          "ct": "DnCDzFf5&tW9Y+ytaou",
+          "msg": "ZIsz%d!b_!Z5;<cp3B0",
+          "ct": "DnCDzFf5&uW9Y+yuaov",
           "result": "valid"
         },
         {
@@ -7307,7 +7307,7 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "($K~f;nfOytA(_5>((*",
+          "msg": "($K~f;nfOysA(:5>((*",
           "ct": "kTTd|;e)44y=gF}bi<#",
           "result": "valid"
         },
@@ -7319,7 +7319,7 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "+kPXtz}Poa)9W1Q_W=>",
+          "msg": "+kPXuz}Poa)9W1Q_W=>",
           "ct": "0000000000000000000",
           "result": "valid"
         },
@@ -7331,7 +7331,7 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "B+_?nm4{ufttKL9zi#y",
+          "msg": "B+_?nm4{vfssKL9zi#y",
           "ct": "~~~~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -7343,8 +7343,8 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "}@S@HRAB#CzA1Kq0tsr",
-          "ct": "q>f;|Ocg2_tv2=@*|O1",
+          "msg": "}@S@HRAB#CzA1Kq0utr",
+          "ct": "q>f;|Ocg2_sw2=@*|O1",
           "result": "valid"
         },
         {
@@ -7355,8 +7355,8 @@
           ],
           "key": "cd031dce5e1bca3a7e04c997ac13ef2d",
           "tweak": "3d906a02e77bcc5c",
-          "msg": "UbeCo;0R_tpn6ygo^BT",
-          "ct": "q>f;|Ocg1_tv2=@*|O0",
+          "msg": "UbeCo;0R:spn6ygo^BT",
+          "ct": "q>f;|Ocg1_sw2=@*|O0",
           "result": "valid"
         },
         {
@@ -7367,8 +7367,8 @@
           ],
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "dd13a75b3e5950533add4b07c1465ac29d79a51a4bd3",
-          "msg": "dMtfhPlo3cmb02sSnmq",
-          "ct": "}Q<@;)Rg$tl@KyWF<K`",
+          "msg": "dMsfhPlo3cmb02tSnmq",
+          "ct": "}Q<@;)Rg$sl@KyWF<K`",
           "result": "valid"
         },
         {
@@ -7379,7 +7379,7 @@
           ],
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "dd13a75b3e5950533add4b07c1465ac29d79a51a4bd3",
-          "msg": "~Qt;xFD|PqxH<oOpC@U",
+          "msg": "~Qu;xFD|PqxH<oOpC@U",
           "ct": "#a{}>+fa{7jZ>=ek)x4",
           "result": "valid"
         },
@@ -7392,7 +7392,7 @@
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "dd13a75b3e5950533add4b07c1465ac29d79a51a4bd3",
           "msg": "_YF%!ROfzO!p(XB`h$b",
-          "ct": "^_#P_VHqmRSt_ih{xdG",
+          "ct": "^_#P:VHqmRSs_ih{xdG",
           "result": "valid"
         },
         {
@@ -7403,7 +7403,7 @@
           ],
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "dd13a75b3e5950533add4b07c1465ac29d79a51a4bd3",
-          "msg": "Aa&v@Mf$YX##1RTP0vL",
+          "msg": "Aa&w@Mf$YX##1RTP0wL",
           "ct": "b^fmV;eQpZg#~&MG9&B",
           "result": "valid"
         },
@@ -7415,7 +7415,7 @@
           ],
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "dd13a75b3e5950533add4b07c1465ac29d79a51a4bd3",
-          "msg": "D<SOh%atOOEc<uxlrpP",
+          "msg": "D<SOh%asOOEc<vxlrpP",
           "ct": "RchA!;NQ?>V9EWRP{5Q",
           "result": "valid"
         },
@@ -7428,7 +7428,7 @@
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "00fa66c1dbaeac162cecfc87e4ec2accbb5634449bbb",
           "msg": "8U+4eK+S1<GeN^AQ~0e",
-          "ct": "~Hi%c2ym0#B49|tPt~6",
+          "ct": "~Hi%c2ym0#B49|sPu~6",
           "result": "valid"
         },
         {
@@ -7451,7 +7451,7 @@
           ],
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "00fa66c1dbaeac162cecfc87e4ec2accbb5634449bbb",
-          "msg": "eoMeniZ2GDB|tIpKlT>",
+          "msg": "eoMeniZ2GDB|uIpKlT>",
           "ct": "~~~~~~~~~UXoz?Ri=JF",
           "result": "valid"
         },
@@ -7464,7 +7464,7 @@
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "00fa66c1dbaeac162cecfc87e4ec2accbb5634449bbb",
           "msg": "(zK)elnay<X7#}3>{i4",
-          "ct": "000000000KQt~0B>t++",
+          "ct": "000000000KQu~0B>s++",
           "result": "valid"
         },
         {
@@ -7475,7 +7475,7 @@
           ],
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "00fa66c1dbaeac162cecfc87e4ec2accbb5634449bbb",
-          "msg": "FBH2t(e&xJrup_Jq&_D",
+          "msg": "FBH2s(e&xJrvp:Jq&_D",
           "ct": "q81rZRE52dp6(m2f3^C",
           "result": "valid"
         },
@@ -7487,8 +7487,8 @@
           ],
           "key": "522debdfba3b6828bb97848da895884a",
           "tweak": "00fa66c1dbaeac162cecfc87e4ec2accbb5634449bbb",
-          "msg": "*Z#6!V7s@37aid_%8R7",
-          "ct": "~Hi%c2yl~+lx4t+4pT0",
+          "msg": "*Z#6!V7t@37aid_%8R7",
+          "ct": "~Hi%c2yl~+lx4s+4pT0",
           "result": "valid"
         },
         {
@@ -7499,8 +7499,8 @@
           ],
           "key": "1cf89329cac719e6c7544a9303e78801",
           "tweak": "169faf154b10cac4",
-          "msg": "/Qu%_J?C_Q|PP{~7&Au",
-          "ct": "3B6of(!QAAAOFU7HuEc",
+          "msg": "-Qv%:J?C_Q|PP{~7&Av",
+          "ct": "3B6of(!QAAAOFU7HvEc",
           "result": "invalid"
         },
         {
@@ -7511,8 +7511,8 @@
           ],
           "key": "1cf89329cac719e6c7544a9303e78801",
           "tweak": "169faf154b10cac4",
-          "msg": "XQu%_J]C_Q|PP{~7&Au",
-          "ct": "U~nvVOl~GA!tf@9gKBo",
+          "msg": "XQv%:J-C_Q|PP{~7&Av",
+          "ct": "U~nwVOl~GA!sf@9gKBo",
           "result": "invalid"
         },
         {
@@ -7523,8 +7523,8 @@
           ],
           "key": "1cf89329cac719e6c7544a9303e78801",
           "tweak": "169faf154b10cac4",
-          "msg": "XQu%_J?C_Q|PP{~7&Aw",
-          "ct": "+&_zUUHr$*mNmaT8T0r",
+          "msg": "XQv%:J?C_Q|PP{~7&A-",
+          "ct": "+&:zUUHr$*mNmaT8T0r",
           "result": "invalid"
         },
         {
@@ -7535,8 +7535,8 @@
           ],
           "key": "1dd4fbf95318aaee210bf7998af2e151",
           "tweak": "9e51c7c565c4d041",
-          "msg": "\u007f_5~+{lP)iP>JDm}|dV",
-          "ct": "Cyi%6_5B0;OY#%!mt2E",
+          "msg": "-:5~+{lP)iP>JDm}|dV",
+          "ct": "Cyi%6_5B0;OY#%!ms2E",
           "result": "invalid"
         },
         {
@@ -7547,8 +7547,8 @@
           ],
           "key": "1dd4fbf95318aaee210bf7998af2e151",
           "tweak": "9e51c7c565c4d041",
-          "msg": "{_5~+{\u007fP)iP>JDm}|dV",
-          "ct": "SF%OS@>&*lju%0b~A8_",
+          "msg": "{:5~+{-P)iP>JDm}|dV",
+          "ct": "SF%OS@>&*ljv%0b~A8:",
           "result": "invalid"
         },
         {
@@ -7559,14 +7559,14 @@
           ],
           "key": "1dd4fbf95318aaee210bf7998af2e151",
           "tweak": "9e51c7c565c4d041",
-          "msg": "{_5~+{lP)iP>JDm}|d\u007f",
-          "ct": "v5DXbY?tefVUtOv@`U`",
+          "msg": "{:5~+{lP)iP>JDm}|d-",
+          "ct": "w5DXbY?sefVUuOw@`U`",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 4,
       "radix": 85,
@@ -7641,7 +7641,7 @@
           "key": "449d31bba4be09dfd5a4523610236b6c80775dfa965a70dc",
           "tweak": "f7e902be3a607c1c",
           "msg": "7UfH",
-          "ct": "LjvD",
+          "ct": "LjwD",
           "result": "valid"
         },
         {
@@ -7652,7 +7652,7 @@
           ],
           "key": "449d31bba4be09dfd5a4523610236b6c80775dfa965a70dc",
           "tweak": "f7e902be3a607c1c",
-          "msg": "v}Qx",
+          "msg": "w}Qx",
           "ct": "#hLa",
           "result": "valid"
         },
@@ -7676,7 +7676,7 @@
           ],
           "key": "449d31bba4be09dfd5a4523610236b6c80775dfa965a70dc",
           "tweak": "f7e902be3a607c1c",
-          "msg": "3t?7",
+          "msg": "3u?7",
           "ct": "9l9N",
           "result": "valid"
         },
@@ -7688,8 +7688,8 @@
           ],
           "key": "449d31bba4be09dfd5a4523610236b6c80775dfa965a70dc",
           "tweak": "f7e902be3a607c1c",
-          "msg": "tWtb",
-          "ct": "+tTg",
+          "msg": "uWub",
+          "ct": "+uTg",
           "result": "valid"
         },
         {
@@ -7748,7 +7748,7 @@
           ],
           "key": "449d31bba4be09dfd5a4523610236b6c80775dfa965a70dc",
           "tweak": "f7e902be3a607c1c",
-          "msg": "g9sY",
+          "msg": "g9tY",
           "ct": "~~~~",
           "result": "valid"
         },
@@ -7784,7 +7784,7 @@
           ],
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "e8d5719379099595d18e33a4a3",
-          "msg": "00m_",
+          "msg": "00m:",
           "ct": "S}i>",
           "result": "valid"
         },
@@ -7796,7 +7796,7 @@
           ],
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "e8d5719379099595d18e33a4a3",
-          "msg": "01m_",
+          "msg": "01m:",
           "ct": "foO|",
           "result": "valid"
         },
@@ -7808,7 +7808,7 @@
           ],
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "e8d5719379099595d18e33a4a3",
-          "msg": "mGm_",
+          "msg": "mGm:",
           "ct": "GY(M",
           "result": "valid"
         },
@@ -7820,8 +7820,8 @@
           ],
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "e8d5719379099595d18e33a4a3",
-          "msg": "~~m_",
-          "ct": "*_Nf",
+          "msg": "~~m:",
+          "ct": "*:Nf",
           "result": "valid"
         },
         {
@@ -7832,7 +7832,7 @@
           ],
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "8848db3941ff63c2d73299d93f",
-          "msg": "et^h",
+          "msg": "es^h",
           "ct": "{2R=",
           "result": "valid"
         },
@@ -7844,7 +7844,7 @@
           ],
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "8848db3941ff63c2d73299d93f",
-          "msg": "Ivz`",
+          "msg": "Iwz`",
           "ct": "jD>P",
           "result": "valid"
         },
@@ -7868,7 +7868,7 @@
           ],
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "8848db3941ff63c2d73299d93f",
-          "msg": "_jF<",
+          "msg": ":jF<",
           "ct": "l{r*",
           "result": "valid"
         },
@@ -7892,7 +7892,7 @@
           ],
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "012ddfdeb32ce9d323dd48e098",
-          "msg": "_E4X",
+          "msg": ":E4X",
           "ct": "O0)z",
           "result": "valid"
         },
@@ -7965,7 +7965,7 @@
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "ff7f9d8ad63763bb33980fb281",
           "msg": "jFdc",
-          "ct": "F>du",
+          "ct": "F>dv",
           "result": "valid"
         },
         {
@@ -7977,7 +7977,7 @@
           "key": "cc15ff8fc1e35214d16a3a58278c62123d56a1b8b87fc1b3",
           "tweak": "ff7f9d8ad63763bb33980fb281",
           "msg": "))i%",
-          "ct": "sE~&",
+          "ct": "tE~&",
           "result": "valid"
         },
         {
@@ -8012,7 +8012,7 @@
           ],
           "key": "ecd2c32bd1b77097a477742649b384243714a567a0f67eb9",
           "tweak": "2cd30b0db6e83292",
-          "msg": "'QZC",
+          "msg": "-QZC",
           "ct": "ZE{G",
           "result": "invalid"
         },
@@ -8024,7 +8024,7 @@
           ],
           "key": "ecd2c32bd1b77097a477742649b384243714a567a0f67eb9",
           "tweak": "2cd30b0db6e83292",
-          "msg": "T:ZC",
+          "msg": "T-ZC",
           "ct": "l1|3",
           "result": "invalid"
         },
@@ -8036,7 +8036,7 @@
           ],
           "key": "ecd2c32bd1b77097a477742649b384243714a567a0f67eb9",
           "tweak": "2cd30b0db6e83292",
-          "msg": "TQZw",
+          "msg": "TQZ-",
           "ct": "FX>n",
           "result": "invalid"
         },
@@ -8048,7 +8048,7 @@
           ],
           "key": "115497adde2f2b03c500571460257c2d5d6e4adbf930ed92",
           "tweak": "8898e78fe1234981",
-          "msg": "\u007fHIh",
+          "msg": "-HIh",
           "ct": "R3gT",
           "result": "invalid"
         },
@@ -8060,7 +8060,7 @@
           ],
           "key": "115497adde2f2b03c500571460257c2d5d6e4adbf930ed92",
           "tweak": "8898e78fe1234981",
-          "msg": "=\u007fIh",
+          "msg": "=-Ih",
           "ct": "D&SE",
           "result": "invalid"
         },
@@ -8072,14 +8072,14 @@
           ],
           "key": "115497adde2f2b03c500571460257c2d5d6e4adbf930ed92",
           "tweak": "8898e78fe1234981",
-          "msg": "=HI\u007f",
+          "msg": "=HI-",
           "ct": "#>Vn",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 5,
       "radix": 85,
@@ -8093,8 +8093,8 @@
           ],
           "key": "a6c055a8cba4718f411d1a3d9c9e2051261ce3e369b2fa13",
           "tweak": "c5d9512a52de22b7",
-          "msg": "t^j_I",
-          "ct": "dtTtN",
+          "msg": "u^j:I",
+          "ct": "duTsN",
           "result": "valid"
         },
         {
@@ -8118,7 +8118,7 @@
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
           "msg": "~~~~~",
-          "ct": "_gtm`",
+          "ct": "_gsm`",
           "result": "valid"
         },
         {
@@ -8142,7 +8142,7 @@
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
           "msg": "mF;m7",
-          "ct": "H_%{K",
+          "ct": "H:%{K",
           "result": "valid"
         },
         {
@@ -8154,7 +8154,7 @@
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
           "msg": "&3$R@",
-          "ct": "vlSa<",
+          "ct": "wlSa<",
           "result": "valid"
         },
         {
@@ -8166,7 +8166,7 @@
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
           "msg": "@3E(Y",
-          "ct": "_U$@@",
+          "ct": ":U$@@",
           "result": "valid"
         },
         {
@@ -8177,7 +8177,7 @@
           ],
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
-          "msg": "BQ_sa",
+          "msg": "BQ_ta",
           "ct": "5nW#}",
           "result": "valid"
         },
@@ -8237,7 +8237,7 @@
           ],
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
-          "msg": "i4`ts",
+          "msg": "i4`ut",
           "ct": "G67}O",
           "result": "valid"
         },
@@ -8249,7 +8249,7 @@
           ],
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
-          "msg": "v8?OV",
+          "msg": "w8?OV",
           "ct": "00000",
           "result": "valid"
         },
@@ -8261,7 +8261,7 @@
           ],
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
-          "msg": "KFFvt",
+          "msg": "KFFws",
           "ct": "~~~~~",
           "result": "valid"
         },
@@ -8285,7 +8285,7 @@
           ],
           "key": "96fc2e2e2fba26508b73927dea1a42c8edcaa1e9d752f84e",
           "tweak": "bdbf3377d69e6a6e",
-          "msg": "lYy1u",
+          "msg": "lYy1v",
           "ct": "mF;m7",
           "result": "valid"
         },
@@ -8298,7 +8298,7 @@
           "key": "47ba0d5030df62cede1d0ed4f4e86b418ad54d330cb37894",
           "tweak": "92c392f460ed6924cddc3608",
           "msg": "F?IPL",
-          "ct": "tr|I^",
+          "ct": "sr|I^",
           "result": "valid"
         },
         {
@@ -8322,7 +8322,7 @@
           "key": "47ba0d5030df62cede1d0ed4f4e86b418ad54d330cb37894",
           "tweak": "92c392f460ed6924cddc3608",
           "msg": "^>$JT",
-          "ct": "t__#g",
+          "ct": "s:_#g",
           "result": "valid"
         },
         {
@@ -8333,7 +8333,7 @@
           ],
           "key": "47ba0d5030df62cede1d0ed4f4e86b418ad54d330cb37894",
           "tweak": "92c392f460ed6924cddc3608",
-          "msg": "gv&TX",
+          "msg": "gw&TX",
           "ct": "*67~+",
           "result": "valid"
         },
@@ -8357,7 +8357,7 @@
           ],
           "key": "47ba0d5030df62cede1d0ed4f4e86b418ad54d330cb37894",
           "tweak": "4e24b2a652b9d24914b4c32a",
-          "msg": "P^vHf",
+          "msg": "P^wHf",
           "ct": "9{;V0",
           "result": "valid"
         },
@@ -8394,7 +8394,7 @@
           "key": "47ba0d5030df62cede1d0ed4f4e86b418ad54d330cb37894",
           "tweak": "4e24b2a652b9d24914b4c32a",
           "msg": "5#)01",
-          "ct": "^y~_5",
+          "ct": "^y~:5",
           "result": "valid"
         },
         {
@@ -8441,7 +8441,7 @@
           ],
           "key": "47ba0d5030df62cede1d0ed4f4e86b418ad54d330cb37894",
           "tweak": "c64e2687ab9de9d00081af91",
-          "msg": "}2yPs",
+          "msg": "}2yPt",
           "ct": "UB$kZ",
           "result": "valid"
         },
@@ -8465,7 +8465,7 @@
           ],
           "key": "47ba0d5030df62cede1d0ed4f4e86b418ad54d330cb37894",
           "tweak": "c64e2687ab9de9d00081af91",
-          "msg": "PTFDv",
+          "msg": "PTFDw",
           "ct": "%;WI_",
           "result": "valid"
         },
@@ -8477,8 +8477,8 @@
           ],
           "key": "7d1dd7c87db4b2ad95137c34ca1baac73b195c0ede42becd",
           "tweak": "2ae737de3b2aa4b0",
-          "msg": "\\#~jt",
-          "ct": "h{spZ",
+          "msg": "-#~js",
+          "ct": "h{tpZ",
           "result": "invalid"
         },
         {
@@ -8489,7 +8489,7 @@
           ],
           "key": "7d1dd7c87db4b2ad95137c34ca1baac73b195c0ede42becd",
           "tweak": "2ae737de3b2aa4b0",
-          "msg": "V:~jt",
+          "msg": "V-~js",
           "ct": "hboqN",
           "result": "invalid"
         },
@@ -8501,7 +8501,7 @@
           ],
           "key": "7d1dd7c87db4b2ad95137c34ca1baac73b195c0ede42becd",
           "tweak": "2ae737de3b2aa4b0",
-          "msg": "V#~j,",
+          "msg": "V#~j-",
           "ct": "ANK%Q",
           "result": "invalid"
         },
@@ -8513,8 +8513,8 @@
           ],
           "key": "ddac46d5938acf57e6453139d3133408262e08aa8fd3d716",
           "tweak": "e3558a23742ec229",
-          "msg": "\u007f#SdR",
-          "ct": "vmSEk",
+          "msg": "-#SdR",
+          "ct": "wmSEk",
           "result": "invalid"
         },
         {
@@ -8525,8 +8525,8 @@
           ],
           "key": "ddac46d5938acf57e6453139d3133408262e08aa8fd3d716",
           "tweak": "e3558a23742ec229",
-          "msg": "G\u007fSdR",
-          "ct": ";WtW%",
+          "msg": "G-SdR",
+          "ct": ";WsW%",
           "result": "invalid"
         },
         {
@@ -8537,14 +8537,14 @@
           ],
           "key": "ddac46d5938acf57e6453139d3133408262e08aa8fd3d716",
           "tweak": "e3558a23742ec229",
-          "msg": "G#Sd\u007f",
+          "msg": "G#Sd-",
           "ct": "#edoK",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 6,
       "radix": 85,
@@ -8571,7 +8571,7 @@
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
           "msg": "000000",
-          "ct": "xuGg5e",
+          "ct": "xvGg5e",
           "result": "valid"
         },
         {
@@ -8595,7 +8595,7 @@
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
           "msg": ";m8;m8",
-          "ct": "ys7{uW",
+          "ct": "yt7{vW",
           "result": "valid"
         },
         {
@@ -8618,8 +8618,8 @@
           ],
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
-          "msg": "8MAti5",
-          "ct": "__artt",
+          "msg": "8MAsi5",
+          "ct": ":_arsu",
           "result": "valid"
         },
         {
@@ -8642,7 +8642,7 @@
           ],
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
-          "msg": "J|$#_E",
+          "msg": "J|$#:E",
           "ct": "6L@80V",
           "result": "valid"
         },
@@ -8654,8 +8654,8 @@
           ],
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
-          "msg": "=$QGls",
-          "ct": "t@Ob&c",
+          "msg": "=$QGlt",
+          "ct": "s@Ob&c",
           "result": "valid"
         },
         {
@@ -8678,7 +8678,7 @@
           ],
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
-          "msg": "g%2tHn",
+          "msg": "g%2sHn",
           "ct": "^n%@Z$",
           "result": "valid"
         },
@@ -8714,7 +8714,7 @@
           ],
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
-          "msg": "Bba7_u",
+          "msg": "Bba7_v",
           "ct": "000000",
           "result": "valid"
         },
@@ -8726,7 +8726,7 @@
           ],
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
-          "msg": "sbVntF",
+          "msg": "tbVnuF",
           "ct": "~~~~~~",
           "result": "valid"
         },
@@ -8750,7 +8750,7 @@
           ],
           "key": "fb11ec30c2d9417c1a8e1484073c1d8e73277b92880ff21e",
           "tweak": "94045aa1a1f8fef4",
-          "msg": "NN>?tA",
+          "msg": "NN>?sA",
           "ct": ";m7;m7",
           "result": "valid"
         },
@@ -8762,7 +8762,7 @@
           ],
           "key": "554366274f70a25ea36c134016e632c910fb14f397c950ed",
           "tweak": "253bd3c2be0043ab360c86a2",
-          "msg": "HcmdTv",
+          "msg": "HcmdTw",
           "ct": "9*0zpQ",
           "result": "valid"
         },
@@ -8774,7 +8774,7 @@
           ],
           "key": "554366274f70a25ea36c134016e632c910fb14f397c950ed",
           "tweak": "253bd3c2be0043ab360c86a2",
-          "msg": "Xu=E0v",
+          "msg": "Xv=E0w",
           "ct": "e)}maN",
           "result": "valid"
         },
@@ -8798,7 +8798,7 @@
           ],
           "key": "554366274f70a25ea36c134016e632c910fb14f397c950ed",
           "tweak": "253bd3c2be0043ab360c86a2",
-          "msg": "@Vt2tG",
+          "msg": "@Vs2sG",
           "ct": "9NW`!y",
           "result": "valid"
         },
@@ -8883,7 +8883,7 @@
           "key": "554366274f70a25ea36c134016e632c910fb14f397c950ed",
           "tweak": "d9e7c5e3f1961cd33a36c686",
           "msg": "L4)#2k",
-          "ct": "7tzEJZ",
+          "ct": "7uzEJZ",
           "result": "valid"
         },
         {
@@ -8894,7 +8894,7 @@
           ],
           "key": "554366274f70a25ea36c134016e632c910fb14f397c950ed",
           "tweak": "d9e7c5e3f1961cd33a36c686",
-          "msg": "ukW#V*",
+          "msg": "vkW#V*",
           "ct": "zI|*H1",
           "result": "valid"
         },
@@ -8918,7 +8918,7 @@
           ],
           "key": "554366274f70a25ea36c134016e632c910fb14f397c950ed",
           "tweak": "d9e7c5e3f1961cd33a36c686",
-          "msg": ";>zsl>",
+          "msg": ";>ztl>",
           "ct": "G_Q~)i",
           "result": "valid"
         },
@@ -8930,8 +8930,8 @@
           ],
           "key": "88167c8609d65b4d1f5f83c582b079e4ef7079b329a49fda",
           "tweak": "c0b22a647b59d5ca",
-          "msg": "]F>$BO",
-          "ct": "@_B!_b",
+          "msg": "-F>$BO",
+          "ct": "@_B!:b",
           "result": "invalid"
         },
         {
@@ -8942,7 +8942,7 @@
           ],
           "key": "88167c8609d65b4d1f5f83c582b079e4ef7079b329a49fda",
           "tweak": "c0b22a647b59d5ca",
-          "msg": "aF.$BO",
+          "msg": "aF-$BO",
           "ct": "N$&PUj",
           "result": "invalid"
         },
@@ -8954,7 +8954,7 @@
           ],
           "key": "88167c8609d65b4d1f5f83c582b079e4ef7079b329a49fda",
           "tweak": "c0b22a647b59d5ca",
-          "msg": "aF>$B]",
+          "msg": "aF>$B-",
           "ct": "rC$TB+",
           "result": "invalid"
         },
@@ -8966,8 +8966,8 @@
           ],
           "key": "bb2978d48f4e5c125cd7bbcc129f8a2ad093b9a2cf88598d",
           "tweak": "15ac069bfbc353e3",
-          "msg": "\u007f_I{oF",
-          "ct": "ltlF)G",
+          "msg": "-_I{oF",
+          "ct": "lulF)G",
           "result": "invalid"
         },
         {
@@ -8978,8 +8978,8 @@
           ],
           "key": "bb2978d48f4e5c125cd7bbcc129f8a2ad093b9a2cf88598d",
           "tweak": "15ac069bfbc353e3",
-          "msg": "p_\u007f{oF",
-          "ct": "c=)#vp",
+          "msg": "p_-{oF",
+          "ct": "c=)#wp",
           "result": "invalid"
         },
         {
@@ -8990,14 +8990,14 @@
           ],
           "key": "bb2978d48f4e5c125cd7bbcc129f8a2ad093b9a2cf88598d",
           "tweak": "15ac069bfbc353e3",
-          "msg": "p_I{o\u007f",
+          "msg": "p_I{o-",
           "ct": "60%J+x",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 7,
       "radix": 85,
@@ -9047,8 +9047,8 @@
           ],
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
-          "msg": ";m8ttI2",
-          "ct": "T(A0s{S",
+          "msg": ";m8ssI2",
+          "ct": "T(A0t{S",
           "result": "valid"
         },
         {
@@ -9059,8 +9059,8 @@
           ],
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
-          "msg": ";m7ttI1",
-          "ct": "QtRKhEK",
+          "msg": ";m7ssI1",
+          "ct": "QsRKhEK",
           "result": "valid"
         },
         {
@@ -9071,8 +9071,8 @@
           ],
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
-          "msg": "9QvGu0j",
-          "ct": "uhy7fKK",
+          "msg": "9QwGv0j",
+          "ct": "vhy7fKK",
           "result": "valid"
         },
         {
@@ -9095,7 +9095,7 @@
           ],
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
-          "msg": "JxvJk_G",
+          "msg": "JxwJk:G",
           "ct": "d>2#NYZ",
           "result": "valid"
         },
@@ -9107,8 +9107,8 @@
           ],
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
-          "msg": "_&+JgWQ",
-          "ct": "hu(x_{y",
+          "msg": ":&+JgWQ",
+          "ct": "hv(x:{y",
           "result": "valid"
         },
         {
@@ -9119,7 +9119,7 @@
           ],
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
-          "msg": "<PEtltq",
+          "msg": "<PEsluq",
           "ct": "1^g`LY3",
           "result": "valid"
         },
@@ -9131,7 +9131,7 @@
           ],
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
-          "msg": "XGsgI<C",
+          "msg": "XGtgI<C",
           "ct": "8LR}0{S",
           "result": "valid"
         },
@@ -9192,7 +9192,7 @@
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
           "msg": "m><r_C_",
-          "ct": ";m8ttI2",
+          "ct": ";m8ssI2",
           "result": "valid"
         },
         {
@@ -9204,7 +9204,7 @@
           "key": "75cab941d9824399ade8dd4b38df396804fe8d43296f901c",
           "tweak": "b08eb74eb083e732",
           "msg": "mNmzM^b",
-          "ct": ";m7ttI1",
+          "ct": ";m7ssI1",
           "result": "valid"
         },
         {
@@ -9227,7 +9227,7 @@
           ],
           "key": "5770c68113fac20abbd419d0c588e7929dd202a9829db695",
           "tweak": "244e63d681be379220fc46",
-          "msg": "&1F}Apt",
+          "msg": "&1F}Apu",
           "ct": "eI7*|O1",
           "result": "valid"
         },
@@ -9251,7 +9251,7 @@
           ],
           "key": "5770c68113fac20abbd419d0c588e7929dd202a9829db695",
           "tweak": "244e63d681be379220fc46",
-          "msg": "Mh54oso",
+          "msg": "Mh54oto",
           "ct": "eI70000",
           "result": "valid"
         },
@@ -9287,7 +9287,7 @@
           ],
           "key": "feb4107ae457413c5445e8f77175ea0ee1d610dcea97129b",
           "tweak": "60ffe987c829b479",
-          "msg": "]0%mou0",
+          "msg": "-0%mov0",
           "ct": "%*bKTPK",
           "result": "invalid"
         },
@@ -9299,8 +9299,8 @@
           ],
           "key": "feb4107ae457413c5445e8f77175ea0ee1d610dcea97129b",
           "tweak": "60ffe987c829b479",
-          "msg": "S0wmou0",
-          "ct": "Iv(|4uu",
+          "msg": "S0-mov0",
+          "ct": "Iw(|4vv",
           "result": "invalid"
         },
         {
@@ -9311,7 +9311,7 @@
           ],
           "key": "feb4107ae457413c5445e8f77175ea0ee1d610dcea97129b",
           "tweak": "60ffe987c829b479",
-          "msg": "S0%mou]",
+          "msg": "S0%mov-",
           "ct": "^U?GS;_",
           "result": "invalid"
         },
@@ -9323,8 +9323,8 @@
           ],
           "key": "2d2b7f922559160dabb493fec8514c0897a30cca2f2aece2",
           "tweak": "126a300455b32ffc",
-          "msg": "\u007fx@i>@;",
-          "ct": "#9_YSxG",
+          "msg": "-x@i>@;",
+          "ct": "#9:YSxG",
           "result": "invalid"
         },
         {
@@ -9335,7 +9335,7 @@
           ],
           "key": "2d2b7f922559160dabb493fec8514c0897a30cca2f2aece2",
           "tweak": "126a300455b32ffc",
-          "msg": "px\u007fi>@;",
+          "msg": "px-i>@;",
           "ct": "Lc4d=qQ",
           "result": "invalid"
         },
@@ -9347,14 +9347,14 @@
           ],
           "key": "2d2b7f922559160dabb493fec8514c0897a30cca2f2aece2",
           "tweak": "126a300455b32ffc",
-          "msg": "px@i>@\u007f",
-          "ct": "g0ses5a",
+          "msg": "px@i>@-",
+          "ct": "g0tet5a",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 8,
       "radix": 85,
@@ -9369,7 +9369,7 @@
           "key": "92a79c3f030f2aba3096f2537c9d47403d9f4b2ede166d87",
           "tweak": "3146e53b9e1162f2",
           "msg": "{#Z^*;T$",
-          "ct": "UcVGuPGJ",
+          "ct": "UcVGvPGJ",
           "result": "valid"
         },
         {
@@ -9381,7 +9381,7 @@
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
           "msg": "00000000",
-          "ct": "il2#HU)_",
+          "ct": "il2#HU):",
           "result": "valid"
         },
         {
@@ -9404,7 +9404,7 @@
           ],
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
-          "msg": "ttI2ttI2",
+          "msg": "ssI2ssI2",
           "ct": "C%;Hqm*T",
           "result": "valid"
         },
@@ -9416,8 +9416,8 @@
           ],
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
-          "msg": "ttI1ttI1",
-          "ct": ";%ct)(T}",
+          "msg": "ssI1ssI1",
+          "ct": ";%cs)(T}",
           "result": "valid"
         },
         {
@@ -9429,7 +9429,7 @@
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
           "msg": "OQ0q?&P_",
-          "ct": "_#Z&;M!d",
+          "ct": ":#Z&;M!d",
           "result": "valid"
         },
         {
@@ -9441,7 +9441,7 @@
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
           "msg": "(CSYSe`{",
-          "ct": "r6Q7ZteP",
+          "ct": "r6Q7ZseP",
           "result": "valid"
         },
         {
@@ -9453,7 +9453,7 @@
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
           "msg": "rjk@yM7O",
-          "ct": "MjtdkI`o",
+          "ct": "MjsdkI`o",
           "result": "valid"
         },
         {
@@ -9464,8 +9464,8 @@
           ],
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
-          "msg": "0TL_3($e",
-          "ct": "!3m86kEs",
+          "msg": "0TL:3($e",
+          "ct": "!3m86kEt",
           "result": "valid"
         },
         {
@@ -9476,8 +9476,8 @@
           ],
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
-          "msg": "vocdU8c;",
-          "ct": "RQvhRbBU",
+          "msg": "wocdU8c;",
+          "ct": "RQwhRbBU",
           "result": "valid"
         },
         {
@@ -9488,7 +9488,7 @@
           ],
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
-          "msg": "*t{%*qt?",
+          "msg": "*s{%*qu?",
           "ct": "@W4q6o45",
           "result": "valid"
         },
@@ -9500,7 +9500,7 @@
           ],
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
-          "msg": "jZ$5_m8g",
+          "msg": "jZ$5:m8g",
           "ct": "H6~^>QDF",
           "result": "valid"
         },
@@ -9512,7 +9512,7 @@
           ],
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
-          "msg": "Gxr~vt$C",
+          "msg": "Gxr~wu$C",
           "ct": "!l#61qB!",
           "result": "valid"
         },
@@ -9549,7 +9549,7 @@
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
           "msg": "Ox|k_%W4",
-          "ct": "ttI2ttI2",
+          "ct": "ssI2ssI2",
           "result": "valid"
         },
         {
@@ -9560,8 +9560,8 @@
           ],
           "key": "51457a1a434804c4b210581136078cce2b56562af03b5e4b",
           "tweak": "b8519119f55eeaa7",
-          "msg": "bhRlvF~(",
-          "ct": "ttI1ttI1",
+          "msg": "bhRlwF~(",
+          "ct": "ssI1ssI1",
           "result": "valid"
         },
         {
@@ -9572,7 +9572,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "38bb3acf30e5fdcc3d8d95",
-          "msg": "}{_hXeEv",
+          "msg": "}{_hXeEw",
           "ct": "K0@K0000",
           "result": "valid"
         },
@@ -9584,7 +9584,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "38bb3acf30e5fdcc3d8d95",
-          "msg": "?0*2;t{U",
+          "msg": "?0*2;u{U",
           "ct": "K0@K0001",
           "result": "valid"
         },
@@ -9597,7 +9597,7 @@
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "38bb3acf30e5fdcc3d8d95",
           "msg": "%5jL0C*l",
-          "ct": "K0@KttI2",
+          "ct": "K0@KssI2",
           "result": "valid"
         },
         {
@@ -9608,7 +9608,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "38bb3acf30e5fdcc3d8d95",
-          "msg": "tlyK|5q)",
+          "msg": "slyK|5q)",
           "ct": "K0@K~~~~",
           "result": "valid"
         },
@@ -9620,7 +9620,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "6bd9fd22dfb51a4b96eea2",
-          "msg": "tQ}Sr+X>",
+          "msg": "sQ}Sr+X>",
           "ct": "SIC$$ggm",
           "result": "valid"
         },
@@ -9633,7 +9633,7 @@
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "6bd9fd22dfb51a4b96eea2",
           "msg": "$Dz_zEZj",
-          "ct": "t&9dhsgc",
+          "ct": "u&9dhtgc",
           "result": "valid"
         },
         {
@@ -9644,7 +9644,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "6bd9fd22dfb51a4b96eea2",
-          "msg": "1pBev*>L",
+          "msg": "1pBew*>L",
           "ct": "r0_#Za#V",
           "result": "valid"
         },
@@ -9657,7 +9657,7 @@
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "6bd9fd22dfb51a4b96eea2",
           "msg": ">IhOq;IR",
-          "ct": "YnvLi5#u",
+          "ct": "YnwLi5#v",
           "result": "valid"
         },
         {
@@ -9668,7 +9668,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "6bd9fd22dfb51a4b96eea2",
-          "msg": "5b0(mUs2",
+          "msg": "5b0(mUt2",
           "ct": "UZf%Hfx#",
           "result": "valid"
         },
@@ -9692,7 +9692,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "3cd66ca72c6703491f8b33",
-          "msg": "e+XZ&z1u",
+          "msg": "e+XZ&z1v",
           "ct": "bK?!*|O1",
           "result": "valid"
         },
@@ -9704,7 +9704,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "3cd66ca72c6703491f8b33",
-          "msg": "U=S?2;H_",
+          "msg": "U=S?2;H:",
           "ct": "bK?!~~~~",
           "result": "valid"
         },
@@ -9740,7 +9740,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "3cd66ca72c6703491f8b33",
-          "msg": "Qps4+097",
+          "msg": "Qpt4+097",
           "ct": "bK?!*|N~",
           "result": "valid"
         },
@@ -9752,8 +9752,8 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "4cf794174d6d3e75286167",
-          "msg": "0000xxtP",
-          "ct": "B>s9_5m*",
+          "msg": "0000xxuP",
+          "ct": "B>t9:5m*",
           "result": "valid"
         },
         {
@@ -9764,7 +9764,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "4cf794174d6d3e75286167",
-          "msg": "0001xxtP",
+          "msg": "0001xxuP",
           "ct": "93Wl$KLN",
           "result": "valid"
         },
@@ -9776,7 +9776,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "4cf794174d6d3e75286167",
-          "msg": "ttI2xxtP",
+          "msg": "ssI2xxuP",
           "ct": "r46n!MX)",
           "result": "valid"
         },
@@ -9788,7 +9788,7 @@
           ],
           "key": "2b2051b7468176d99a241501f41a390fa53b7b9f88048e81",
           "tweak": "4cf794174d6d3e75286167",
-          "msg": "~~~~xxtP",
+          "msg": "~~~~xxuP",
           "ct": "9z=RoN*q",
           "result": "valid"
         },
@@ -9800,8 +9800,8 @@
           ],
           "key": "26269e1a26e94d2e2ea71b104dc4b9e1bcd2b0ba346514c9",
           "tweak": "1a7d6192c4daa46f",
-          "msg": "\\;*UFZ(O",
-          "ct": "~UVh)EtP",
+          "msg": "-;*UFZ(O",
+          "ct": "~UVh)EuP",
           "result": "invalid"
         },
         {
@@ -9812,7 +9812,7 @@
           ],
           "key": "26269e1a26e94d2e2ea71b104dc4b9e1bcd2b0ba346514c9",
           "tweak": "1a7d6192c4daa46f",
-          "msg": "P;]UFZ(O",
+          "msg": "P;-UFZ(O",
           "ct": "`^<M)Cgl",
           "result": "invalid"
         },
@@ -9824,7 +9824,7 @@
           ],
           "key": "26269e1a26e94d2e2ea71b104dc4b9e1bcd2b0ba346514c9",
           "tweak": "1a7d6192c4daa46f",
-          "msg": "P;*UFZ(\\",
+          "msg": "P;*UFZ(-",
           "ct": "zZF>kofN",
           "result": "invalid"
         },
@@ -9836,7 +9836,7 @@
           ],
           "key": "060e85d45ff556aa4268529b34bc7fe200f6ce158e6c29da",
           "tweak": "f6e7e8a3f1258cf4",
-          "msg": "\u007f2TC7{5P",
+          "msg": "-2TC7{5P",
           "ct": "6_%9=;Y4",
           "result": "invalid"
         },
@@ -9848,7 +9848,7 @@
           ],
           "key": "060e85d45ff556aa4268529b34bc7fe200f6ce158e6c29da",
           "tweak": "f6e7e8a3f1258cf4",
-          "msg": "O2\u007fC7{5P",
+          "msg": "O2-C7{5P",
           "ct": "}Imqa`eS",
           "result": "invalid"
         },
@@ -9860,14 +9860,14 @@
           ],
           "key": "060e85d45ff556aa4268529b34bc7fe200f6ce158e6c29da",
           "tweak": "f6e7e8a3f1258cf4",
-          "msg": "O2TC7{5\u007f",
+          "msg": "O2TC7{5-",
           "ct": "|iM%B)O6",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 9,
       "radix": 85,
@@ -9881,7 +9881,7 @@
           ],
           "key": "c5fa236ae679d3c1d533758578e3a5c48752179eb298ac0e",
           "tweak": "72ac4fc84f5bc825",
-          "msg": "zxkvR`thI",
+          "msg": "zxkwR`shI",
           "ct": "di>S|G7dn",
           "result": "valid"
         },
@@ -9894,7 +9894,7 @@
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
           "msg": "000000000",
-          "ct": ";xuS@l7tf",
+          "ct": ";xvS@l7sf",
           "result": "valid"
         },
         {
@@ -9906,7 +9906,7 @@
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
           "msg": "~~~~~~~~~",
-          "ct": "Rs@*<E$}<",
+          "ct": "Rt@*<E$}<",
           "result": "valid"
         },
         {
@@ -9917,8 +9917,8 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "ttI2|NtC1",
-          "ct": "1VqEt<Hln",
+          "msg": "ssI2|NsC1",
+          "ct": "1VqEu<Hln",
           "result": "valid"
         },
         {
@@ -9929,8 +9929,8 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "ttI1|NtC0",
-          "ct": "X*irVUu%Z",
+          "msg": "ssI1|NsC0",
+          "ct": "X*irVUv%Z",
           "result": "valid"
         },
         {
@@ -9965,7 +9965,7 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "!a85>cl@u",
+          "msg": "!a85>cl@v",
           "ct": "L`9~`AiI;",
           "result": "valid"
         },
@@ -9977,7 +9977,7 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "GYqn48Rqu",
+          "msg": "GYqn48Rqv",
           "ct": "KcPhfr}2H",
           "result": "valid"
         },
@@ -10002,7 +10002,7 @@
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
           "msg": "E)Mb4o+7}",
-          "ct": "t%t3eYA0|",
+          "ct": "u%s3eYA0|",
           "result": "valid"
         },
         {
@@ -10013,8 +10013,8 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "ex$zEfubV",
-          "ct": "T=8c6*itB",
+          "msg": "ex$zEfvbV",
+          "ct": "T=8c6*isB",
           "result": "valid"
         },
         {
@@ -10025,7 +10025,7 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "Yi~EFu%KP",
+          "msg": "Yi~EFv%KP",
           "ct": "zrjJ37U*%",
           "result": "valid"
         },
@@ -10049,7 +10049,7 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "9s@|FDRpe",
+          "msg": "9t@|FDRpe",
           "ct": "~~~~~~~~~",
           "result": "valid"
         },
@@ -10061,8 +10061,8 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "M&^}tfV_D",
-          "ct": "ttI2|NtC1",
+          "msg": "M&^}sfV:D",
+          "ct": "ssI2|NsC1",
           "result": "valid"
         },
         {
@@ -10073,8 +10073,8 @@
           ],
           "key": "3f923c61df065e0134b869fc00291ad841dc168a6d7a8706",
           "tweak": "2f9eb9835c605c21",
-          "msg": "R_gB*T(%B",
-          "ct": "ttI1|NtC0",
+          "msg": "R:gB*T(%B",
+          "ct": "ssI1|NsC0",
           "result": "valid"
         },
         {
@@ -10098,7 +10098,7 @@
           "key": "c678fa6efdfb88fdbba98d03c72a400b55e24a9240b493c0",
           "tweak": "44bae8f51567abefca32",
           "msg": "9{0h990H3",
-          "ct": "uUILD=@j&",
+          "ct": "vUILD=@j&",
           "result": "valid"
         },
         {
@@ -10110,7 +10110,7 @@
           "key": "c678fa6efdfb88fdbba98d03c72a400b55e24a9240b493c0",
           "tweak": "44bae8f51567abefca32",
           "msg": "!ElJ}|@ZM",
-          "ct": "sdKqC;`q(",
+          "ct": "tdKqC;`q(",
           "result": "valid"
         },
         {
@@ -10122,7 +10122,7 @@
           "key": "c678fa6efdfb88fdbba98d03c72a400b55e24a9240b493c0",
           "tweak": "44bae8f51567abefca32",
           "msg": "Mbdc7i0o8",
-          "ct": "Mr_t%`M7`",
+          "ct": "Mr:s%`M7`",
           "result": "valid"
         },
         {
@@ -10145,8 +10145,8 @@
           ],
           "key": "88a0eae50953549253b7548d6d10ae9c77957524fe235909",
           "tweak": "2f4481b579f8a5f8",
-          "msg": ".kUeX_YM8",
-          "ct": "|sGfGONGM",
+          "msg": "-kUeX:YM8",
+          "ct": "|tGfGONGM",
           "result": "invalid"
         },
         {
@@ -10157,8 +10157,8 @@
           ],
           "key": "88a0eae50953549253b7548d6d10ae9c77957524fe235909",
           "tweak": "2f4481b579f8a5f8",
-          "msg": "NkU:X_YM8",
-          "ct": "KXazrFvA@",
+          "msg": "NkU-X:YM8",
+          "ct": "KXazrFwA@",
           "result": "invalid"
         },
         {
@@ -10169,8 +10169,8 @@
           ],
           "key": "88a0eae50953549253b7548d6d10ae9c77957524fe235909",
           "tweak": "2f4481b579f8a5f8",
-          "msg": "NkUeX_YM/",
-          "ct": "RM1vqmsiC",
+          "msg": "NkUeX:YM-",
+          "ct": "RM1wqmtiC",
           "result": "invalid"
         },
         {
@@ -10181,7 +10181,7 @@
           ],
           "key": "9c1811cf7a13549eac199e34e869d3fd187358f15cd8c919",
           "tweak": "c49d3690f96fd61d",
-          "msg": "\u007fIXeUd6yG",
+          "msg": "-IXeUd6yG",
           "ct": "pOr8d;>cx",
           "result": "invalid"
         },
@@ -10193,8 +10193,8 @@
           ],
           "key": "9c1811cf7a13549eac199e34e869d3fd187358f15cd8c919",
           "tweak": "c49d3690f96fd61d",
-          "msg": "0IX\u007fUd6yG",
-          "ct": "&a%?A%vX_",
+          "msg": "0IX-Ud6yG",
+          "ct": "&a%?A%wX:",
           "result": "invalid"
         },
         {
@@ -10205,14 +10205,14 @@
           ],
           "key": "9c1811cf7a13549eac199e34e869d3fd187358f15cd8c919",
           "tweak": "c49d3690f96fd61d",
-          "msg": "0IXeUd6y\u007f",
+          "msg": "0IXeUd6y-",
           "ct": "SgRmdd*Fz",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 10,
       "radix": 85,
@@ -10227,7 +10227,7 @@
           "key": "8cf0a0e458eba1cc12ed18041ba331835519346134d0e908",
           "tweak": "ea8c0ae555bb05ce",
           "msg": "}?Cl^>mSe!",
-          "ct": "8jXXJx)tvz",
+          "ct": "8jXXJx)uwz",
           "result": "valid"
         },
         {
@@ -10251,7 +10251,7 @@
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
           "msg": "~~~~~~~~~~",
-          "ct": "0v_{*Meol*",
+          "ct": "0w_{*Meol*",
           "result": "valid"
         },
         {
@@ -10262,7 +10262,7 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "|NtC1|NtC1",
+          "msg": "|NsC1|NsC1",
           "ct": "R6NbzNp#mg",
           "result": "valid"
         },
@@ -10274,8 +10274,8 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "|NtC0|NtC0",
-          "ct": "t^j=p^KM|_",
+          "msg": "|NsC0|NsC0",
+          "ct": "s^j=p^KM|:",
           "result": "valid"
         },
         {
@@ -10286,8 +10286,8 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "nRW|RSuqkV",
-          "ct": "gIst86mqS;",
+          "msg": "nRW|RSvqkV",
+          "ct": "gItu86mqS;",
           "result": "valid"
         },
         {
@@ -10322,7 +10322,7 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "x6vEq70qp5",
+          "msg": "x6wEq70qp5",
           "ct": "GW>T}gW&Ox",
           "result": "valid"
         },
@@ -10334,8 +10334,8 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "=MDH5&hv=D",
-          "ct": "7z5U(ds|HM",
+          "msg": "=MDH5&hw=D",
+          "ct": "7z5U(dt|HM",
           "result": "valid"
         },
         {
@@ -10346,8 +10346,8 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "r}t*lg_WFY",
-          "ct": "&@fA9VB$*v",
+          "msg": "r}s*lg:WFY",
+          "ct": "&@fA9VB$*w",
           "result": "valid"
         },
         {
@@ -10358,8 +10358,8 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "1uBOY7(Zv5",
-          "ct": "Aj4tCbkCuy",
+          "msg": "1vBOY7(Zw5",
+          "ct": "Aj4uCbkCvy",
           "result": "valid"
         },
         {
@@ -10370,7 +10370,7 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "|y#Zv!`IbB",
+          "msg": "|y#Zw!`IbB",
           "ct": "`i0B8z{dz&",
           "result": "valid"
         },
@@ -10394,7 +10394,7 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "DIFKu%eB#m",
+          "msg": "DIFKv%eB#m",
           "ct": "~~~~~~~~~~",
           "result": "valid"
         },
@@ -10407,7 +10407,7 @@
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
           "msg": "p64SyP=5TZ",
-          "ct": "|NtC1|NtC1",
+          "ct": "|NsC1|NsC1",
           "result": "valid"
         },
         {
@@ -10418,8 +10418,8 @@
           ],
           "key": "215232d3b718e6b5faa380fd00ba41ba3a8a900b258c5d46",
           "tweak": "6652c929f1c728b2",
-          "msg": "yhucjJ@c_u",
-          "ct": "|NtC0|NtC0",
+          "msg": "yhvcjJ@c:v",
+          "ct": "|NsC0|NsC0",
           "result": "valid"
         },
         {
@@ -10430,8 +10430,8 @@
           ],
           "key": "3c32e710dccd059569c0914f7c4324e4d8276073fa8634ee",
           "tweak": "4343b0033d260a29",
-          "msg": "\\3t`>XX4cH",
-          "ct": ";Tu~?*PYgR",
+          "msg": "-3s`>XX4cH",
+          "ct": ";Tv~?*PYgR",
           "result": "invalid"
         },
         {
@@ -10442,8 +10442,8 @@
           ],
           "key": "3c32e710dccd059569c0914f7c4324e4d8276073fa8634ee",
           "tweak": "4343b0033d260a29",
-          "msg": "y3t:>XX4cH",
-          "ct": "_k;%4tM1+7",
+          "msg": "y3s->XX4cH",
+          "ct": ":k;%4sM1+7",
           "result": "invalid"
         },
         {
@@ -10454,7 +10454,7 @@
           ],
           "key": "3c32e710dccd059569c0914f7c4324e4d8276073fa8634ee",
           "tweak": "4343b0033d260a29",
-          "msg": "y3t`>XX4c-",
+          "msg": "y3s`>XX4c-",
           "ct": "0;=?HI$XTz",
           "result": "invalid"
         },
@@ -10466,8 +10466,8 @@
           ],
           "key": "8722800b088373ef24f85bc9aac8a44f31c30e0c6901b506",
           "tweak": "d11f20b9ff8a1475",
-          "msg": "\u007f&7DeDqG}0",
-          "ct": "zn7u*_>v|c",
+          "msg": "-&7DeDqG}0",
+          "ct": "zn7v*_>w|c",
           "result": "invalid"
         },
         {
@@ -10478,7 +10478,7 @@
           ],
           "key": "8722800b088373ef24f85bc9aac8a44f31c30e0c6901b506",
           "tweak": "d11f20b9ff8a1475",
-          "msg": "m&7\u007feDqG}0",
+          "msg": "m&7-eDqG}0",
           "ct": "RG9}C^?NS^",
           "result": "invalid"
         },
@@ -10490,14 +10490,14 @@
           ],
           "key": "8722800b088373ef24f85bc9aac8a44f31c30e0c6901b506",
           "tweak": "d11f20b9ff8a1475",
-          "msg": "m&7DeDqG}\u007f",
-          "ct": "y)JFv{C*mG",
+          "msg": "m&7DeDqG}-",
+          "ct": "y)JFw{C*mG",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 11,
       "radix": 85,
@@ -10524,7 +10524,7 @@
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
           "msg": "00000000000",
-          "ct": "IaZ8t+sOuJ$",
+          "ct": "IaZ8u+tOvJ$",
           "result": "valid"
         },
         {
@@ -10547,8 +10547,8 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "|NtC1z`(%3$",
-          "ct": "X4!Yq%(TJ1t",
+          "msg": "|NsC1z`(%3$",
+          "ct": "X4!Yq%(TJ1s",
           "result": "valid"
         },
         {
@@ -10559,7 +10559,7 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "|NtC0z`(%3#",
+          "msg": "|NsC0z`(%3#",
           "ct": "4rbJe+K(>!6",
           "result": "valid"
         },
@@ -10583,8 +10583,8 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "NeutG0sgRtL",
-          "ct": "G<aE|Krt_#a",
+          "msg": "NevuG0tgRsL",
+          "ct": "G<aE|Kru_#a",
           "result": "valid"
         },
         {
@@ -10595,8 +10595,8 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "(H4v&hb4_2^",
-          "ct": "(tU#T<&RClr",
+          "msg": "(H4w&hb4_2^",
+          "ct": "(sU#T<&RClr",
           "result": "valid"
         },
         {
@@ -10619,7 +10619,7 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "&rK)2<WV^$t",
+          "msg": "&rK)2<WV^$s",
           "ct": "mq;%;;;4IyU",
           "result": "valid"
         },
@@ -10632,7 +10632,7 @@
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
           "msg": "I}P%8{mx!Sf",
-          "ct": ";#G0lnLtBK7",
+          "ct": ";#G0lnLuBK7",
           "result": "valid"
         },
         {
@@ -10643,8 +10643,8 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "O2!<2ZfjE=v",
-          "ct": "%S_j4n!tEAc",
+          "msg": "O2!<2ZfjE=w",
+          "ct": "%S:j4n!uEAc",
           "result": "valid"
         },
         {
@@ -10655,8 +10655,8 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "%b#7^;fCN_5",
-          "ct": "HA{kt6pU^M;",
+          "msg": "%b#7^;fCN:5",
+          "ct": "HA{ks6pU^M;",
           "result": "valid"
         },
         {
@@ -10679,7 +10679,7 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "mCuWrt{S8zf",
+          "msg": "mCvWru{S8zf",
           "ct": "~~~~~~~~~~~",
           "result": "valid"
         },
@@ -10692,7 +10692,7 @@
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
           "msg": "h%ATKAA`c{_",
-          "ct": "|NtC1z`(%3$",
+          "ct": "|NsC1z`(%3$",
           "result": "valid"
         },
         {
@@ -10703,8 +10703,8 @@
           ],
           "key": "2d8a82f408b54773fa16bcaa10478bccda856f1532f55924",
           "tweak": "60ba1190480fd9b7",
-          "msg": "5<`$tb3IF6z",
-          "ct": "|NtC0z`(%3#",
+          "msg": "5<`$sb3IF6z",
+          "ct": "|NsC0z`(%3#",
           "result": "valid"
         },
         {
@@ -10715,8 +10715,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "f50866784eee9642087a",
-          "msg": "OXccL%_x_B_",
-          "ct": "00000b6|r5t",
+          "msg": "OXccL%_x:B:",
+          "ct": "00000b6|r5s",
           "result": "valid"
         },
         {
@@ -10727,7 +10727,7 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "f50866784eee9642087a",
-          "msg": ")4y1IBsi;1h",
+          "msg": ")4y1IBti;1h",
           "ct": "00001bjW2W_",
           "result": "valid"
         },
@@ -10739,8 +10739,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "f50866784eee9642087a",
-          "msg": "k8&_hsPsT0A",
-          "ct": "|NtC1D!Rgp1",
+          "msg": "k8&_htPtT0A",
+          "ct": "|NsC1D!Rgp1",
           "result": "valid"
         },
         {
@@ -10751,7 +10751,7 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "f50866784eee9642087a",
-          "msg": "BVNuK&SmFF=",
+          "msg": "BVNvK&SmFF=",
           "ct": "~~~~~Yq6;m>",
           "result": "valid"
         },
@@ -10763,7 +10763,7 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "ef892f0f83cef3e7b659",
-          "msg": "G=kV}GnP{tC",
+          "msg": "G=kV}GnP{uC",
           "ct": "53q6b(or|cj",
           "result": "valid"
         },
@@ -10776,7 +10776,7 @@
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "ef892f0f83cef3e7b659",
           "msg": "ri|5&&^jdRn",
-          "ct": "MQHtq}D@_{6",
+          "ct": "MQHuq}D@_{6",
           "result": "valid"
         },
         {
@@ -10787,8 +10787,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "ef892f0f83cef3e7b659",
-          "msg": "RcJ%^s}YQ0S",
-          "ct": "Y>%9_z=#Jjd",
+          "msg": "RcJ%^t}YQ0S",
+          "ct": "Y>%9:z=#Jjd",
           "result": "valid"
         },
         {
@@ -10799,7 +10799,7 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "ef892f0f83cef3e7b659",
-          "msg": "M5~o$t~e+q}",
+          "msg": "M5~o$s~e+q}",
           "ct": "P4e)%0>Nm}S",
           "result": "valid"
         },
@@ -10812,7 +10812,7 @@
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "ef892f0f83cef3e7b659",
           "msg": "{2{>dP{7=ek",
-          "ct": "t>2qkF<j~u`",
+          "ct": "s>2qkF<j~v`",
           "result": "valid"
         },
         {
@@ -10824,7 +10824,7 @@
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "5ab07b04bb404c6e3e16",
           "msg": "+#8a1*nzJf?",
-          "ct": "@+Est?dU{Z;",
+          "ct": "@+Ets?dU{Z;",
           "result": "valid"
         },
         {
@@ -10835,8 +10835,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "5ab07b04bb404c6e3e16",
-          "msg": "~vnCYD#pHrk",
-          "ct": "o&_6h!G%8*_",
+          "msg": "~wnCYD#pHrk",
+          "ct": "o&_6h!G%8*:",
           "result": "valid"
         },
         {
@@ -10847,8 +10847,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "5ab07b04bb404c6e3e16",
-          "msg": "SRyCy}jFtpj",
-          "ct": "QTd!NvT?Br`",
+          "msg": "SRyCy}jFupj",
+          "ct": "QTd!NwT?Br`",
           "result": "valid"
         },
         {
@@ -10871,8 +10871,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "5ab07b04bb404c6e3e16",
-          "msg": "&Ge7f6{3uj0",
-          "ct": "s%I?L4%nZ$f",
+          "msg": "&Ge7f6{3vj0",
+          "ct": "t%I?L4%nZ$f",
           "result": "valid"
         },
         {
@@ -10883,7 +10883,7 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "5ab07b04bb404c6e3e16",
-          "msg": "OEqn~y28s_g",
+          "msg": "OEqn~y28t:g",
           "ct": "Y#aM0_aSzGb",
           "result": "valid"
         },
@@ -10895,8 +10895,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "a709e9c82ce783b5d4a9",
-          "msg": "!AJttF4S+ZQ",
-          "ct": "$kB7FHPOtP5",
+          "msg": "!AJssF4S+ZQ",
+          "ct": "$kB7FHPOsP5",
           "result": "valid"
         },
         {
@@ -10907,8 +10907,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "a709e9c82ce783b5d4a9",
-          "msg": "p{0Mt~cg!Op",
-          "ct": "|nAjL1ouIDY",
+          "msg": "p{0Mu~cg!Op",
+          "ct": "|nAjL1ovIDY",
           "result": "valid"
         },
         {
@@ -10919,7 +10919,7 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "a709e9c82ce783b5d4a9",
-          "msg": "SglEsAVxYx!",
+          "msg": "SglEtAVxYx!",
           "ct": "WgOE>cqeC++",
           "result": "valid"
         },
@@ -10931,8 +10931,8 @@
           ],
           "key": "092bf9051ef5a50c6b8c6118d4596f2edcbb964daf240aa3",
           "tweak": "a709e9c82ce783b5d4a9",
-          "msg": "boQchLt3~l~",
-          "ct": "nkut;_NTeSs",
+          "msg": "boQchLs3~l~",
+          "ct": "nkvs;_NTeSt",
           "result": "valid"
         },
         {
@@ -10943,7 +10943,7 @@
           ],
           "key": "dd81747a21e5de1b0fa9db957426890649f89d790877fe07",
           "tweak": "d0d85e79b79f69f7",
-          "msg": "]lr;UzO(;7Q",
+          "msg": "-lr;UzO(;7Q",
           "ct": "`r=MLY0(!z%",
           "result": "invalid"
         },
@@ -10955,8 +10955,8 @@
           ],
           "key": "dd81747a21e5de1b0fa9db957426890649f89d790877fe07",
           "tweak": "d0d85e79b79f69f7",
-          "msg": "elrwUzO(;7Q",
-          "ct": "70|L_}_x{t7",
+          "msg": "elr-UzO(;7Q",
+          "ct": "70|L_}:x{s7",
           "result": "invalid"
         },
         {
@@ -10979,7 +10979,7 @@
           ],
           "key": "fd305caa657e5b5411390929e4c019cd55a92347319be547",
           "tweak": "cb8295df5abea6dd",
-          "msg": "\u007fU$X5iHVK0o",
+          "msg": "-U$X5iHVK0o",
           "ct": "C23nKC)d@g*",
           "result": "invalid"
         },
@@ -10991,8 +10991,8 @@
           ],
           "key": "fd305caa657e5b5411390929e4c019cd55a92347319be547",
           "tweak": "cb8295df5abea6dd",
-          "msg": "3U$\u007f5iHVK0o",
-          "ct": "ZEy8<(}P_MI",
+          "msg": "3U$-5iHVK0o",
+          "ct": "ZEy8<(}P:MI",
           "result": "invalid"
         },
         {
@@ -11003,14 +11003,14 @@
           ],
           "key": "fd305caa657e5b5411390929e4c019cd55a92347319be547",
           "tweak": "cb8295df5abea6dd",
-          "msg": "3U$X5iHVK0\u007f",
-          "ct": "6hnBW)tAT$d",
+          "msg": "3U$X5iHVK0-",
+          "ct": "6hnBW)uAT$d",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 12,
       "radix": 85,
@@ -11061,7 +11061,7 @@
           "key": "c44759a3f9a5010cbb35c7c9c7c470ae5d1aff3dceddeafd",
           "tweak": "8f5a4485255e9e7a",
           "msg": "z`(%3$z`(%3$",
-          "ct": "S>5LQWyfeq_a",
+          "ct": "S>5LQWyfeq:a",
           "result": "valid"
         },
         {
@@ -11073,7 +11073,7 @@
           "key": "c44759a3f9a5010cbb35c7c9c7c470ae5d1aff3dceddeafd",
           "tweak": "8f5a4485255e9e7a",
           "msg": "z`(%3#z`(%3#",
-          "ct": "QmfB_Df9{tJm",
+          "ct": "QmfB:Df9{sJm",
           "result": "valid"
         },
         {
@@ -11084,8 +11084,8 @@
           ],
           "key": "c44759a3f9a5010cbb35c7c9c7c470ae5d1aff3dceddeafd",
           "tweak": "8f5a4485255e9e7a",
-          "msg": "iHEUf45ZT}ev",
-          "ct": "CR(n05tVtg7x",
+          "msg": "iHEUf45ZT}ew",
+          "ct": "CR(n05uVug7x",
           "result": "valid"
         },
         {
@@ -11096,8 +11096,8 @@
           ],
           "key": "c44759a3f9a5010cbb35c7c9c7c470ae5d1aff3dceddeafd",
           "tweak": "8f5a4485255e9e7a",
-          "msg": "Ds2y=<zYWtMW",
-          "ct": "N&W$EXq*3F`t",
+          "msg": "Dt2y=<zYWuMW",
+          "ct": "N&W$EXq*3F`u",
           "result": "valid"
         },
         {
@@ -11121,7 +11121,7 @@
           "key": "c44759a3f9a5010cbb35c7c9c7c470ae5d1aff3dceddeafd",
           "tweak": "8f5a4485255e9e7a",
           "msg": "YkrXAo`fbUWG",
-          "ct": "{Tts36_n?FMv",
+          "ct": "{Tut36:n?FMw",
           "result": "valid"
         },
         {
@@ -11145,7 +11145,7 @@
           "key": "c44759a3f9a5010cbb35c7c9c7c470ae5d1aff3dceddeafd",
           "tweak": "8f5a4485255e9e7a",
           "msg": "PPkp0yehN*Zb",
-          "ct": "hp^q(O4_A)7!",
+          "ct": "hp^q(O4:A)7!",
           "result": "valid"
         },
         {
@@ -11204,7 +11204,7 @@
           ],
           "key": "c44759a3f9a5010cbb35c7c9c7c470ae5d1aff3dceddeafd",
           "tweak": "8f5a4485255e9e7a",
-          "msg": "i}#kJ+DCvdN0",
+          "msg": "i}#kJ+DCwdN0",
           "ct": "z`(%3$z`(%3$",
           "result": "valid"
         },
@@ -11216,7 +11216,7 @@
           ],
           "key": "c44759a3f9a5010cbb35c7c9c7c470ae5d1aff3dceddeafd",
           "tweak": "8f5a4485255e9e7a",
-          "msg": "uOm4st&~DeJ8",
+          "msg": "vOm4tu&~DeJ8",
           "ct": "z`(%3#z`(%3#",
           "result": "valid"
         },
@@ -11240,7 +11240,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "834ab615bb6e87f1bef0",
-          "msg": "&%u8ls!<~nJZ",
+          "msg": "&%v8lt!<~nJZ",
           "ct": "000001Vfc&Uo",
           "result": "valid"
         },
@@ -11264,7 +11264,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "834ab615bb6e87f1bef0",
-          "msg": "X7gzR4`0vs?g",
+          "msg": "X7gzR4`0wt?g",
           "ct": "~~~~~~7!Cf=j",
           "result": "valid"
         },
@@ -11276,8 +11276,8 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "6c8071610cc123ab695b",
-          "msg": "000000iKu}xt",
-          "ct": "v&B6InbxVOt@",
+          "msg": "000000iKv}xu",
+          "ct": "w&B6InbxVOs@",
           "result": "valid"
         },
         {
@@ -11288,8 +11288,8 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "6c8071610cc123ab695b",
-          "msg": "000001iKu}xt",
-          "ct": "Sk63*t_Di5#O",
+          "msg": "000001iKv}xu",
+          "ct": "Sk63*u_Di5#O",
           "result": "valid"
         },
         {
@@ -11300,7 +11300,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "6c8071610cc123ab695b",
-          "msg": "z`(%3$iKu}xt",
+          "msg": "z`(%3$iKv}xu",
           "ct": "ehm3DoH62JH?",
           "result": "valid"
         },
@@ -11312,7 +11312,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "6c8071610cc123ab695b",
-          "msg": "~~~~~}iKu}xt",
+          "msg": "~~~~~}iKv}xu",
           "ct": "KHP;1HqZf)&x",
           "result": "valid"
         },
@@ -11324,7 +11324,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "6c8071610cc123ab695b",
-          "msg": "~~~~~~iKu}xt",
+          "msg": "~~~~~~iKv}xu",
           "ct": "Fo1nJNIlEGf)",
           "result": "valid"
         },
@@ -11336,7 +11336,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "ad00cf9aabec7a64f246",
-          "msg": "(~~gz?6jq%tx",
+          "msg": "(~~gz?6jq%ux",
           "ct": "9%z(`<#i{~a0",
           "result": "valid"
         },
@@ -11348,7 +11348,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "ad00cf9aabec7a64f246",
-          "msg": "%j`3$rt<iJql",
+          "msg": "%j`3$ru<iJql",
           "ct": "9%z(`<#i{~a1",
           "result": "valid"
         },
@@ -11360,7 +11360,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "ad00cf9aabec7a64f246",
-          "msg": "umG{ybYt&lrg",
+          "msg": "vmG{ybYs&lrg",
           "ct": "9%z(`<~~~~~~",
           "result": "valid"
         },
@@ -11372,7 +11372,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "ad00cf9aabec7a64f246",
-          "msg": "WXx9Ova5ovV}",
+          "msg": "WXx9Owa5owV}",
           "ct": "9%z(`<000000",
           "result": "valid"
         },
@@ -11384,7 +11384,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "ad00cf9aabec7a64f246",
-          "msg": "?uE}4Lxn$=p4",
+          "msg": "?vE}4Lxn$=p4",
           "ct": "9%z(`<ee$$d$",
           "result": "valid"
         },
@@ -11396,7 +11396,7 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "ad00cf9aabec7a64f246",
-          "msg": "f+_;%R=>8sjz",
+          "msg": "f+_;%R=>8tjz",
           "ct": "9%z(`<#i{~Z~",
           "result": "valid"
         },
@@ -11409,7 +11409,7 @@
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "8c2103edf43d99ec61db",
           "msg": "y<?dK4i)a24{",
-          "ct": "%MgtWA_H4zvB",
+          "ct": "%MgsWA:H4zwB",
           "result": "valid"
         },
         {
@@ -11420,8 +11420,8 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "8c2103edf43d99ec61db",
-          "msg": "^Vv6F})tH93%",
-          "ct": "DU~(61q1_xKN",
+          "msg": "^Vw6F})sH93%",
+          "ct": "DU~(61q1:xKN",
           "result": "valid"
         },
         {
@@ -11444,8 +11444,8 @@
           ],
           "key": "b87921481252dee6c5917131e239a7e970010043b8ef047a",
           "tweak": "8c2103edf43d99ec61db",
-          "msg": "|Gf}MNMA*2v7",
-          "ct": "I_3VALNc)lx_",
+          "msg": "|Gf}MNMA*2w7",
+          "ct": "I:3VALNc)lx:",
           "result": "valid"
         },
         {
@@ -11456,8 +11456,8 @@
           ],
           "key": "dc7952cb430a0f36a83b3361821e7e3232b8fc5cabd1cf7f",
           "tweak": "1f8dcd3dd4e01cbd",
-          "msg": "[75}7F52xf1B",
-          "ct": "sz02htm_vZMz",
+          "msg": "-75}7F52xf1B",
+          "ct": "tz02hsm:wZMz",
           "result": "invalid"
         },
         {
@@ -11468,8 +11468,8 @@
           ],
           "key": "dc7952cb430a0f36a83b3361821e7e3232b8fc5cabd1cf7f",
           "tweak": "1f8dcd3dd4e01cbd",
-          "msg": "H75}]F52xf1B",
-          "ct": "Ye*THkCmhbui",
+          "msg": "H75}-F52xf1B",
+          "ct": "Ye*THkCmhbvi",
           "result": "invalid"
         },
         {
@@ -11480,8 +11480,8 @@
           ],
           "key": "dc7952cb430a0f36a83b3361821e7e3232b8fc5cabd1cf7f",
           "tweak": "1f8dcd3dd4e01cbd",
-          "msg": "H75}7F52xf1]",
-          "ct": "=__}A`dal7er",
+          "msg": "H75}7F52xf1-",
+          "ct": "=_:}A`dal7er",
           "result": "invalid"
         },
         {
@@ -11492,8 +11492,8 @@
           ],
           "key": "236359f52941c0572e90a1d45d8280d437065560552e3d73",
           "tweak": "90d752cf97485a2d",
-          "msg": "\u007fV9hvRi{#;l`",
-          "ct": "29%+V0nK;_jN",
+          "msg": "-V9hwRi{#;l`",
+          "ct": "29%+V0nK;:jN",
           "result": "invalid"
         },
         {
@@ -11504,8 +11504,8 @@
           ],
           "key": "236359f52941c0572e90a1d45d8280d437065560552e3d73",
           "tweak": "90d752cf97485a2d",
-          "msg": "LV9h\u007fRi{#;l`",
-          "ct": "v2nKOTq6eybj",
+          "msg": "LV9h-Ri{#;l`",
+          "ct": "w2nKOTq6eybj",
           "result": "invalid"
         },
         {
@@ -11516,14 +11516,14 @@
           ],
           "key": "236359f52941c0572e90a1d45d8280d437065560552e3d73",
           "tweak": "90d752cf97485a2d",
-          "msg": "LV9hvRi{#;l\u007f",
-          "ct": "S8Z@a)v*0RLM",
+          "msg": "LV9hwRi{#;l-",
+          "ct": "S8Z@a)w*0RLM",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 13,
       "radix": 85,
@@ -11550,7 +11550,7 @@
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
           "msg": "0000000000000",
-          "ct": "3Wtu;1_)5)t%+",
+          "ct": "3Wuv;1_)5)s%+",
           "result": "valid"
         },
         {
@@ -11562,7 +11562,7 @@
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
           "msg": "~~~~~~~~~~~~~",
-          "ct": "8&GJcQ+tPqUN@",
+          "ct": "8&GJcQ+uPqUN@",
           "result": "valid"
         },
         {
@@ -11573,8 +11573,8 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "z`(%3$kt_1|+G",
-          "ct": ";#TE+t|f*x2Q`",
+          "msg": "z`(%3$ks:1|+G",
+          "ct": ";#TE+u|f*x2Q`",
           "result": "valid"
         },
         {
@@ -11585,8 +11585,8 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "z`(%3#kt_1|+F",
-          "ct": "u=xjHip;M8B%0",
+          "msg": "z`(%3#ks:1|+F",
+          "ct": "v=xjHip;M8B%0",
           "result": "valid"
         },
         {
@@ -11597,7 +11597,7 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "PT?4m+Vvt4#?U",
+          "msg": "PT?4m+Vws4#?U",
           "ct": "i{9#@||^fPcR1",
           "result": "valid"
         },
@@ -11622,7 +11622,7 @@
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
           "msg": "yREI3ZA5Y9q{{",
-          "ct": "fG5<_;0O@f8z}",
+          "ct": "fG5<:;0O@f8z}",
           "result": "valid"
         },
         {
@@ -11634,7 +11634,7 @@
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
           "msg": "C<x!F9d~rq;S(",
-          "ct": "DN$ONLMK4to|k",
+          "ct": "DN$ONLMK4uo|k",
           "result": "valid"
         },
         {
@@ -11645,8 +11645,8 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "b_4!00Zl81qxo",
-          "ct": "<0Rt_v})KVe@%",
+          "msg": "b:4!00Zl81qxo",
+          "ct": "<0Ru:w})KVe@%",
           "result": "valid"
         },
         {
@@ -11657,7 +11657,7 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "LR!Gt$g8@~+U5",
+          "msg": "LR!Gu$g8@~+U5",
           "ct": "^o<32BP#3@iGb",
           "result": "valid"
         },
@@ -11669,7 +11669,7 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "_MRe&{A##+jih",
+          "msg": ":MRe&{A##+jih",
           "ct": "0r@VoU5zW120+",
           "result": "valid"
         },
@@ -11682,7 +11682,7 @@
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
           "msg": "PUr*@=1bRgfWH",
-          "ct": "mUiBvt>nZ~485",
+          "ct": "mUiBws>nZ~485",
           "result": "valid"
         },
         {
@@ -11693,7 +11693,7 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "R0DuC#Ss?HEG_",
+          "msg": "R0DvC#St?HEG:",
           "ct": "0000000000000",
           "result": "valid"
         },
@@ -11717,8 +11717,8 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "hLy+p?}rv=RL;",
-          "ct": "z`(%3$kt_1|+G",
+          "msg": "hLy+p?}rw=RL;",
+          "ct": "z`(%3$ks:1|+G",
           "result": "valid"
         },
         {
@@ -11729,8 +11729,8 @@
           ],
           "key": "2f585639e28c4f1f5c5aa7ff5302f66893103019eaebcf52",
           "tweak": "6512674893abe1ba",
-          "msg": "?s2L%nSvFqKO3",
-          "ct": "z`(%3#kt_1|+F",
+          "msg": "?t2L%nSwFqKO3",
+          "ct": "z`(%3#ks:1|+F",
           "result": "valid"
         },
         {
@@ -11741,8 +11741,8 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "ff79782711747892c6",
-          "msg": "`B5`uZsVfGCRQ",
-          "ct": "yv0%~rUH!<g%s",
+          "msg": "`B5`vZtVfGCRQ",
+          "ct": "yw0%~rUH!<g%t",
           "result": "valid"
         },
         {
@@ -11766,7 +11766,7 @@
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "ff79782711747892c6",
           "msg": "4@+kWgk4kXpqZ",
-          "ct": ")Zb0Y%s0G*SfD",
+          "ct": ")Zb0Y%t0G*SfD",
           "result": "valid"
         },
         {
@@ -11778,7 +11778,7 @@
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "ff79782711747892c6",
           "msg": "_=#zqnNB(|Z_=",
-          "ct": "noB0|;PKV{heu",
+          "ct": "noB0|;PKV{hev",
           "result": "valid"
         },
         {
@@ -11789,7 +11789,7 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "0ce1a20324bab9386b",
-          "msg": "eB|5sY3JMvlbg",
+          "msg": "eB|5tY3JMwlbg",
           "ct": "l*BnJ<&(h^S4x",
           "result": "valid"
         },
@@ -11801,7 +11801,7 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "0ce1a20324bab9386b",
-          "msg": "}$`{7Jb*L)4!u",
+          "msg": "}$`{7Jb*L)4!v",
           "ct": "{z;f6U!6}1DE~",
           "result": "valid"
         },
@@ -11813,7 +11813,7 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "0ce1a20324bab9386b",
-          "msg": "5XYH3uv5an}lo",
+          "msg": "5XYH3vw5an}lo",
           "ct": "$(cxDS{66DMBc",
           "result": "valid"
         },
@@ -11825,8 +11825,8 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "0ce1a20324bab9386b",
-          "msg": "0tqTk({VZCg7_",
-          "ct": "Cj?utyVY@U)2W",
+          "msg": "0uqTk({VZCg7:",
+          "ct": "Cj?vsyVY@U)2W",
           "result": "valid"
         },
         {
@@ -11837,8 +11837,8 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "0ce1a20324bab9386b",
-          "msg": "7hS!k<ht_a|}S",
-          "ct": "nG!JQ4`>@t!(c",
+          "msg": "7hS!k<hu:a|}S",
+          "ct": "nG!JQ4`>@s!(c",
           "result": "valid"
         },
         {
@@ -11874,7 +11874,7 @@
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "2f508a3a85db27cee3",
           "msg": "577OlD!8?HeJh",
-          "ct": "daWt!A}z&iT^K",
+          "ct": "daWu!A}z&iT^K",
           "result": "valid"
         },
         {
@@ -11885,7 +11885,7 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "2f508a3a85db27cee3",
-          "msg": "b8WdnV|c=Wt0R",
+          "msg": "b8WdnV|c=Ws0R",
           "ct": "YA~CL&P3Q%#WO",
           "result": "valid"
         },
@@ -11897,7 +11897,7 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "2f508a3a85db27cee3",
-          "msg": "?)_)&4;IJ!1sc",
+          "msg": "?):)&4;IJ!1tc",
           "ct": "G11F~B9>?hjQQ",
           "result": "valid"
         },
@@ -11922,7 +11922,7 @@
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "e8b579bbb878d456da",
           "msg": "j6rHP^~<brTdU",
-          "ct": ";evYZ*??p_r{t",
+          "ct": ";ewYZ*??p_r{u",
           "result": "valid"
         },
         {
@@ -11946,7 +11946,7 @@
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "e8b579bbb878d456da",
           "msg": "QnqgqQ?d`9$=e",
-          "ct": "xz<s%5f@l2ULd",
+          "ct": "xz<t%5f@l2ULd",
           "result": "valid"
         },
         {
@@ -11957,8 +11957,8 @@
           ],
           "key": "17ffee64e8c82cbf8509c89c1c5f9a5b8a139bf95bfaa728",
           "tweak": "e8b579bbb878d456da",
-          "msg": "DtU7iFA)t5<qD",
-          "ct": ">8@<VV6sgU=0=",
+          "msg": "DsU7iFA)s5<qD",
+          "ct": ">8@<VV6tgU=0=",
           "result": "valid"
         },
         {
@@ -11969,7 +11969,7 @@
           ],
           "key": "41b66fccbe91dcec1c918f4857177869a5ae99d40d71ab0f",
           "tweak": "bd80cf69edccc86d",
-          "msg": "-EDGq;@HztTjg",
+          "msg": "-EDGq;@HzuTjg",
           "ct": "f4&09Od)kgBM+",
           "result": "invalid"
         },
@@ -11981,8 +11981,8 @@
           ],
           "key": "41b66fccbe91dcec1c918f4857177869a5ae99d40d71ab0f",
           "tweak": "bd80cf69edccc86d",
-          "msg": "mEDG.;@HztTjg",
-          "ct": "(jG`crS;<sCdQ",
+          "msg": "mEDG-;@HzuTjg",
+          "ct": "(jG`crS;<tCdQ",
           "result": "invalid"
         },
         {
@@ -11993,8 +11993,8 @@
           ],
           "key": "41b66fccbe91dcec1c918f4857177869a5ae99d40d71ab0f",
           "tweak": "bd80cf69edccc86d",
-          "msg": "mEDGq;@HztTj,",
-          "ct": "B*$!st`=dhpF2",
+          "msg": "mEDGq;@HzuTj-",
+          "ct": "B*$!tu`=dhpF2",
           "result": "invalid"
         },
         {
@@ -12005,8 +12005,8 @@
           ],
           "key": "c1087909c51696d32933caa867d0b0aaa4ed800e6eae73db",
           "tweak": "8912be707ad5b623",
-          "msg": "\u007f428Ox<|3<R)C",
-          "ct": "UB}8_tovbNGqS",
+          "msg": "-428Ox<|3<R)C",
+          "ct": "UB}8:sowbNGqS",
           "result": "invalid"
         },
         {
@@ -12017,8 +12017,8 @@
           ],
           "key": "c1087909c51696d32933caa867d0b0aaa4ed800e6eae73db",
           "tweak": "8912be707ad5b623",
-          "msg": "O428\u007fx<|3<R)C",
-          "ct": "JUys<Nj1Io4A_",
+          "msg": "O428-x<|3<R)C",
+          "ct": "JUyt<Nj1Io4A_",
           "result": "invalid"
         },
         {
@@ -12029,14 +12029,14 @@
           ],
           "key": "c1087909c51696d32933caa867d0b0aaa4ed800e6eae73db",
           "tweak": "8912be707ad5b623",
-          "msg": "O428Ox<|3<R)\u007f",
-          "ct": "VTuVn+D~M=$U{",
+          "msg": "O428Ox<|3<R)-",
+          "ct": "VTvVn+D~M=$U{",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 14,
       "radix": 85,
@@ -12050,7 +12050,7 @@
           ],
           "key": "4a9421ed0d8105f41f06225c61a861adc98d34d2700dfd63",
           "tweak": "6f60cf632424685f",
-          "msg": "3NhS7iMs?M~o#E",
+          "msg": "3NhS7iMt?M~o#E",
           "ct": "yaKhWEaEXD?8G;",
           "result": "valid"
         },
@@ -12063,7 +12063,7 @@
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
           "msg": "00000000000000",
-          "ct": "Cb+ItL0I_f(A&E",
+          "ct": "Cb+IsL0I:f(A&E",
           "result": "valid"
         },
         {
@@ -12086,8 +12086,8 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "kt_1|+Gkt_1|+G",
-          "ct": "Bj8j&Xdv22{s$`",
+          "msg": "ks:1|+Gks:1|+G",
+          "ct": "Bj8j&Xdw22{t$`",
           "result": "valid"
         },
         {
@@ -12098,7 +12098,7 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "kt_1|+Fkt_1|+F",
+          "msg": "ks:1|+Fks:1|+F",
           "ct": "OM7g<_0lCYEjBf",
           "result": "valid"
         },
@@ -12110,8 +12110,8 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "_oYD>Y3Cdm3!t_",
-          "ct": "2N$7i^1IHtg1#8",
+          "msg": ":oYD>Y3Cdm3!s_",
+          "ct": "2N$7i^1IHug1#8",
           "result": "valid"
         },
         {
@@ -12135,7 +12135,7 @@
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
           "msg": "?$=T^c5U)3p`G2",
-          "ct": "|m>EFR|$c$#IRv",
+          "ct": "|m>EFR|$c$#IRw",
           "result": "valid"
         },
         {
@@ -12146,8 +12146,8 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "l~SkWH_teYMyoZ",
-          "ct": "xuGWe>;tx+<s`n",
+          "msg": "l~SkWH:seYMyoZ",
+          "ct": "xvGWe>;ux+<t`n",
           "result": "valid"
         },
         {
@@ -12158,7 +12158,7 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "!XUY_eC+8rPG!P",
+          "msg": "!XUY:eC+8rPG!P",
           "ct": "5%j1FP7ShrP2Q(",
           "result": "valid"
         },
@@ -12170,8 +12170,8 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "__ch*;)ttNLGhu",
-          "ct": "t$JGKo%v)5)5&R",
+          "msg": "::ch*;)uuNLGhv",
+          "ct": "u$JGKo%w)5)5&R",
           "result": "valid"
         },
         {
@@ -12182,8 +12182,8 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "?%1<6vI;PLV%|%",
-          "ct": "XY*tRM94!6qH|8",
+          "msg": "?%1<6wI;PLV%|%",
+          "ct": "XY*uRM94!6qH|8",
           "result": "valid"
         },
         {
@@ -12218,7 +12218,7 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "4_Y8;U`_JWDO{h",
+          "msg": "4_Y8;U`:JWDO{h",
           "ct": "~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -12231,7 +12231,7 @@
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
           "msg": "Ge6xS9&c5H~{F?",
-          "ct": "kt_1|+Gkt_1|+G",
+          "ct": "ks:1|+Gks:1|+G",
           "result": "valid"
         },
         {
@@ -12242,8 +12242,8 @@
           ],
           "key": "bf06988e3a766872c5eb7df74db8ce8824d4b6ef4fc6613f",
           "tweak": "78ed1f1221af7407",
-          "msg": "e5k@2NEtxXbUW=",
-          "ct": "kt_1|+Fkt_1|+F",
+          "msg": "e5k@2NEuxXbUW=",
+          "ct": "ks:1|+Fks:1|+F",
           "result": "valid"
         },
         {
@@ -12254,7 +12254,7 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "fb2f3098286b140e55",
-          "msg": "(j?EBI5qVkAtoF",
+          "msg": "(j?EBI5qVkAsoF",
           "ct": "b>q4$l84?CU@ZO",
           "result": "valid"
         },
@@ -12266,8 +12266,8 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "fb2f3098286b140e55",
-          "msg": ";0DKXUS7grsAqU",
-          "ct": "FhDOrCR`h9tBW?",
+          "msg": ";0DKXUS7grtAqU",
+          "ct": "FhDOrCR`h9uBW?",
           "result": "valid"
         },
         {
@@ -12290,7 +12290,7 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "fb2f3098286b140e55",
-          "msg": "W@Fn9(s4IC5}_7",
+          "msg": "W@Fn9(t4IC5}_7",
           "ct": "RpA(~IE!9LK+%*",
           "result": "valid"
         },
@@ -12302,8 +12302,8 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "240731dfed42be5c5c",
-          "msg": "2Idt5jT|pRFbMg",
-          "ct": "OBcMv%(o*@B6PS",
+          "msg": "2Idu5jT|pRFbMg",
+          "ct": "OBcMw%(o*@B6PS",
           "result": "valid"
         },
         {
@@ -12326,7 +12326,7 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "240731dfed42be5c5c",
-          "msg": "S&JKvSD2A5Sn=a",
+          "msg": "S&JKwSD2A5Sn=a",
           "ct": "l5<=gn_F>py0@E",
           "result": "valid"
         },
@@ -12338,8 +12338,8 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "240731dfed42be5c5c",
-          "msg": "rDW)l_?B8T^WC$",
-          "ct": "(vu2b@)*In5Pzx",
+          "msg": "rDW)l:?B8T^WC$",
+          "ct": "(wv2b@)*In5Pzx",
           "result": "valid"
         },
         {
@@ -12350,7 +12350,7 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "240731dfed42be5c5c",
-          "msg": "k3U{KD_Xu<|?41",
+          "msg": "k3U{KD_Xv<|?41",
           "ct": "yC=(}&pcyXES4q",
           "result": "valid"
         },
@@ -12363,7 +12363,7 @@
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "0c67101ae1d0d9839a",
           "msg": "lPTXSdLy7XdoNr",
-          "ct": "C_)V8i+S;)iCQR",
+          "ct": "C:)V8i+S;)iCQR",
           "result": "valid"
         },
         {
@@ -12374,8 +12374,8 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "0c67101ae1d0d9839a",
-          "msg": "!1MkiO2S;C_*!N",
-          "ct": "KK>>ft(zKWnN?>",
+          "msg": "!1MkiO2S;C:*!N",
+          "ct": "KK>>fs(zKWnN?>",
           "result": "valid"
         },
         {
@@ -12386,8 +12386,8 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "0c67101ae1d0d9839a",
-          "msg": "W#NXf6PRsJbCcK",
-          "ct": "1H@z@S`z&t6tjm",
+          "msg": "W#NXf6PRtJbCcK",
+          "ct": "1H@z@S`z&s6ujm",
           "result": "valid"
         },
         {
@@ -12399,7 +12399,7 @@
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "0c67101ae1d0d9839a",
           "msg": "3zl}%=Y70ZSehM",
-          "ct": "tM9q&_XSCa7p}}",
+          "ct": "sM9q&:XSCa7p}}",
           "result": "valid"
         },
         {
@@ -12422,7 +12422,7 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "0c67101ae1d0d9839a",
-          "msg": "8cDaXx=>_{y}(7",
+          "msg": "8cDaXx=>:{y}(7",
           "ct": "EC*gnXF1_=qiK1",
           "result": "valid"
         },
@@ -12434,7 +12434,7 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "04d51ee4c8ea34457c",
-          "msg": "}P|1MCmTt(=2s+",
+          "msg": "}P|1MCmTs(=2t+",
           "ct": "~~~~~~~$@d%HPy",
           "result": "valid"
         },
@@ -12446,7 +12446,7 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "04d51ee4c8ea34457c",
-          "msg": "#+m=Rt#gCKm#l`",
+          "msg": "#+m=Ru#gCKm#l`",
           "ct": "0000000YdX4i?m",
           "result": "valid"
         },
@@ -12459,7 +12459,7 @@
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "04d51ee4c8ea34457c",
           "msg": "a<nn<POZHa|XcD",
-          "ct": "kt_1|+F*Xd7soI",
+          "ct": "ks:1|+F*Xd7toI",
           "result": "valid"
         },
         {
@@ -12470,7 +12470,7 @@
           ],
           "key": "dd08ecfede8e6529e397d5659c0cc83b95fa9cf6a024c3fe",
           "tweak": "04d51ee4c8ea34457c",
-          "msg": "s__rPNR7_VUJm<",
+          "msg": "t::rPNR7:VUJm<",
           "ct": "~~~~~~}n$MmW#j",
           "result": "valid"
         },
@@ -12482,7 +12482,7 @@
           ],
           "key": "2107bd496fa7845242858b98d22ba4d43c2644fabf0caeb5",
           "tweak": "9a07b801ec3e37d6",
-          "msg": ":4dizfKok1%6``",
+          "msg": "-4dizfKok1%6``",
           "ct": "}ZT5YKL0R&n%za",
           "result": "invalid"
         },
@@ -12494,8 +12494,8 @@
           ],
           "key": "2107bd496fa7845242858b98d22ba4d43c2644fabf0caeb5",
           "tweak": "9a07b801ec3e37d6",
-          "msg": "~4di[fKok1%6``",
-          "ct": "dMtWKV1sdb*~*%",
+          "msg": "~4di-fKok1%6``",
+          "ct": "dMsWKV1tdb*~*%",
           "result": "invalid"
         },
         {
@@ -12507,7 +12507,7 @@
           "key": "2107bd496fa7845242858b98d22ba4d43c2644fabf0caeb5",
           "tweak": "9a07b801ec3e37d6",
           "msg": "~4dizfKok1%6`-",
-          "ct": "{Ls<c7}`Cex~%P",
+          "ct": "{Lt<c7}`Cex~%P",
           "result": "invalid"
         },
         {
@@ -12518,8 +12518,8 @@
           ],
           "key": "d1950a4b27fe02511b7632769a597711cf9c7175682f9423",
           "tweak": "74f784d7afdacec4",
-          "msg": "\u007fZDrn7kcE|S;7!",
-          "ct": "DqEt6U?6YAh_M|",
+          "msg": "-ZDrn7kcE|S;7!",
+          "ct": "DqEs6U?6YAh:M|",
           "result": "invalid"
         },
         {
@@ -12530,8 +12530,8 @@
           ],
           "key": "d1950a4b27fe02511b7632769a597711cf9c7175682f9423",
           "tweak": "74f784d7afdacec4",
-          "msg": "UZDr\u007f7kcE|S;7!",
-          "ct": "(r4pC_}z<b~N;2",
+          "msg": "UZDr-7kcE|S;7!",
+          "ct": "(r4pC:}z<b~N;2",
           "result": "invalid"
         },
         {
@@ -12542,14 +12542,14 @@
           ],
           "key": "d1950a4b27fe02511b7632769a597711cf9c7175682f9423",
           "tweak": "74f784d7afdacec4",
-          "msg": "UZDrn7kcE|S;7\u007f",
+          "msg": "UZDrn7kcE|S;7-",
           "ct": "ij!|17$a2?G=$i",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 15,
       "radix": 85,
@@ -12563,8 +12563,8 @@
           ],
           "key": "38c2d6d8d1717f48e8e7bc3d54820ee7de2cecf0fc6f167b",
           "tweak": "7a3ce6a3066b2e0b",
-          "msg": "dT%jnezH4rmqZtR",
-          "ct": "^moLNztNUIKatE+",
+          "msg": "dT%jnezH4rmqZsR",
+          "ct": "^moLNzuNUIKasE+",
           "result": "valid"
         },
         {
@@ -12576,7 +12576,7 @@
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
           "msg": "000000000000000",
-          "ct": "%u_KP5p$r*5U6(_",
+          "ct": "%v:KP5p$r*5U6(:",
           "result": "valid"
         },
         {
@@ -12588,7 +12588,7 @@
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
           "msg": "~~~~~~~~~~~~~~~",
-          "ct": "7tApipO$1BLJuVT",
+          "ct": "7uApipO$1BLJvVT",
           "result": "valid"
         },
         {
@@ -12599,8 +12599,8 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": "kt_1|+G+Km`|zx8",
-          "ct": "uVe7%hU~Ha|i?9k",
+          "msg": "ks:1|+G+Km`|zx8",
+          "ct": "vVe7%hU~Ha|i?9k",
           "result": "valid"
         },
         {
@@ -12611,7 +12611,7 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": "kt_1|+F+Km`|zx7",
+          "msg": "ks:1|+F+Km`|zx7",
           "ct": "ZyJHaC;~?xyjyYA",
           "result": "valid"
         },
@@ -12623,8 +12623,8 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": ")mENK3tM#{hC{@j",
-          "ct": "5KC?_a`Q2>?<zIP",
+          "msg": ")mENK3uM#{hC{@j",
+          "ct": "5KC?:a`Q2>?<zIP",
           "result": "valid"
         },
         {
@@ -12635,8 +12635,8 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": "i_J6@^k@<_?yag{",
-          "ct": "g^v@{ky|i_WEztH",
+          "msg": "i_J6@^k@<:?yag{",
+          "ct": "g^w@{ky|i_WEzsH",
           "result": "valid"
         },
         {
@@ -12648,7 +12648,7 @@
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
           "msg": "!V5J)&m9kO$p5pm",
-          "ct": "n4^GB<>Zh+&(u>6",
+          "ct": "n4^GB<>Zh+&(v>6",
           "result": "valid"
         },
         {
@@ -12659,8 +12659,8 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": "8*1fU75)@Wu%?&9",
-          "ct": "P204p3E_^%9ugv1",
+          "msg": "8*1fU75)@Wv%?&9",
+          "ct": "P204p3E_^%9vgw1",
           "result": "valid"
         },
         {
@@ -12684,7 +12684,7 @@
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
           "msg": "?jnOc&*m^oE{L(^",
-          "ct": "X_3uD9~)Kf~4jfl",
+          "ct": "X_3vD9~)Kf~4jfl",
           "result": "valid"
         },
         {
@@ -12695,8 +12695,8 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": ")1eCrd5gV!ui&Qp",
-          "ct": "2K`#dk_IK!7`582",
+          "msg": ")1eCrd5gV!vi&Qp",
+          "ct": "2K`#dk:IK!7`582",
           "result": "valid"
         },
         {
@@ -12707,8 +12707,8 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": "+lZ3d$!<>HS_Knt",
-          "ct": "u2ZC6<box)P*6W&",
+          "msg": "+lZ3d$!<>HS:Kns",
+          "ct": "v2ZC6<box)P*6W&",
           "result": "valid"
         },
         {
@@ -12719,7 +12719,7 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": "iacdz_KH&NSY<Pf",
+          "msg": "iacdz:KH&NSY<Pf",
           "ct": "000000000000000",
           "result": "valid"
         },
@@ -12731,7 +12731,7 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": "Mh;JpB+v|E4V=|p",
+          "msg": "Mh;JpB+w|E4V=|p",
           "ct": "~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -12744,7 +12744,7 @@
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
           "msg": "bCKLgqeKIqQ?}kS",
-          "ct": "kt_1|+G+Km`|zx8",
+          "ct": "ks:1|+G+Km`|zx8",
           "result": "valid"
         },
         {
@@ -12755,8 +12755,8 @@
           ],
           "key": "43ab05932af579c659d6070b3378f5fa29ec02a71944c442",
           "tweak": "19c77fee40ebf48e",
-          "msg": "P{Q=^KR+KtZ1A+d",
-          "ct": "kt_1|+F+Km`|zx7",
+          "msg": "P{Q=^KR+KuZ1A+d",
+          "ct": "ks:1|+F+Km`|zx7",
           "result": "valid"
         },
         {
@@ -12768,7 +12768,7 @@
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "ba6405bef9d82812",
           "msg": "cT<iFiK*?|m$>@d",
-          "ct": "&|mC_<8?*{K4&K6",
+          "ct": "&|mC:<8?*{K4&K6",
           "result": "valid"
         },
         {
@@ -12780,7 +12780,7 @@
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "ba6405bef9d82812",
           "msg": "@nQ+&SZk5+C)Iz4",
-          "ct": "Pj?=t0y%L%nn3cM",
+          "ct": "Pj?=u0y%L%nn3cM",
           "result": "valid"
         },
         {
@@ -12803,7 +12803,7 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "ba6405bef9d82812",
-          "msg": "`_!PNpaN~sM#W8M",
+          "msg": "`_!PNpaN~tM#W8M",
           "ct": "?iK#>FP0F)B`+UB",
           "result": "valid"
         },
@@ -12839,7 +12839,7 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "165eeff9ac7a5bf9",
-          "msg": "NQly<tt^n^yU9J?",
+          "msg": "NQly<us^n^yU9J?",
           "ct": "OQ=@hrAE&TN<66(",
           "result": "valid"
         },
@@ -12851,8 +12851,8 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "165eeff9ac7a5bf9",
-          "msg": "qopkW0Vs6T5flf4",
-          "ct": "Cb&;o@t%}0UG|E+",
+          "msg": "qopkW0Vt6T5flf4",
+          "ct": "Cb&;o@s%}0UG|E+",
           "result": "valid"
         },
         {
@@ -12875,8 +12875,8 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "98e219cc22c58bc3",
-          "msg": "8b@=T}KG;t(9VKx",
-          "ct": "~yfoU1OT5dRsr)q",
+          "msg": "8b@=T}KG;u(9VKx",
+          "ct": "~yfoU1OT5dRtr)q",
           "result": "valid"
         },
         {
@@ -12899,8 +12899,8 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "98e219cc22c58bc3",
-          "msg": "i~Y_C6Odn9`$k+h",
-          "ct": "B0hTE618^SuA^<M",
+          "msg": "i~Y:C6Odn9`$k+h",
+          "ct": "B0hTE618^SvA^<M",
           "result": "valid"
         },
         {
@@ -12911,8 +12911,8 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "98e219cc22c58bc3",
-          "msg": "~@BS+K_(^$5_rv_",
-          "ct": "GJ!t(2%@|8c;{$$",
+          "msg": "~@BS+K:(^$5:rw_",
+          "ct": "GJ!s(2%@|8c;{$$",
           "result": "valid"
         },
         {
@@ -12923,8 +12923,8 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "98e219cc22c58bc3",
-          "msg": "g!7n(b?2|vf5GS^",
-          "ct": "+|Hg;p<lkYvVzNP",
+          "msg": "g!7n(b?2|wf5GS^",
+          "ct": "+|Hg;p<lkYwVzNP",
           "result": "valid"
         },
         {
@@ -12935,8 +12935,8 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "98e219cc22c58bc3",
-          "msg": "lr3UGq%i<jo_UzR",
-          "ct": "=6XCoWybaOQdsxr",
+          "msg": "lr3UGq%i<jo:UzR",
+          "ct": "=6XCoWybaOQdtxr",
           "result": "valid"
         },
         {
@@ -12948,7 +12948,7 @@
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "2ec2d51f781c629c",
           "msg": "a=T?WgDD{0cd)6q",
-          "ct": "#uIHBbc`(`(HtB)",
+          "ct": "#vIHBbc`(`(HuB)",
           "result": "valid"
         },
         {
@@ -12972,7 +12972,7 @@
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "2ec2d51f781c629c",
           "msg": ">~m^mBL%_8<7^&f",
-          "ct": "ihqO*0X$6tbInpJ",
+          "ct": "ihqO*0X$6ubInpJ",
           "result": "valid"
         },
         {
@@ -12983,7 +12983,7 @@
           ],
           "key": "3ca92a1143c2b711b30aa46ca8bf730caefa2d20dd755c5d",
           "tweak": "2ec2d51f781c629c",
-          "msg": "uv_nnOv1e*KHUQn",
+          "msg": "vw_nnOw1e*KHUQn",
           "ct": "3Rg;a{{#d4n*zd8",
           "result": "valid"
         },
@@ -12995,8 +12995,8 @@
           ],
           "key": "537f91a1404831c02aff71525895c914be0f0b626b189c2c",
           "tweak": "ba017ceaf04a7470",
-          "msg": ":xe7QJ|G&5$3?fg",
-          "ct": "#NFIOt>8DJa@oPd",
+          "msg": "-xe7QJ|G&5$3?fg",
+          "ct": "#NFIOs>8DJa@oPd",
           "result": "invalid"
         },
         {
@@ -13007,8 +13007,8 @@
           ],
           "key": "537f91a1404831c02aff71525895c914be0f0b626b189c2c",
           "tweak": "ba017ceaf04a7470",
-          "msg": "9xe7Q[|G&5$3?fg",
-          "ct": "_AK<ykq2rRmX!G|",
+          "msg": "9xe7Q-|G&5$3?fg",
+          "ct": ":AK<ykq2rRmX!G|",
           "result": "invalid"
         },
         {
@@ -13019,8 +13019,8 @@
           ],
           "key": "537f91a1404831c02aff71525895c914be0f0b626b189c2c",
           "tweak": "ba017ceaf04a7470",
-          "msg": "9xe7QJ|G&5$3?f.",
-          "ct": "aR5!}?)+P(ur<VN",
+          "msg": "9xe7QJ|G&5$3?f-",
+          "ct": "aR5!}?)+P(vr<VN",
           "result": "invalid"
         },
         {
@@ -13031,8 +13031,8 @@
           ],
           "key": "34529c33750e7dd679eeda39b4699c1f46f1d7f9c38c37f0",
           "tweak": "8f3f07649e14c582",
-          "msg": "\u007fNoT!S&(FFNT@_V",
-          "ct": "Kl4Rz_2kFr`6zmq",
+          "msg": "-NoT!S&(FFNT@_V",
+          "ct": "Kl4Rz:2kFr`6zmq",
           "result": "invalid"
         },
         {
@@ -13043,8 +13043,8 @@
           ],
           "key": "34529c33750e7dd679eeda39b4699c1f46f1d7f9c38c37f0",
           "tweak": "8f3f07649e14c582",
-          "msg": "aNoT!\u007f&(FFNT@_V",
-          "ct": "TNGPiuDek5tn~Lp",
+          "msg": "aNoT!-&(FFNT@_V",
+          "ct": "TNGPivDek5un~Lp",
           "result": "invalid"
         },
         {
@@ -13055,14 +13055,14 @@
           ],
           "key": "34529c33750e7dd679eeda39b4699c1f46f1d7f9c38c37f0",
           "tweak": "8f3f07649e14c582",
-          "msg": "aNoT!S&(FFNT@_\u007f",
-          "ct": "buaPptM=A&{=UEk",
+          "msg": "aNoT!S&(FFNT@_-",
+          "ct": "bvaPpsM=A&{=UEk",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 16,
       "radix": 85,
@@ -13076,8 +13076,8 @@
           ],
           "key": "28d8da67806410e5565bcc5a9d7ab9fb357413fa0158378c",
           "tweak": "63ff6d96b7960f8a",
-          "msg": "_#s37B!b`}%BtTxt",
-          "ct": "o9?SnxE@<+5Y7xv_",
+          "msg": "_#t37B!b`}%BuTxs",
+          "ct": "o9?SnxE@<+5Y7xw_",
           "result": "valid"
         },
         {
@@ -13089,7 +13089,7 @@
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
           "msg": "0000000000000000",
-          "ct": "z2NtRrq_@To_l2Vk",
+          "ct": "z2NuRrq:@To_l2Vk",
           "result": "valid"
         },
         {
@@ -13101,7 +13101,7 @@
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
           "msg": "~~~~~~~~~~~~~~~~",
-          "ct": "s|8TPdZ7rUrUkOnZ",
+          "ct": "t|8TPdZ7rUrUkOnZ",
           "result": "valid"
         },
         {
@@ -13113,7 +13113,7 @@
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
           "msg": "+Km`|zx8+Km`|zx8",
-          "ct": "MhtoIb@J%Kmp&D1}",
+          "ct": "MhsoIb@J%Kmp&D1}",
           "result": "valid"
         },
         {
@@ -13136,8 +13136,8 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "~I0BCs^?+XMgtpij",
-          "ct": "!<5BAsMT?yl`5@dK",
+          "msg": "~I0BCt^?+XMgupij",
+          "ct": "!<5BAtMT?yl`5@dK",
           "result": "valid"
         },
         {
@@ -13148,8 +13148,8 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "B?g<^u0mcIR>Ind7",
-          "ct": "_VyUET6$e3Rqnhtt",
+          "msg": "B?g<^v0mcIR>Ind7",
+          "ct": ":VyUET6$e3Rqnhss",
           "result": "valid"
         },
         {
@@ -13160,8 +13160,8 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "d7;|JER*7urt52z(",
-          "ct": "P4?tBgsVg8S1nndi",
+          "msg": "d7;|JER*7vrs52z(",
+          "ct": "P4?sBgtVg8S1nndi",
           "result": "valid"
         },
         {
@@ -13172,8 +13172,8 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "_{>y=9TnY(UAlW!s",
-          "ct": "E_P~j6Zgu}Ispeq@",
+          "msg": ":{>y=9TnY(UAlW!t",
+          "ct": "E_P~j6Zgv}Itpeq@",
           "result": "valid"
         },
         {
@@ -13184,7 +13184,7 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "9(Y(Su^D?13%J}f6",
+          "msg": "9(Y(Sv^D?13%J}f6",
           "ct": "5e*9Kj4b2$Q>QMND",
           "result": "valid"
         },
@@ -13196,8 +13196,8 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "vxViun5}lTc0%EHP",
-          "ct": "N?S)ntDZN?P)P<%h",
+          "msg": "wxVivn5}lTc0%EHP",
+          "ct": "N?S)nsDZN?P)P<%h",
           "result": "valid"
         },
         {
@@ -13208,8 +13208,8 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "Jsa~N<7vfz=^A#q<",
-          "ct": "V|dEa0_NGp04i>u@",
+          "msg": "Jta~N<7wfz=^A#q<",
+          "ct": "V|dEa0_NGp04i>v@",
           "result": "valid"
         },
         {
@@ -13232,7 +13232,7 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "tGH9Cte5N7jnl@g<",
+          "msg": "uGH9Cse5N7jnl@g<",
           "ct": "0000000000000000",
           "result": "valid"
         },
@@ -13244,7 +13244,7 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "ELW^WC%69X@$vNWX",
+          "msg": "ELW^WC%69X@$wNWX",
           "ct": "~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -13256,7 +13256,7 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "sN}5x^({8KNTjkVa",
+          "msg": "tN}5x^({8KNTjkVa",
           "ct": "+Km`|zx8+Km`|zx8",
           "result": "valid"
         },
@@ -13268,7 +13268,7 @@
           ],
           "key": "2bb7e01d6ad98bb2457d16a95fe117731f3c2bf0f4ab1c36",
           "tweak": "9fe4a8c4cc889cfa",
-          "msg": "x>?rT?4_xau+qosc",
+          "msg": "x>?rT?4:xav+qotc",
           "ct": "+Km`|zx7+Km`|zx7",
           "result": "valid"
         },
@@ -13281,7 +13281,7 @@
           "key": "b05b4d0496ec1b3501c2a0136db871974cebb1f70cc5b2b1",
           "tweak": "fa6a148b86f749ab",
           "msg": "hP!qq*Zk00000000",
-          "ct": "q;8ttNyeDkX@j*pF",
+          "ct": "q;8ssNyeDkX@j*pF",
           "result": "valid"
         },
         {
@@ -13304,8 +13304,8 @@
           ],
           "key": "b05b4d0496ec1b3501c2a0136db871974cebb1f70cc5b2b1",
           "tweak": "fa6a148b86f749ab",
-          "msg": "h>IAuB}e+Km`|zx8",
-          "ct": "`JNUvuUII_XjoTnE",
+          "msg": "h>IAvB}e+Km`|zx8",
+          "ct": "`JNUwvUII_XjoTnE",
           "result": "valid"
         },
         {
@@ -13328,8 +13328,8 @@
           ],
           "key": "b05b4d0496ec1b3501c2a0136db871974cebb1f70cc5b2b1",
           "tweak": "5e0904ec2ab3a5e0",
-          "msg": "P1g$9rMos#}Xn`S>",
-          "ct": "Z&Lc7Y8Lu}3<C`yE",
+          "msg": "P1g$9rMot#}Xn`S>",
+          "ct": "Z&Lc7Y8Lv}3<C`yE",
           "result": "valid"
         },
         {
@@ -13340,8 +13340,8 @@
           ],
           "key": "b05b4d0496ec1b3501c2a0136db871974cebb1f70cc5b2b1",
           "tweak": "5e0904ec2ab3a5e0",
-          "msg": "lTXygfAS_TtVNuTc",
-          "ct": "3gX_2g?)!yx!L<N2",
+          "msg": "lTXygfAS:TsVNvTc",
+          "ct": "3gX:2g?)!yx!L<N2",
           "result": "valid"
         },
         {
@@ -13352,8 +13352,8 @@
           ],
           "key": "b05b4d0496ec1b3501c2a0136db871974cebb1f70cc5b2b1",
           "tweak": "5e0904ec2ab3a5e0",
-          "msg": "F0WDUt=vd%qA#qm#",
-          "ct": "nJLe7nF)o>rTt!7B",
+          "msg": "F0WDUs=wd%qA#qm#",
+          "ct": "nJLe7nF)o>rTu!7B",
           "result": "valid"
         },
         {
@@ -13364,8 +13364,8 @@
           ],
           "key": "b05b4d0496ec1b3501c2a0136db871974cebb1f70cc5b2b1",
           "tweak": "5e0904ec2ab3a5e0",
-          "msg": "s8`RTE3y#ee>TUJF",
-          "ct": "pIu=aJSEcYe>3Yx!",
+          "msg": "t8`RTE3y#ee>TUJF",
+          "ct": "pIv=aJSEcYe>3Yx!",
           "result": "valid"
         },
         {
@@ -13377,7 +13377,7 @@
           "key": "b05b4d0496ec1b3501c2a0136db871974cebb1f70cc5b2b1",
           "tweak": "5e0904ec2ab3a5e0",
           "msg": ")CI+&x_drr<*BYWO",
-          "ct": "vcxuLom7Zy3P<7Ih",
+          "ct": "wcxvLom7Zy3P<7Ih",
           "result": "valid"
         },
         {
@@ -13388,8 +13388,8 @@
           ],
           "key": "b05b4d0496ec1b3501c2a0136db871974cebb1f70cc5b2b1",
           "tweak": "5e0904ec2ab3a5e0",
-          "msg": "%$jx%_+V4r#nQUF7",
-          "ct": "}@F;7tB^M9AJjcl~",
+          "msg": "%$jx%:+V4r#nQUF7",
+          "ct": "}@F;7uB^M9AJjcl~",
           "result": "valid"
         },
         {
@@ -13400,8 +13400,8 @@
           ],
           "key": "771592477eb1f2cbafd80567f2adaf6625618f2b9c161cb6",
           "tweak": "81c9e9d9fc6bb6db",
-          "msg": "\\veXtiaD{a!lG9O8",
-          "ct": "Qj<|S$xtASZyelKH",
+          "msg": "-weXuiaD{a!lG9O8",
+          "ct": "Qj<|S$xuASZyelKH",
           "result": "invalid"
         },
         {
@@ -13412,8 +13412,8 @@
           ],
           "key": "771592477eb1f2cbafd80567f2adaf6625618f2b9c161cb6",
           "tweak": "81c9e9d9fc6bb6db",
-          "msg": "jveXt-aD{a!lG9O8",
-          "ct": "uWPo_kj0eZq~su4q",
+          "msg": "jweXu-aD{a!lG9O8",
+          "ct": "vWPo_kj0eZq~tv4q",
           "result": "invalid"
         },
         {
@@ -13424,8 +13424,8 @@
           ],
           "key": "771592477eb1f2cbafd80567f2adaf6625618f2b9c161cb6",
           "tweak": "81c9e9d9fc6bb6db",
-          "msg": "jveXtiaD{a!lG9O/",
-          "ct": ";FEsF0=Z_5?<O@|B",
+          "msg": "jweXuiaD{a!lG9O-",
+          "ct": ";FEtF0=Z_5?<O@|B",
           "result": "invalid"
         },
         {
@@ -13436,8 +13436,8 @@
           ],
           "key": "6cac9aabfcbc0da807fb366ac243fc6f27e18399b923c7d4",
           "tweak": "c77433eef983d9c1",
-          "msg": "\u007fI$>fX@WuVV(n96%",
-          "ct": "t=;4S7XW6@f+f3lp",
+          "msg": "-I$>fX@WvVV(n96%",
+          "ct": "u=;4S7XW6@f+f3lp",
           "result": "invalid"
         },
         {
@@ -13448,7 +13448,7 @@
           ],
           "key": "6cac9aabfcbc0da807fb366ac243fc6f27e18399b923c7d4",
           "tweak": "c77433eef983d9c1",
-          "msg": "aI$>f\u007f@WuVV(n96%",
+          "msg": "aI$>f-@WvVV(n96%",
           "ct": "xkHMi%xm6``SxZjq",
           "result": "invalid"
         },
@@ -13460,14 +13460,14 @@
           ],
           "key": "6cac9aabfcbc0da807fb366ac243fc6f27e18399b923c7d4",
           "tweak": "c77433eef983d9c1",
-          "msg": "aI$>fX@WuVV(n96\u007f",
-          "ct": "{CRB}qUxh_++o*8_",
+          "msg": "aI$>fX@WvVV(n96-",
+          "ct": "{CRB}qUxh_++o*8:",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 17,
       "radix": 85,
@@ -13481,8 +13481,8 @@
           ],
           "key": "f620ff36bcd7f62b38ee8dc91b2a1d1ac5645e4c31432921",
           "tweak": "fedb3a07315c4484",
-          "msg": "B(Q01xc#`3gbsI)7Z",
-          "ct": "%1UkgJ)F}9#tVSQCK",
+          "msg": "B(Q01xc#`3gbtI)7Z",
+          "ct": "%1UkgJ)F}9#sVSQCK",
           "result": "valid"
         },
         {
@@ -13494,7 +13494,7 @@
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
           "msg": "00000000000000000",
-          "ct": "PI4CB?bT>jia{pdt?",
+          "ct": "PI4CB?bT>jia{pdu?",
           "result": "valid"
         },
         {
@@ -13506,7 +13506,7 @@
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
           "msg": "~~~~~~~~~~~~~~~~~",
-          "ct": "ZhhLo4I;_CGa0;Z&d",
+          "ct": "ZhhLo4I;:CGa0;Z&d",
           "result": "valid"
         },
         {
@@ -13530,7 +13530,7 @@
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
           "msg": "+Km`|zx7q>f;|Ocg1",
-          "ct": "i{PC5GaK(v?i0=ikr",
+          "ct": "i{PC5GaK(w?i0=ikr",
           "result": "valid"
         },
         {
@@ -13541,8 +13541,8 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "mc%I}y0hH6M6%?t`C",
-          "ct": "1J}GrABNu){l_M^8B",
+          "msg": "mc%I}y0hH6M6%?s`C",
+          "ct": "1J}GrABNv){l:M^8B",
           "result": "valid"
         },
         {
@@ -13553,8 +13553,8 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "9FCcoPStP%)+?rAIT",
-          "ct": "9HcA~P!QA0_hJ%Euy",
+          "msg": "9FCcoPSuP%)+?rAIT",
+          "ct": "9HcA~P!QA0_hJ%Evy",
           "result": "valid"
         },
         {
@@ -13565,8 +13565,8 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "_t9>~v~68Jp1g!~?@",
-          "ct": "eQ@^a|yDUJyuIWJs2",
+          "msg": ":s9>~w~68Jp1g!~?@",
+          "ct": "eQ@^a|yDUJyvIWJt2",
           "result": "valid"
         },
         {
@@ -13577,7 +13577,7 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "MZlF3J_T69iftc{2p",
+          "msg": "MZlF3J_T69ifsc{2p",
           "ct": "BEA8p`Pc@0`h?b)+b",
           "result": "valid"
         },
@@ -13589,7 +13589,7 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "?2VjbMj~6MMhPU_vV",
+          "msg": "?2VjbMj~6MMhPU_wV",
           "ct": "$7&z*X;0Sp3fnM%C}",
           "result": "valid"
         },
@@ -13601,7 +13601,7 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "eh=#vYlY>scI?o^I;",
+          "msg": "eh=#wYlY>tcI?o^I;",
           "ct": "yoK4$YaZC`UyDFdMW",
           "result": "valid"
         },
@@ -13613,8 +13613,8 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "{ut*QMP@Fs1$in~pV",
-          "ct": "ZhZ!05okI8_B4JNqT",
+          "msg": "{vu*QMP@Ft1$in~pV",
+          "ct": "ZhZ!05okI8:B4JNqT",
           "result": "valid"
         },
         {
@@ -13625,8 +13625,8 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "(#3ZZ6Az_~7<t0b#c",
-          "ct": "5M38ck}Z`Yu3#x5_6",
+          "msg": "(#3ZZ6Az_~7<u0b#c",
+          "ct": "5M38ck}Z`Yv3#x5:6",
           "result": "valid"
         },
         {
@@ -13637,7 +13637,7 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "SodtPltLgmhA<<Wbt",
+          "msg": "SodsPlsLgmhA<<Wbs",
           "ct": "00000000000000000",
           "result": "valid"
         },
@@ -13649,7 +13649,7 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "Cvrkj;NyfU>~4FLN{",
+          "msg": "Cwrkj;NyfU>~4FLN{",
           "ct": "~~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -13661,7 +13661,7 @@
           ],
           "key": "de9df32f9a861ddcae277ddad3061ffce4f43582604996e0",
           "tweak": "13d480958d51fab5",
-          "msg": "U@v`0N<=)z5X7xe;E",
+          "msg": "U@w`0N<=)z5X7xe;E",
           "ct": "+Km`|zx8q>f;|Ocg2",
           "result": "valid"
         },
@@ -13685,7 +13685,7 @@
           ],
           "key": "c3b02d8febc431681dab0a13b1e082a0891e62ae573ee2b2",
           "tweak": "29fd6d311d3da4",
-          "msg": "K|JX)!z&_H#x?We2H",
+          "msg": "K|JX)!z&:H#x?We2H",
           "ct": "00000000Wh;MhlSm`",
           "result": "valid"
         },
@@ -13710,7 +13710,7 @@
           "key": "c3b02d8febc431681dab0a13b1e082a0891e62ae573ee2b2",
           "tweak": "29fd6d311d3da4",
           "msg": "h4g#ASVxd#MAP<U^$",
-          "ct": "+Km`|zx8&u{d1+H@_",
+          "ct": "+Km`|zx8&v{d1+H@:",
           "result": "valid"
         },
         {
@@ -13733,7 +13733,7 @@
           ],
           "key": "c3b02d8febc431681dab0a13b1e082a0891e62ae573ee2b2",
           "tweak": "9457ecd4aa2b46",
-          "msg": "O|$P7@O4sKqR$P`cr",
+          "msg": "O|$P7@O4tKqR$P`cr",
           "ct": "p)F#>UJ7P7yTdPQy$",
           "result": "valid"
         },
@@ -13745,8 +13745,8 @@
           ],
           "key": "c3b02d8febc431681dab0a13b1e082a0891e62ae573ee2b2",
           "tweak": "9457ecd4aa2b46",
-          "msg": "!~&VE186X2=Q=LtP2",
-          "ct": "1csT*fJr_FC7Eg?MH",
+          "msg": "!~&VE186X2=Q=LuP2",
+          "ct": "1ctT*fJr:FC7Eg?MH",
           "result": "valid"
         },
         {
@@ -13757,8 +13757,8 @@
           ],
           "key": "c3b02d8febc431681dab0a13b1e082a0891e62ae573ee2b2",
           "tweak": "9457ecd4aa2b46",
-          "msg": "CK6Z0Ps||}PF07p!m",
-          "ct": ";vL4`LN3Cn55tu_e%",
+          "msg": "CK6Z0Pt||}PF07p!m",
+          "ct": ";wL4`LN3Cn55uv_e%",
           "result": "valid"
         },
         {
@@ -13781,8 +13781,8 @@
           ],
           "key": "c3b02d8febc431681dab0a13b1e082a0891e62ae573ee2b2",
           "tweak": "9457ecd4aa2b46",
-          "msg": ">(lVy9VMzT6t5qYNs",
-          "ct": "k;<(tp4t3{I>usQ77",
+          "msg": ">(lVy9VMzT6u5qYNt",
+          "ct": "k;<(up4u3{I>vtQ77",
           "result": "valid"
         },
         {
@@ -13794,7 +13794,7 @@
           "key": "c3b02d8febc431681dab0a13b1e082a0891e62ae573ee2b2",
           "tweak": "9457ecd4aa2b46",
           "msg": "2g(*8;QUBAO~<CF+k",
-          "ct": "nN;4nfl|UqPfL!u`{",
+          "ct": "nN;4nfl|UqPfL!v`{",
           "result": "valid"
         },
         {
@@ -13805,8 +13805,8 @@
           ],
           "key": "3cef98a039613df2af2eb3c602a98dace8ce3b905959b872",
           "tweak": "0284255ddf9a1021",
-          "msg": "\\hH=);=Vz<^YE_yVL",
-          "ct": "_qc=&>`lLAl_(#^ac",
+          "msg": "-hH=);=Vz<^YE_yVL",
+          "ct": "_qc=&>`lLAl:(#^ac",
           "result": "invalid"
         },
         {
@@ -13829,8 +13829,8 @@
           ],
           "key": "3cef98a039613df2af2eb3c602a98dace8ce3b905959b872",
           "tweak": "0284255ddf9a1021",
-          "msg": ">hH=);=Vz<^YE_yV:",
-          "ct": "m^p8*<>Nuv6g|q6kj",
+          "msg": ">hH=);=Vz<^YE_yV-",
+          "ct": "m^p8*<>Nvw6g|q6kj",
           "result": "invalid"
         },
         {
@@ -13841,8 +13841,8 @@
           ],
           "key": "574427a307818e9d1d06a18b6cd389a947d3822b73d1476e",
           "tweak": "0b97e0d7c0d522d4",
-          "msg": "\u007fEA^?}_4LoH?@yN!^",
-          "ct": "@ttS*(P57}^Bq@dv)",
+          "msg": "-EA^?}:4LoH?@yN!^",
+          "ct": "@ssS*(P57}^Bq@dw)",
           "result": "invalid"
         },
         {
@@ -13853,8 +13853,8 @@
           ],
           "key": "574427a307818e9d1d06a18b6cd389a947d3822b73d1476e",
           "tweak": "0b97e0d7c0d522d4",
-          "msg": "9EA^?\u007f_4LoH?@yN!^",
-          "ct": "ln$xb+OUav9rlp)SO",
+          "msg": "9EA^?-:4LoH?@yN!^",
+          "ct": "ln$xb+OUaw9rlp)SO",
           "result": "invalid"
         },
         {
@@ -13865,14 +13865,14 @@
           ],
           "key": "574427a307818e9d1d06a18b6cd389a947d3822b73d1476e",
           "tweak": "0b97e0d7c0d522d4",
-          "msg": "9EA^?}_4LoH?@yN!\u007f",
-          "ct": "Lilv0_R)4z<(NaL|z",
+          "msg": "9EA^?}:4LoH?@yN!-",
+          "ct": "Lilw0:R)4z<(NaL|z",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 18,
       "radix": 85,
@@ -13886,7 +13886,7 @@
           ],
           "key": "47eb4430ea1cb545acc8f09ada1ecc8574d394b5a20e5017",
           "tweak": "683baf80b9d31daa",
-          "msg": "?Q+(8SEYrBKk7qvJa2",
+          "msg": "?Q+(8SEYrBKk7qwJa2",
           "ct": "xhUFlqQZTUf;~zZf&1",
           "result": "valid"
         },
@@ -13923,7 +13923,7 @@
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
           "msg": "q>f;|Ocg2q>f;|Ocg2",
-          "ct": "~AktbSNqBDWT`j2qzY",
+          "ct": "~AksbSNqBDWT`j2qzY",
           "result": "valid"
         },
         {
@@ -13935,7 +13935,7 @@
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
           "msg": "q>f;|Ocg1q>f;|Ocg1",
-          "ct": "uU3e#_17|)m<834#Hf",
+          "ct": "vU3e#:17|)m<834#Hf",
           "result": "valid"
         },
         {
@@ -13946,7 +13946,7 @@
           ],
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
-          "msg": "4Fpd%P3YS@v9o1<)?7",
+          "msg": "4Fpd%P3YS@w9o1<)?7",
           "ct": "IAVHPW51^FT}klB_|M",
           "result": "valid"
         },
@@ -13959,7 +13959,7 @@
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
           "msg": "(MZL$Q&i)qNq5}AY4B",
-          "ct": "l23(Y=V{GHt{ZWE9tR",
+          "ct": "l23(Y=V{GHs{ZWE9sR",
           "result": "valid"
         },
         {
@@ -13970,7 +13970,7 @@
           ],
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
-          "msg": "j@0!m2trWPVR_t;<r^",
+          "msg": "j@0!m2srWPVR:s;<r^",
           "ct": "L&$(Ta{FhSfglHXEfX",
           "result": "valid"
         },
@@ -13983,7 +13983,7 @@
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
           "msg": "$l@y(f3n*?#!AhRk>6",
-          "ct": "{OBtu(rZoi}Vq+HPTz",
+          "ct": "{OBsv(rZoi}Vq+HPTz",
           "result": "valid"
         },
         {
@@ -13994,8 +13994,8 @@
           ],
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
-          "msg": "?W{4Foopv6#U9Gf$vg",
-          "ct": "n<DjX@=jsD4R;s;^Zy",
+          "msg": "?W{4Foopw6#U9Gf$wg",
+          "ct": "n<DjX@=jtD4R;t;^Zy",
           "result": "valid"
         },
         {
@@ -14006,8 +14006,8 @@
           ],
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
-          "msg": "hp0|7u~maD~4>nxTo|",
-          "ct": "N3zo;*>O05YubbO2We",
+          "msg": "hp0|7v~maD~4>nxTo|",
+          "ct": "N3zo;*>O05YvbbO2We",
           "result": "valid"
         },
         {
@@ -14018,8 +14018,8 @@
           ],
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
-          "msg": "F{HGGPY)ANz|(f_Zz$",
-          "ct": "R_$5U0(ib%k7y?XJ3%",
+          "msg": "F{HGGPY)ANz|(f:Zz$",
+          "ct": "R:$5U0(ib%k7y?XJ3%",
           "result": "valid"
         },
         {
@@ -14030,8 +14030,8 @@
           ],
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
-          "msg": "uX=y}7?9Bzx)*NGP*E",
-          "ct": "zg}mb}u=gk|@h%z5X(",
+          "msg": "vX=y}7?9Bzx)*NGP*E",
+          "ct": "zg}mb}v=gk|@h%z5X(",
           "result": "valid"
         },
         {
@@ -14042,7 +14042,7 @@
           ],
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
-          "msg": "(0t+;f=;TviH|WF=u2",
+          "msg": "(0s+;f=;TwiH|WF=v2",
           "ct": "000000000000000000",
           "result": "valid"
         },
@@ -14078,7 +14078,7 @@
           ],
           "key": "1d950d20d93140a7d5fa11ba5925c80dfed1cf97e4627f6d",
           "tweak": "8ef1d4315ed3c68f",
-          "msg": "G0yFEoV1X8avfzBRit",
+          "msg": "G0yFEoV1X8awfzBRis",
           "ct": "q>f;|Ocg1q>f;|Ocg1",
           "result": "valid"
         },
@@ -14090,8 +14090,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "d98f7275fddc7e",
-          "msg": "i8OBsp77)%QPCuD_~C",
-          "ct": "D5>Etp|@I*NCdvWUVC",
+          "msg": "i8OBtp77)%QPCvD_~C",
+          "ct": "D5>Eup|@I*NCdwWUVC",
           "result": "valid"
         },
         {
@@ -14102,8 +14102,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "d98f7275fddc7e",
-          "msg": "XsJmBRRbOL%a*{0>0P",
-          "ct": "Yepb8yI|QvDr>mQNM2",
+          "msg": "XtJmBRRbOL%a*{0>0P",
+          "ct": "Yepb8yI|QwDr>mQNM2",
           "result": "valid"
         },
         {
@@ -14114,8 +14114,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "d98f7275fddc7e",
-          "msg": "t<;>p{25WjI;7v!avv",
-          "ct": "#vi$m@YTJIpOIu`m9q",
+          "msg": "s<;>p{25WjI;7w!aww",
+          "ct": "#wi$m@YTJIpOIv`m9q",
           "result": "valid"
         },
         {
@@ -14126,8 +14126,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "d98f7275fddc7e",
-          "msg": "gPtN_+(>d_)lxjXEr`",
-          "ct": "1@O3TuZlVLkPJ~t8U@",
+          "msg": "gPsN_+(>d:)lxjXEr`",
+          "ct": "1@O3TvZlVLkPJ~s8U@",
           "result": "valid"
         },
         {
@@ -14138,8 +14138,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "37eef3910d889a",
-          "msg": "a2`u`Ant}`%z@QuB+e",
-          "ct": "|yhZuu@{(1KU#i{~a0",
+          "msg": "a2`v`Anu}`%z@QvB+e",
+          "ct": "|yhZvv@{(1KU#i{~a0",
           "result": "valid"
         },
         {
@@ -14151,7 +14151,7 @@
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "37eef3910d889a",
           "msg": "8eFhfC?4rFCF458!Np",
-          "ct": "|yhZuu@{(1KU#i{~a1",
+          "ct": "|yhZvv@{(1KU#i{~a1",
           "result": "valid"
         },
         {
@@ -14162,8 +14162,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "37eef3910d889a",
-          "msg": "UpfVP$fa1a%uzZ~|C2",
-          "ct": "|yhZuu@{(tA;pgLb^2",
+          "msg": "UpfVP$fa1a%vzZ~|C2",
+          "ct": "|yhZvv@{(sA;pgLb^2",
           "result": "valid"
         },
         {
@@ -14175,7 +14175,7 @@
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "37eef3910d889a",
           "msg": "Oor8=MPl`2qClkn*gT",
-          "ct": "|yhZuu@{(~~~~~~~~~",
+          "ct": "|yhZvv@{(~~~~~~~~~",
           "result": "valid"
         },
         {
@@ -14186,8 +14186,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "37eef3910d889a",
-          "msg": "i8SYA2Hx!Qy26tha&D",
-          "ct": "|yhZuu@{(000000000",
+          "msg": "i8SYA2Hx!Qy26sha&D",
+          "ct": "|yhZvv@{(000000000",
           "result": "valid"
         },
         {
@@ -14198,8 +14198,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "37eef3910d889a",
-          "msg": "?_2OZ2$Ipe<tM~Q~$^",
-          "ct": "|yhZuu@{(1KU#i{~Z~",
+          "msg": "?:2OZ2$Ipe<uM~Q~$^",
+          "ct": "|yhZvv@{(1KU#i{~Z~",
           "result": "valid"
         },
         {
@@ -14222,8 +14222,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "688335089539e4",
-          "msg": "&Q)xQyti=AtWjKtGfm",
-          "ct": "<vb$*x#st)7(Ju^T*C",
+          "msg": "&Q)xQysi=AsWjKuGfm",
+          "ct": "<wb$*x#ts)7(Jv^T*C",
           "result": "valid"
         },
         {
@@ -14234,8 +14234,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "688335089539e4",
-          "msg": "X2a91t=h`|b#mIvs~i",
-          "ct": "Pc?c_f>kF3v_dcNJ=`",
+          "msg": "X2a91s=h`|b#mIwt~i",
+          "ct": "Pc?c_f>kF3w_dcNJ=`",
           "result": "valid"
         },
         {
@@ -14246,8 +14246,8 @@
           ],
           "key": "22a428a12b3e0997d57269dd636522a55205836e84c76bb6",
           "tweak": "688335089539e4",
-          "msg": "m3)Oaj$@|aQ*v;u)6#",
-          "ct": "kFTN@(_B0^XnhAzN8L",
+          "msg": "m3)Oaj$@|aQ*w;v)6#",
+          "ct": "kFTN@(:B0^XnhAzN8L",
           "result": "valid"
         },
         {
@@ -14270,8 +14270,8 @@
           ],
           "key": "7d2f8122f40d9e7abdfdc5533d00861d4c2e02b4f78f9b8f",
           "tweak": "8fb4ffb3514c5fcc",
-          "msg": "jDhknk/4JG3Q*fYzd<",
-          "ct": "tb98Fm$~YKuNf{CERF",
+          "msg": "jDhknk-4JG3Q*fYzd<",
+          "ct": "sb98Fm$~YKvNf{CERF",
           "result": "invalid"
         },
         {
@@ -14282,8 +14282,8 @@
           ],
           "key": "7d2f8122f40d9e7abdfdc5533d00861d4c2e02b4f78f9b8f",
           "tweak": "8fb4ffb3514c5fcc",
-          "msg": "jDhknk^4JG3Q*fYzd.",
-          "ct": "K_;_m96$JOAB9PZ^}L",
+          "msg": "jDhknk^4JG3Q*fYzd-",
+          "ct": "K:;_m96$JOAB9PZ^}L",
           "result": "invalid"
         },
         {
@@ -14294,8 +14294,8 @@
           ],
           "key": "12f8dfb4a41367cb1d5c277a71e9ecb966fd25d953affc33",
           "tweak": "10f09614089ca74a",
-          "msg": "\u007f?GPXi?NYM0Xmpa)pj",
-          "ct": "d0jzuW9nc+ZXi2tgZJ",
+          "msg": "-?GPXi?NYM0Xmpa)pj",
+          "ct": "d0jzvW9nc+ZXi2sgZJ",
           "result": "invalid"
         },
         {
@@ -14306,8 +14306,8 @@
           ],
           "key": "12f8dfb4a41367cb1d5c277a71e9ecb966fd25d953affc33",
           "tweak": "10f09614089ca74a",
-          "msg": "Q?GPXi\u007fNYM0Xmpa)pj",
-          "ct": "rAtSx7MMYm1Kfq%gC4",
+          "msg": "Q?GPXi-NYM0Xmpa)pj",
+          "ct": "rAsSx7MMYm1Kfq%gC4",
           "result": "invalid"
         },
         {
@@ -14318,14 +14318,14 @@
           ],
           "key": "12f8dfb4a41367cb1d5c277a71e9ecb966fd25d953affc33",
           "tweak": "10f09614089ca74a",
-          "msg": "Q?GPXi?NYM0Xmpa)p\u007f",
+          "msg": "Q?GPXi?NYM0Xmpa)p-",
           "ct": "oS@2RGC=k@zcjf3@+f",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 19,
       "radix": 85,
@@ -14339,8 +14339,8 @@
           ],
           "key": "ba47709f6c5147bb5e20ee8869b439706fef5f984862cc0d",
           "tweak": "1a8494e5274bc2df",
-          "msg": "aXkr)a5MKMCZo35vX_B",
-          "ct": "u!VFXpE1Do9I<bnj2;S",
+          "msg": "aXkr)a5MKMCZo35wX:B",
+          "ct": "v!VFXpE1Do9I<bnj2;S",
           "result": "valid"
         },
         {
@@ -14352,7 +14352,7 @@
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
           "msg": "0000000000000000000",
-          "ct": "{js`VvRPe&GIt&W~1t7",
+          "ct": "{jt`VwRPe&GIu&W~1u7",
           "result": "valid"
         },
         {
@@ -14364,7 +14364,7 @@
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
           "msg": "~~~~~~~~~~~~~~~~~~~",
-          "ct": "hilv$?g1n%SNq;U1L)H",
+          "ct": "hilw$?g1n%SNq;U1L)H",
           "result": "valid"
         },
         {
@@ -14375,8 +14375,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "q>f;|Ocg2_tv2=@*|O1",
-          "ct": "(Hd4Ddfbdf`OYVto_$}",
+          "msg": "q>f;|Ocg2_sw2=@*|O1",
+          "ct": "(Hd4Ddfbdf`OYVuo_$}",
           "result": "valid"
         },
         {
@@ -14387,8 +14387,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "q>f;|Ocg1_tv2=@*|O0",
-          "ct": "$~sjjI;(qoc;VW|uTtb",
+          "msg": "q>f;|Ocg1_sw2=@*|O0",
+          "ct": "$~tjjI;(qoc;VW|vTub",
           "result": "valid"
         },
         {
@@ -14399,8 +14399,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "rUjsj=kJl8;9yc#ik1y",
-          "ct": "rpR=SG)yl0t#VQ$t1vB",
+          "msg": "rUjtj=kJl8;9yc#ik1y",
+          "ct": "rpR=SG)yl0s#VQ$u1wB",
           "result": "valid"
         },
         {
@@ -14411,7 +14411,7 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "fZQGvBM{_VoJNeakRri",
+          "msg": "fZQGwBM{:VoJNeakRri",
           "ct": "*?PBF6%6!xlPQOo5J*$",
           "result": "valid"
         },
@@ -14423,8 +14423,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "_8mduAf>tEZ%PY;6=Zo",
-          "ct": "3oSVLtB_g)hsh$YBZO8",
+          "msg": ":8mdvAf>uEZ%PY;6=Zo",
+          "ct": "3oSVLuB:g)hth$YBZO8",
           "result": "valid"
         },
         {
@@ -14435,7 +14435,7 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "TS%1nz;GI9GLU4QgsTA",
+          "msg": "TS%1nz;GI9GLU4QgtTA",
           "ct": "n3VWf6c*BM}B?}E}f%h",
           "result": "valid"
         },
@@ -14447,8 +14447,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "`hUYcs<MQkHz1V^F3`b",
-          "ct": "tXFklq3s0;5*+(^|u=+",
+          "msg": "`hUYct<MQkHz1V^F3`b",
+          "ct": "uXFklq3t0;5*+(^|v=+",
           "result": "valid"
         },
         {
@@ -14459,8 +14459,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "S~OEs5M`g}i|*8hLrff",
-          "ct": "FGpPWuaFpkXWn~v2TR~",
+          "msg": "S~OEt5M`g}i|*8hLrff",
+          "ct": "FGpPWvaFpkXWn~w2TR~",
           "result": "valid"
         },
         {
@@ -14471,8 +14471,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "{_&}t{Y!+}H+6{>9i*1",
-          "ct": "~a_l=A6z9th?<LRIQae",
+          "msg": "{:&}u{Y!+}H+6{>9i*1",
+          "ct": "~a:l=A6z9sh?<LRIQae",
           "result": "valid"
         },
         {
@@ -14483,8 +14483,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "Cc_cM^a$UR{zS53F8I{",
-          "ct": "(ZRA=P*s}1{_V3t&y8n",
+          "msg": "Cc:cM^a$UR{zS53F8I{",
+          "ct": "(ZRA=P*t}1{:V3u&y8n",
           "result": "valid"
         },
         {
@@ -14495,7 +14495,7 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "raZC5&_QcV5}G1W*b_F",
+          "msg": "raZC5&_QcV5}G1W*b:F",
           "ct": "0000000000000000000",
           "result": "valid"
         },
@@ -14507,7 +14507,7 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "o=8#J|81;2!_@cdP_8O",
+          "msg": "o=8#J|81;2!:@cdP_8O",
           "ct": "~~~~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -14520,7 +14520,7 @@
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
           "msg": "<M&yZYHoBnNeU0cdnV1",
-          "ct": "q>f;|Ocg2_tv2=@*|O1",
+          "ct": "q>f;|Ocg2_sw2=@*|O1",
           "result": "valid"
         },
         {
@@ -14531,8 +14531,8 @@
           ],
           "key": "bb0a13e9ed20862fab51dbd134fd658cbf3a610e0100fc78",
           "tweak": "eb0ec722d32a5563",
-          "msg": "g;tYM5_n@uv~U#JAtiG",
-          "ct": "q>f;|Ocg1_tv2=@*|O0",
+          "msg": "g;uYM5:n@vw~U#JAuiG",
+          "ct": "q>f;|Ocg1_sw2=@*|O0",
           "result": "valid"
         },
         {
@@ -14543,7 +14543,7 @@
           ],
           "key": "be9a8fba5d4b186c6ccb1e78380a89a9fda592669dcb40b9",
           "tweak": "210a87007dcef98c",
-          "msg": "w+ZFM;g1)MO}~3$Lyuh",
+          "msg": "-+ZFM;g1)MO}~3$Lyvh",
           "ct": "7EW)P~2g9<)!_o;K4~m",
           "result": "invalid"
         },
@@ -14555,8 +14555,8 @@
           ],
           "key": "be9a8fba5d4b186c6ccb1e78380a89a9fda592669dcb40b9",
           "tweak": "210a87007dcef98c",
-          "msg": "7+ZFM;.1)MO}~3$Lyuh",
-          "ct": "`Wla#qb$v+6Ul!v7Qz!",
+          "msg": "7+ZFM;-1)MO}~3$Lyvh",
+          "ct": "`Wla#qb$w+6Ul!w7Qz!",
           "result": "invalid"
         },
         {
@@ -14567,7 +14567,7 @@
           ],
           "key": "be9a8fba5d4b186c6ccb1e78380a89a9fda592669dcb40b9",
           "tweak": "210a87007dcef98c",
-          "msg": "7+ZFM;g1)MO}~3$Lyuw",
+          "msg": "7+ZFM;g1)MO}~3$Lyv-",
           "ct": "!QpV7pQ`S4oJ`i+LM;k",
           "result": "invalid"
         },
@@ -14579,8 +14579,8 @@
           ],
           "key": "e43b71d32f12126623630bca40c90e69b33594f8d37ef4ad",
           "tweak": "09b665033869ab7c",
-          "msg": "\u007fru|ulS8MhU%*@jqQW+",
-          "ct": "uxFSA0g&Pi2OUpK^uW?",
+          "msg": "-rv|vlS8MhU%*@jqQW+",
+          "ct": "vxFSA0g&Pi2OUpK^vW?",
           "result": "invalid"
         },
         {
@@ -14591,7 +14591,7 @@
           ],
           "key": "e43b71d32f12126623630bca40c90e69b33594f8d37ef4ad",
           "tweak": "09b665033869ab7c",
-          "msg": "kru|ul\u007f8MhU%*@jqQW+",
+          "msg": "krv|vl-8MhU%*@jqQW+",
           "ct": "CB(cFFnrojUJ8P|7Y9z",
           "result": "invalid"
         },
@@ -14603,14 +14603,14 @@
           ],
           "key": "e43b71d32f12126623630bca40c90e69b33594f8d37ef4ad",
           "tweak": "09b665033869ab7c",
-          "msg": "kru|ulS8MhU%*@jqQW\u007f",
+          "msg": "krv|vlS8MhU%*@jqQW-",
           "ct": "ZM*?X!C>~7lMD&=SQkg",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 4,
       "radix": 85,
@@ -14721,7 +14721,7 @@
           "key": "f638a9e757d6800efdb9561250892046f45f55f0de9c48bfa01057d1c36efd82",
           "tweak": "943f8393fb6c5876",
           "msg": "8aB#",
-          "ct": "}tB6",
+          "ct": "}uB6",
           "result": "valid"
         },
         {
@@ -14733,7 +14733,7 @@
           "key": "f638a9e757d6800efdb9561250892046f45f55f0de9c48bfa01057d1c36efd82",
           "tweak": "943f8393fb6c5876",
           "msg": "`S&|",
-          "ct": "rH5t",
+          "ct": "rH5u",
           "result": "valid"
         },
         {
@@ -14769,7 +14769,7 @@
           "key": "f638a9e757d6800efdb9561250892046f45f55f0de9c48bfa01057d1c36efd82",
           "tweak": "943f8393fb6c5876",
           "msg": "TN8a",
-          "ct": "v_YO",
+          "ct": "w:YO",
           "result": "valid"
         },
         {
@@ -14792,7 +14792,7 @@
           ],
           "key": "f638a9e757d6800efdb9561250892046f45f55f0de9c48bfa01057d1c36efd82",
           "tweak": "943f8393fb6c5876",
-          "msg": "vDe+",
+          "msg": "wDe+",
           "ct": "~~~~",
           "result": "valid"
         },
@@ -14901,7 +14901,7 @@
           "key": "65f2183ef0bf03d2c5c679e7248493b2ac713d86789d3f64c30e2d3554291afd",
           "tweak": "bee6e58811945f1f2f4ca0b980",
           "msg": "Xa4J",
-          "ct": "<t!y",
+          "ct": "<s!y",
           "result": "valid"
         },
         {
@@ -14912,7 +14912,7 @@
           ],
           "key": "65f2183ef0bf03d2c5c679e7248493b2ac713d86789d3f64c30e2d3554291afd",
           "tweak": "bee6e58811945f1f2f4ca0b980",
-          "msg": "`~Xu",
+          "msg": "`~Xv",
           "ct": "Sh&c",
           "result": "valid"
         },
@@ -14937,7 +14937,7 @@
           "key": "65f2183ef0bf03d2c5c679e7248493b2ac713d86789d3f64c30e2d3554291afd",
           "tweak": "c136ac54119482c1579826da61",
           "msg": "PG!3",
-          "ct": "{VN_",
+          "ct": "{VN:",
           "result": "valid"
         },
         {
@@ -15008,8 +15008,8 @@
           ],
           "key": "65f2183ef0bf03d2c5c679e7248493b2ac713d86789d3f64c30e2d3554291afd",
           "tweak": "9f50ebe25b6273b0bacfda1fda",
-          "msg": "9*_(",
-          "ct": "ABSt",
+          "msg": "9*:(",
+          "ct": "ABSs",
           "result": "valid"
         },
         {
@@ -15021,7 +15021,7 @@
           "key": "65f2183ef0bf03d2c5c679e7248493b2ac713d86789d3f64c30e2d3554291afd",
           "tweak": "9f50ebe25b6273b0bacfda1fda",
           "msg": "Jh6V",
-          "ct": "Fs5$",
+          "ct": "Ft5$",
           "result": "valid"
         },
         {
@@ -15033,7 +15033,7 @@
           "key": "65f2183ef0bf03d2c5c679e7248493b2ac713d86789d3f64c30e2d3554291afd",
           "tweak": "9f50ebe25b6273b0bacfda1fda",
           "msg": "Q0+0",
-          "ct": "4>tE",
+          "ct": "4>sE",
           "result": "valid"
         },
         {
@@ -15056,7 +15056,7 @@
           ],
           "key": "5787be1a2ef7a6762f9b7c0ff6a7efb27139e087603476bd0046f1fd58814f6a",
           "tweak": "498e5d8a4a05d992",
-          "msg": "/8KT",
+          "msg": "-8KT",
           "ct": "yU*|",
           "result": "invalid"
         },
@@ -15068,7 +15068,7 @@
           ],
           "key": "5787be1a2ef7a6762f9b7c0ff6a7efb27139e087603476bd0046f1fd58814f6a",
           "tweak": "498e5d8a4a05d992",
-          "msg": "W:KT",
+          "msg": "W-KT",
           "ct": "9a|X",
           "result": "invalid"
         },
@@ -15080,7 +15080,7 @@
           ],
           "key": "5787be1a2ef7a6762f9b7c0ff6a7efb27139e087603476bd0046f1fd58814f6a",
           "tweak": "498e5d8a4a05d992",
-          "msg": "W8K/",
+          "msg": "W8K-",
           "ct": "W5}l",
           "result": "invalid"
         },
@@ -15092,7 +15092,7 @@
           ],
           "key": "4404be1117aaa4ced6500b7063283647873c3742f88905f2ccab5e2b967f8d36",
           "tweak": "b4f8cba246ec06e6",
-          "msg": "\u007f>*P",
+          "msg": "->*P",
           "ct": "ZG0X",
           "result": "invalid"
         },
@@ -15104,7 +15104,7 @@
           ],
           "key": "4404be1117aaa4ced6500b7063283647873c3742f88905f2ccab5e2b967f8d36",
           "tweak": "b4f8cba246ec06e6",
-          "msg": "t\u007f*P",
+          "msg": "s-*P",
           "ct": "qXfP",
           "result": "invalid"
         },
@@ -15116,14 +15116,14 @@
           ],
           "key": "4404be1117aaa4ced6500b7063283647873c3742f88905f2ccab5e2b967f8d36",
           "tweak": "b4f8cba246ec06e6",
-          "msg": "t>*\u007f",
-          "ct": "ssK;",
+          "msg": "s>*-",
+          "ct": "ttK;",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 5,
       "radix": 85,
@@ -15150,7 +15150,7 @@
           "key": "227eb1ec08c2f14d3944f819597a3c5bb7fc2ecd17182db6936a39331af43026",
           "tweak": "16208ad8581f9aa4",
           "msg": "00000",
-          "ct": "sV2$@",
+          "ct": "tV2$@",
           "result": "valid"
         },
         {
@@ -15198,7 +15198,7 @@
           "key": "227eb1ec08c2f14d3944f819597a3c5bb7fc2ecd17182db6936a39331af43026",
           "tweak": "16208ad8581f9aa4",
           "msg": "9iBhi",
-          "ct": "btQ2I",
+          "ct": "bsQ2I",
           "result": "valid"
         },
         {
@@ -15210,7 +15210,7 @@
           "key": "227eb1ec08c2f14d3944f819597a3c5bb7fc2ecd17182db6936a39331af43026",
           "tweak": "16208ad8581f9aa4",
           "msg": "Y1%ok",
-          "ct": "ntolh",
+          "ct": "nuolh",
           "result": "valid"
         },
         {
@@ -15221,8 +15221,8 @@
           ],
           "key": "227eb1ec08c2f14d3944f819597a3c5bb7fc2ecd17182db6936a39331af43026",
           "tweak": "16208ad8581f9aa4",
-          "msg": "tC#zs",
-          "ct": "uGXFq",
+          "msg": "sC#zt",
+          "ct": "vGXFq",
           "result": "valid"
         },
         {
@@ -15233,8 +15233,8 @@
           ],
           "key": "227eb1ec08c2f14d3944f819597a3c5bb7fc2ecd17182db6936a39331af43026",
           "tweak": "16208ad8581f9aa4",
-          "msg": "qHlut",
-          "ct": "VtPb_",
+          "msg": "qHlvu",
+          "ct": "VsPb_",
           "result": "valid"
         },
         {
@@ -15270,7 +15270,7 @@
           "key": "227eb1ec08c2f14d3944f819597a3c5bb7fc2ecd17182db6936a39331af43026",
           "tweak": "16208ad8581f9aa4",
           "msg": "F9^F@",
-          "ct": "t71Pg",
+          "ct": "u71Pg",
           "result": "valid"
         },
         {
@@ -15293,7 +15293,7 @@
           ],
           "key": "227eb1ec08c2f14d3944f819597a3c5bb7fc2ecd17182db6936a39331af43026",
           "tweak": "16208ad8581f9aa4",
-          "msg": "e0FuN",
+          "msg": "e0FvN",
           "ct": "00000",
           "result": "valid"
         },
@@ -15305,7 +15305,7 @@
           ],
           "key": "227eb1ec08c2f14d3944f819597a3c5bb7fc2ecd17182db6936a39331af43026",
           "tweak": "16208ad8581f9aa4",
-          "msg": "Dsrhz",
+          "msg": "Dtrhz",
           "ct": "~~~~~",
           "result": "valid"
         },
@@ -15366,7 +15366,7 @@
           "key": "4fc2ed4958ecb8f461c8196dfad89c65b28e458da8ba0aafb13f62e997d27497",
           "tweak": "e181868dc6174efe3c097ca0",
           "msg": "4DeK_",
-          "ct": "mGv3@",
+          "ct": "mGw3@",
           "result": "valid"
         },
         {
@@ -15450,7 +15450,7 @@
           "key": "4fc2ed4958ecb8f461c8196dfad89c65b28e458da8ba0aafb13f62e997d27497",
           "tweak": "c5b332a0c9ae63875d7bd728",
           "msg": "~~Uqm",
-          "ct": "<_6ji",
+          "ct": "<:6ji",
           "result": "valid"
         },
         {
@@ -15461,8 +15461,8 @@
           ],
           "key": "759fcc081705a15b7d12cf25378f186944b76e767594b2eabfc598811e47f870",
           "tweak": "b69e51a606729a69",
-          "msg": "'Kdf_",
-          "ct": "Qt%zD",
+          "msg": "-Kdf:",
+          "ct": "Qu%zD",
           "result": "invalid"
         },
         {
@@ -15473,8 +15473,8 @@
           ],
           "key": "759fcc081705a15b7d12cf25378f186944b76e767594b2eabfc598811e47f870",
           "tweak": "b69e51a606729a69",
-          "msg": "@'df_",
-          "ct": "_jXdZ",
+          "msg": "@-df:",
+          "ct": ":jXdZ",
           "result": "invalid"
         },
         {
@@ -15485,7 +15485,7 @@
           ],
           "key": "759fcc081705a15b7d12cf25378f186944b76e767594b2eabfc598811e47f870",
           "tweak": "b69e51a606729a69",
-          "msg": "@Kdf[",
+          "msg": "@Kdf-",
           "ct": "<6&7$",
           "result": "invalid"
         },
@@ -15497,7 +15497,7 @@
           ],
           "key": "5803e1e52f24a0377f41888b385b645dbe5df64e37708b91e84bec3ba35f4c67",
           "tweak": "e8c2640d14c2689b",
-          "msg": "\u007fz!ye",
+          "msg": "-z!ye",
           "ct": ">N<c#",
           "result": "invalid"
         },
@@ -15509,7 +15509,7 @@
           ],
           "key": "5803e1e52f24a0377f41888b385b645dbe5df64e37708b91e84bec3ba35f4c67",
           "tweak": "e8c2640d14c2689b",
-          "msg": "~\u007f!ye",
+          "msg": "~-!ye",
           "ct": "kO7ja",
           "result": "invalid"
         },
@@ -15521,14 +15521,14 @@
           ],
           "key": "5803e1e52f24a0377f41888b385b645dbe5df64e37708b91e84bec3ba35f4c67",
           "tweak": "e8c2640d14c2689b",
-          "msg": "~z!y\u007f",
-          "ct": "(=Xt3",
+          "msg": "~z!y-",
+          "ct": "(=Xu3",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 6,
       "radix": 85,
@@ -15602,7 +15602,7 @@
           ],
           "key": "8376c44cb6d0dbc1928bdbf5754ca32aaeace6298b45174f86c3f7151475d2fd",
           "tweak": "9342a88d4b672bbb",
-          "msg": "|ux147",
+          "msg": "|vx147",
           "ct": "<#=2UM",
           "result": "valid"
         },
@@ -15626,7 +15626,7 @@
           ],
           "key": "8376c44cb6d0dbc1928bdbf5754ca32aaeace6298b45174f86c3f7151475d2fd",
           "tweak": "9342a88d4b672bbb",
-          "msg": "DetGr`",
+          "msg": "DesGr`",
           "ct": "J4q2?_",
           "result": "valid"
         },
@@ -15662,7 +15662,7 @@
           ],
           "key": "8376c44cb6d0dbc1928bdbf5754ca32aaeace6298b45174f86c3f7151475d2fd",
           "tweak": "9342a88d4b672bbb",
-          "msg": "_sm{FF",
+          "msg": "_tm{FF",
           "ct": "_BHm)W",
           "result": "valid"
         },
@@ -15687,7 +15687,7 @@
           "key": "8376c44cb6d0dbc1928bdbf5754ca32aaeace6298b45174f86c3f7151475d2fd",
           "tweak": "9342a88d4b672bbb",
           "msg": "GO?V2d",
-          "ct": ")5H%vi",
+          "ct": ")5H%wi",
           "result": "valid"
         },
         {
@@ -15710,7 +15710,7 @@
           ],
           "key": "8376c44cb6d0dbc1928bdbf5754ca32aaeace6298b45174f86c3f7151475d2fd",
           "tweak": "9342a88d4b672bbb",
-          "msg": "V>t=A0",
+          "msg": "V>u=A0",
           "ct": "~~~~~~",
           "result": "valid"
         },
@@ -15722,7 +15722,7 @@
           ],
           "key": "8376c44cb6d0dbc1928bdbf5754ca32aaeace6298b45174f86c3f7151475d2fd",
           "tweak": "9342a88d4b672bbb",
-          "msg": "DYrF>u",
+          "msg": "DYrF>v",
           "ct": ";m8;m8",
           "result": "valid"
         },
@@ -15770,7 +15770,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "602bd456626885a160800040",
-          "msg": "t3<~PR",
+          "msg": "s3<~PR",
           "ct": "x(D*P&",
           "result": "valid"
         },
@@ -15794,7 +15794,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "eaae0f0ee7fcf19665f57dd5",
-          "msg": "&fOtf?",
+          "msg": "&fOuf?",
           "ct": "%)=UxG",
           "result": "valid"
         },
@@ -15806,7 +15806,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "eaae0f0ee7fcf19665f57dd5",
-          "msg": "u3qbk?",
+          "msg": "v3qbk?",
           "ct": "$b(n8$",
           "result": "valid"
         },
@@ -15818,7 +15818,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "eaae0f0ee7fcf19665f57dd5",
-          "msg": "Mt~3`T",
+          "msg": "Mu~3`T",
           "ct": "+q|hBm",
           "result": "valid"
         },
@@ -15830,7 +15830,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "eaae0f0ee7fcf19665f57dd5",
-          "msg": "aK0h<_",
+          "msg": "aK0h<:",
           "ct": "DgEL%#",
           "result": "valid"
         },
@@ -15842,7 +15842,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "eaae0f0ee7fcf19665f57dd5",
-          "msg": "<flt1Z",
+          "msg": "<fls1Z",
           "ct": "eHe){c",
           "result": "valid"
         },
@@ -15866,7 +15866,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "6fce16f66f5a7a4556a4b2d4",
-          "msg": "*vt001",
+          "msg": "*ws001",
           "ct": "}355Vm",
           "result": "valid"
         },
@@ -15878,7 +15878,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "6fce16f66f5a7a4556a4b2d4",
-          "msg": "yDt2y~",
+          "msg": "yDu2y~",
           "ct": "B3(z6V",
           "result": "valid"
         },
@@ -15891,7 +15891,7 @@
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "6fce16f66f5a7a4556a4b2d4",
           "msg": "{822z0",
-          "ct": "vnV`~s",
+          "ct": "wnV`~t",
           "result": "valid"
         },
         {
@@ -15903,7 +15903,7 @@
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "6fce16f66f5a7a4556a4b2d4",
           "msg": "F2d;m8",
-          "ct": "eT0sF~",
+          "ct": "eT0tF~",
           "result": "valid"
         },
         {
@@ -15915,7 +15915,7 @@
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "6fce16f66f5a7a4556a4b2d4",
           "msg": "3!3~~~",
-          "ct": "*)|3mt",
+          "ct": "*)|3mu",
           "result": "valid"
         },
         {
@@ -15926,7 +15926,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "a09f1cb063730beaf0c1d384",
-          "msg": "000uGn",
+          "msg": "000vGn",
           "ct": "@}^Ak1",
           "result": "valid"
         },
@@ -15938,7 +15938,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "a09f1cb063730beaf0c1d384",
-          "msg": "001uGn",
+          "msg": "001vGn",
           "ct": "4)imRo",
           "result": "valid"
         },
@@ -15950,7 +15950,7 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "a09f1cb063730beaf0c1d384",
-          "msg": ";m8uGn",
+          "msg": ";m8vGn",
           "ct": "e!_>*F",
           "result": "valid"
         },
@@ -15962,8 +15962,8 @@
           ],
           "key": "6cb7812f674f83701cb4913833d58fc7abd8a11f077e921eee6a1b0da918fc59",
           "tweak": "a09f1cb063730beaf0c1d384",
-          "msg": "~~~uGn",
-          "ct": "Gs4(SV",
+          "msg": "~~~vGn",
+          "ct": "Gt4(SV",
           "result": "valid"
         },
         {
@@ -15974,8 +15974,8 @@
           ],
           "key": "80089d3b3a0bcf1159ca4f8cb20cd7e24fcbaab8c28d228ffcd22259d3000215",
           "tweak": "bf692e602f57a277",
-          "msg": "]Wsm*B",
-          "ct": "PYt(1*",
+          "msg": "-Wtm*B",
+          "ct": "PYs(1*",
           "result": "invalid"
         },
         {
@@ -15986,7 +15986,7 @@
           ],
           "key": "80089d3b3a0bcf1159ca4f8cb20cd7e24fcbaab8c28d228ffcd22259d3000215",
           "tweak": "bf692e602f57a277",
-          "msg": "OW.m*B",
+          "msg": "OW-m*B",
           "ct": "gB0#)F",
           "result": "invalid"
         },
@@ -15998,7 +15998,7 @@
           ],
           "key": "80089d3b3a0bcf1159ca4f8cb20cd7e24fcbaab8c28d228ffcd22259d3000215",
           "tweak": "bf692e602f57a277",
-          "msg": "OWsm*\\",
+          "msg": "OWtm*-",
           "ct": "m}WnTa",
           "result": "invalid"
         },
@@ -16010,7 +16010,7 @@
           ],
           "key": "ac40ad9e332a0045f7a03e8474e067be3fee6812c71cdcbe07f2ba4c2b289448",
           "tweak": "4e7172cdd991b8fa",
-          "msg": "\u007fAPnM8",
+          "msg": "-APnM8",
           "ct": "n7B@y?",
           "result": "invalid"
         },
@@ -16022,7 +16022,7 @@
           ],
           "key": "ac40ad9e332a0045f7a03e8474e067be3fee6812c71cdcbe07f2ba4c2b289448",
           "tweak": "4e7172cdd991b8fa",
-          "msg": "MA\u007fnM8",
+          "msg": "MA-nM8",
           "ct": "}GjU0m",
           "result": "invalid"
         },
@@ -16034,14 +16034,14 @@
           ],
           "key": "ac40ad9e332a0045f7a03e8474e067be3fee6812c71cdcbe07f2ba4c2b289448",
           "tweak": "4e7172cdd991b8fa",
-          "msg": "MAPnM\u007f",
-          "ct": "3E4utN",
+          "msg": "MAPnM-",
+          "ct": "3E4vuN",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 7,
       "radix": 85,
@@ -16055,7 +16055,7 @@
           ],
           "key": "647b69567516a585377f3fc9a8129c255431b0b5ab6792f9aa3fd646f3146b13",
           "tweak": "39774b45a4fdd85b",
-          "msg": "tzC#gPW",
+          "msg": "szC#gPW",
           "ct": "=0q*#8L",
           "result": "valid"
         },
@@ -16091,7 +16091,7 @@
           ],
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
-          "msg": ";m8ttI2",
+          "msg": ";m8ssI2",
           "ct": "dX{?o%l",
           "result": "valid"
         },
@@ -16103,7 +16103,7 @@
           ],
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
-          "msg": ";m7ttI1",
+          "msg": ";m7ssI1",
           "ct": "Y7gGc^y",
           "result": "valid"
         },
@@ -16115,8 +16115,8 @@
           ],
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
-          "msg": "P6LLtIh",
-          "ct": "CQmM%Xs",
+          "msg": "P6LLsIh",
+          "ct": "CQmM%Xt",
           "result": "valid"
         },
         {
@@ -16139,8 +16139,8 @@
           ],
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
-          "msg": "l?ntxG1",
-          "ct": "_n0A1DI",
+          "msg": "l?nsxG1",
+          "ct": ":n0A1DI",
           "result": "valid"
         },
         {
@@ -16151,7 +16151,7 @@
           ],
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
-          "msg": "xX$}bSs",
+          "msg": "xX$}bSt",
           "ct": "xxXWo=p",
           "result": "valid"
         },
@@ -16163,7 +16163,7 @@
           ],
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
-          "msg": "IushG_8",
+          "msg": "IvthG_8",
           "ct": "i<A>=%Z",
           "result": "valid"
         },
@@ -16176,7 +16176,7 @@
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
           "msg": "xMdEadK",
-          "ct": "yOum#~p",
+          "ct": "yOvm#~p",
           "result": "valid"
         },
         {
@@ -16188,7 +16188,7 @@
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
           "msg": "38?h1!|",
-          "ct": "ex_qfU*",
+          "ct": "ex:qfU*",
           "result": "valid"
         },
         {
@@ -16236,7 +16236,7 @@
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
           "msg": "VD%FMLj",
-          "ct": ";m8ttI2",
+          "ct": ";m8ssI2",
           "result": "valid"
         },
         {
@@ -16248,7 +16248,7 @@
           "key": "7cfa15764604e2f793ec841c54933cda7c15604e96501c2c19a7495c2ca124c2",
           "tweak": "85e4782f20e0178c",
           "msg": "p0xW2x!",
-          "ct": ";m7ttI1",
+          "ct": ";m7ssI1",
           "result": "valid"
         },
         {
@@ -16272,7 +16272,7 @@
           "key": "1058920be115e85e503e04f634a36836428f3086a0387788447be8e1162e14b5",
           "tweak": "7834773830a0cf2cce5850",
           "msg": "!iq@p{Q",
-          "ct": "7s7crcP",
+          "ct": "7t7crcP",
           "result": "valid"
         },
         {
@@ -16284,7 +16284,7 @@
           "key": "1058920be115e85e503e04f634a36836428f3086a0387788447be8e1162e14b5",
           "tweak": "7834773830a0cf2cce5850",
           "msg": "5@=Ueeh",
-          "ct": "Au|DUg*",
+          "ct": "Av|DUg*",
           "result": "valid"
         },
         {
@@ -16308,7 +16308,7 @@
           "key": "1058920be115e85e503e04f634a36836428f3086a0387788447be8e1162e14b5",
           "tweak": "bd604286237f4d1d7eaf5d",
           "msg": "SIYkNZ|",
-          "ct": "q<`_324",
+          "ct": "q<`:324",
           "result": "valid"
         },
         {
@@ -16319,8 +16319,8 @@
           ],
           "key": "1058920be115e85e503e04f634a36836428f3086a0387788447be8e1162e14b5",
           "tweak": "bd604286237f4d1d7eaf5d",
-          "msg": "Xa<Xt6d",
-          "ct": "CvchUm~",
+          "msg": "Xa<Xu6d",
+          "ct": "CwchUm~",
           "result": "valid"
         },
         {
@@ -16332,7 +16332,7 @@
           "key": "1058920be115e85e503e04f634a36836428f3086a0387788447be8e1162e14b5",
           "tweak": "bd604286237f4d1d7eaf5d",
           "msg": "mG1MU6M",
-          "ct": "S(h3Bst",
+          "ct": "S(h3Btu",
           "result": "valid"
         },
         {
@@ -16380,7 +16380,7 @@
           "key": "1058920be115e85e503e04f634a36836428f3086a0387788447be8e1162e14b5",
           "tweak": "96c86bac462a4a58f11799",
           "msg": "001RgXL",
-          "ct": "VoWsOkL",
+          "ct": "VoWtOkL",
           "result": "valid"
         },
         {
@@ -16404,7 +16404,7 @@
           "key": "1058920be115e85e503e04f634a36836428f3086a0387788447be8e1162e14b5",
           "tweak": "96c86bac462a4a58f11799",
           "msg": "2z0RgXL",
-          "ct": "CK>uFb=",
+          "ct": "CK>vFb=",
           "result": "valid"
         },
         {
@@ -16439,8 +16439,8 @@
           ],
           "key": "d77ad296a3a7ac7aaa296912b462b6ae77b8ac6af9e1f213711e989e461e3fac",
           "tweak": "c5df6cad17b46d67",
-          "msg": "/=otR>Q",
-          "ct": "gQr_G_4",
+          "msg": "-=osR>Q",
+          "ct": "gQr:G:4",
           "result": "invalid"
         },
         {
@@ -16451,8 +16451,8 @@
           ],
           "key": "d77ad296a3a7ac7aaa296912b462b6ae77b8ac6af9e1f213711e989e461e3fac",
           "tweak": "c5df6cad17b46d67",
-          "msg": "v=/tR>Q",
-          "ct": "UqvE0f9",
+          "msg": "w=-sR>Q",
+          "ct": "UqwE0f9",
           "result": "invalid"
         },
         {
@@ -16463,7 +16463,7 @@
           ],
           "key": "d77ad296a3a7ac7aaa296912b462b6ae77b8ac6af9e1f213711e989e461e3fac",
           "tweak": "c5df6cad17b46d67",
-          "msg": "v=otR>[",
+          "msg": "w=osR>-",
           "ct": "fECxx9e",
           "result": "invalid"
         },
@@ -16475,7 +16475,7 @@
           ],
           "key": "816f6fc55de4f914bdb6e07698c1b4e628fdccf7b2cba1562c48c79abc471a0a",
           "tweak": "62723fe6e87a61ad",
-          "msg": "\u007fNLI@a~",
+          "msg": "-NLI@a~",
           "ct": "pjmJQ=j",
           "result": "invalid"
         },
@@ -16487,7 +16487,7 @@
           ],
           "key": "816f6fc55de4f914bdb6e07698c1b4e628fdccf7b2cba1562c48c79abc471a0a",
           "tweak": "62723fe6e87a61ad",
-          "msg": "aN\u007fI@a~",
+          "msg": "aN-I@a~",
           "ct": "B<!Ja&I",
           "result": "invalid"
         },
@@ -16499,14 +16499,14 @@
           ],
           "key": "816f6fc55de4f914bdb6e07698c1b4e628fdccf7b2cba1562c48c79abc471a0a",
           "tweak": "62723fe6e87a61ad",
-          "msg": "aNLI@a\u007f",
+          "msg": "aNLI@a-",
           "ct": "RX#jo4_",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 8,
       "radix": 85,
@@ -16521,7 +16521,7 @@
           "key": "066c6a83fd826a5fa7f3b4025bb9c833befa12044d3fbed87280a4c7a0435b03",
           "tweak": "80650ae5bc5e1bb1",
           "msg": "Kd5)RK|O",
-          "ct": "tkeEq`@%",
+          "ct": "skeEq`@%",
           "result": "valid"
         },
         {
@@ -16533,7 +16533,7 @@
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
           "msg": "00000000",
-          "ct": "LE)H~H_F",
+          "ct": "LE)H~H:F",
           "result": "valid"
         },
         {
@@ -16556,8 +16556,8 @@
           ],
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
-          "msg": "ttI2ttI2",
-          "ct": "F?YqJxt3",
+          "msg": "ssI2ssI2",
+          "ct": "F?YqJxu3",
           "result": "valid"
         },
         {
@@ -16568,8 +16568,8 @@
           ],
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
-          "msg": "ttI1ttI1",
-          "ct": "i7t%*2qU",
+          "msg": "ssI1ssI1",
+          "ct": "i7s%*2qU",
           "result": "valid"
         },
         {
@@ -16593,7 +16593,7 @@
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
           "msg": "KpmCkOqE",
-          "ct": "t&T3R1vC",
+          "ct": "u&T3R1wC",
           "result": "valid"
         },
         {
@@ -16605,7 +16605,7 @@
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
           "msg": "T}nR0x*2",
-          "ct": "|}Qpi$fs",
+          "ct": "|}Qpi$ft",
           "result": "valid"
         },
         {
@@ -16617,7 +16617,7 @@
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
           "msg": ")acAB)Dz",
-          "ct": "rF6t0lUe",
+          "ct": "rF6s0lUe",
           "result": "valid"
         },
         {
@@ -16629,7 +16629,7 @@
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
           "msg": "h40BSL0&",
-          "ct": "ud{ha#|q",
+          "ct": "vd{ha#|q",
           "result": "valid"
         },
         {
@@ -16640,7 +16640,7 @@
           ],
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
-          "msg": "ktUpzAvU",
+          "msg": "kuUpzAwU",
           "ct": "|i<5@a{?",
           "result": "valid"
         },
@@ -16665,7 +16665,7 @@
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
           "msg": "j$2DDa$8",
-          "ct": "?|>+Psg(",
+          "ct": "?|>+Ptg(",
           "result": "valid"
         },
         {
@@ -16700,8 +16700,8 @@
           ],
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
-          "msg": "ObEvv@N~",
-          "ct": "ttI2ttI2",
+          "msg": "ObEww@N~",
+          "ct": "ssI2ssI2",
           "result": "valid"
         },
         {
@@ -16713,7 +16713,7 @@
           "key": "54130fa0aa69ad9d15eb6b41ce1bc81da5abbf8091152caa37ee107d1a47aff9",
           "tweak": "6b79eea9265e4ccf",
           "msg": "VGA2+HFZ",
-          "ct": "ttI1ttI1",
+          "ct": "ssI1ssI1",
           "result": "valid"
         },
         {
@@ -16736,7 +16736,7 @@
           ],
           "key": "891cf5ab57f8b6e98407b266bc6e34e6000b7a96e77f1dacb4652ad2be83955a",
           "tweak": "e760d0c08b62aee7c803f8",
-          "msg": "hUNudv%L",
+          "msg": "hUNvdw%L",
           "ct": "1!9O0002",
           "result": "valid"
         },
@@ -16749,7 +16749,7 @@
           "key": "891cf5ab57f8b6e98407b266bc6e34e6000b7a96e77f1dacb4652ad2be83955a",
           "tweak": "e760d0c08b62aee7c803f8",
           "msg": "#FoC%RAj",
-          "ct": "1!9OttI3",
+          "ct": "1!9OssI3",
           "result": "valid"
         },
         {
@@ -16772,7 +16772,7 @@
           ],
           "key": "891cf5ab57f8b6e98407b266bc6e34e6000b7a96e77f1dacb4652ad2be83955a",
           "tweak": "e760d0c08b62aee7c803f8",
-          "msg": "r_Pg5vWc",
+          "msg": "r:Pg5wWc",
           "ct": "1!9O0000",
           "result": "valid"
         },
@@ -16808,8 +16808,8 @@
           ],
           "key": "891cf5ab57f8b6e98407b266bc6e34e6000b7a96e77f1dacb4652ad2be83955a",
           "tweak": "e27c45347526b7ee5b3f11",
-          "msg": "ttI2!ll0",
-          "ct": "pfvn~jl|",
+          "msg": "ssI2!ll0",
+          "ct": "pfwn~jl|",
           "result": "valid"
         },
         {
@@ -16832,7 +16832,7 @@
           ],
           "key": "6290d1209766dbedd27fcce9e0b5c8eac570b78df90cf7ac15c2a6b13f414882",
           "tweak": "55d9bf63cd98d552",
-          "msg": ":thm1TPu",
+          "msg": "-shm1TPv",
           "ct": "!RYgN#l!",
           "result": "invalid"
         },
@@ -16844,8 +16844,8 @@
           ],
           "key": "6290d1209766dbedd27fcce9e0b5c8eac570b78df90cf7ac15c2a6b13f414882",
           "tweak": "55d9bf63cd98d552",
-          "msg": "5t\\m1TPu",
-          "ct": "gKXjA=ot",
+          "msg": "5s-m1TPv",
+          "ct": "gKXjA=os",
           "result": "invalid"
         },
         {
@@ -16856,8 +16856,8 @@
           ],
           "key": "6290d1209766dbedd27fcce9e0b5c8eac570b78df90cf7ac15c2a6b13f414882",
           "tweak": "55d9bf63cd98d552",
-          "msg": "5thm1TP\\",
-          "ct": "l5XuQ$);",
+          "msg": "5shm1TP-",
+          "ct": "l5XvQ$);",
           "result": "invalid"
         },
         {
@@ -16868,7 +16868,7 @@
           ],
           "key": "e29da8d834b3c5afade80ddc7297908adb907b8410ce41ce881bce7ce00fab7f",
           "tweak": "c592cbb9d6073a6e",
-          "msg": "\u007f=aNR<Wp",
+          "msg": "-=aNR<Wp",
           "ct": "I77V5_jf",
           "result": "invalid"
         },
@@ -16880,7 +16880,7 @@
           ],
           "key": "e29da8d834b3c5afade80ddc7297908adb907b8410ce41ce881bce7ce00fab7f",
           "tweak": "c592cbb9d6073a6e",
-          "msg": "(=\u007fNR<Wp",
+          "msg": "(=-NR<Wp",
           "ct": ">;$foA<f",
           "result": "invalid"
         },
@@ -16892,14 +16892,14 @@
           ],
           "key": "e29da8d834b3c5afade80ddc7297908adb907b8410ce41ce881bce7ce00fab7f",
           "tweak": "c592cbb9d6073a6e",
-          "msg": "(=aNR<W\u007f",
+          "msg": "(=aNR<W-",
           "ct": "d_zE{YY)",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 9,
       "radix": 85,
@@ -16913,8 +16913,8 @@
           ],
           "key": "f44f1e998316e5fe6f5c6f8d89919428d692d931130409c41ba4955dfc4c8c14",
           "tweak": "387c0277bb97fa8e",
-          "msg": "V#&s!_$Dx",
-          "ct": "teKDrUFm<",
+          "msg": "V#&t!_$Dx",
+          "ct": "seKDrUFm<",
           "result": "valid"
         },
         {
@@ -16926,7 +16926,7 @@
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
           "msg": "000000000",
-          "ct": "7Uiq_K3vd",
+          "ct": "7Uiq:K3wd",
           "result": "valid"
         },
         {
@@ -16949,8 +16949,8 @@
           ],
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
-          "msg": "ttI2|NtC1",
-          "ct": "#ETY_=|_P",
+          "msg": "ssI2|NsC1",
+          "ct": "#ETY:=|_P",
           "result": "valid"
         },
         {
@@ -16961,7 +16961,7 @@
           ],
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
-          "msg": "ttI1|NtC0",
+          "msg": "ssI1|NsC0",
           "ct": "pc+%h9xF=",
           "result": "valid"
         },
@@ -16998,7 +16998,7 @@
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
           "msg": "nbgLV|ZIV",
-          "ct": "tfB`_ye#2",
+          "ct": "ufB`_ye#2",
           "result": "valid"
         },
         {
@@ -17010,7 +17010,7 @@
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
           "msg": "*O$#P0>^b",
-          "ct": "z(yS<sE>Y",
+          "ct": "z(yS<tE>Y",
           "result": "valid"
         },
         {
@@ -17021,7 +17021,7 @@
           ],
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
-          "msg": "_e3`_?R#y",
+          "msg": ":e3`:?R#y",
           "ct": "X0$V%3eZ5",
           "result": "valid"
         },
@@ -17034,7 +17034,7 @@
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
           "msg": "gd3>ih|o>",
-          "ct": "tT3id$S(5",
+          "ct": "uT3id$S(5",
           "result": "valid"
         },
         {
@@ -17045,8 +17045,8 @@
           ],
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
-          "msg": "HatJ5}6nQ",
-          "ct": "(EE^6!Mjt",
+          "msg": "HauJ5}6nQ",
+          "ct": "(EE^6!Mjs",
           "result": "valid"
         },
         {
@@ -17058,7 +17058,7 @@
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
           "msg": "_Sp^#yGco",
-          "ct": "@S80N6tb_",
+          "ct": "@S80N6sb_",
           "result": "valid"
         },
         {
@@ -17069,7 +17069,7 @@
           ],
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
-          "msg": "h|t2!rkbo",
+          "msg": "h|s2!rkbo",
           "ct": "000000000",
           "result": "valid"
         },
@@ -17093,8 +17093,8 @@
           ],
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
-          "msg": "xxCa=u_Z`",
-          "ct": "ttI2|NtC1",
+          "msg": "xxCa=v_Z`",
+          "ct": "ssI2|NsC1",
           "result": "valid"
         },
         {
@@ -17106,7 +17106,7 @@
           "key": "ca2edd5c1402d6ecb3e52e4619dbbdc800571019507f861c102f7c44ce406119",
           "tweak": "0f79bdd51e894679",
           "msg": "`eZAb*(^Y",
-          "ct": "ttI1|NtC0",
+          "ct": "ssI1|NsC0",
           "result": "valid"
         },
         {
@@ -17117,8 +17117,8 @@
           ],
           "key": "84fff86e7dd22bd4b3bf53279ff7c696568bb9fa6067e40a1354e3a77fdb6b31",
           "tweak": "5b443aeb87b857995abd",
-          "msg": "|*Qs~X(N{",
-          "ct": "0001!%$9_",
+          "msg": "|*Qt~X(N{",
+          "ct": "0001!%$9:",
           "result": "valid"
         },
         {
@@ -17129,7 +17129,7 @@
           ],
           "key": "84fff86e7dd22bd4b3bf53279ff7c696568bb9fa6067e40a1354e3a77fdb6b31",
           "tweak": "5b443aeb87b857995abd",
-          "msg": "GJzmuUb9L",
+          "msg": "GJzmvUb9L",
           "ct": "000255U{A",
           "result": "valid"
         },
@@ -17141,8 +17141,8 @@
           ],
           "key": "84fff86e7dd22bd4b3bf53279ff7c696568bb9fa6067e40a1354e3a77fdb6b31",
           "tweak": "5b443aeb87b857995abd",
-          "msg": "Ks~~SCu0=",
-          "ct": "ttI3sZtB8",
+          "msg": "Kt~~SCv0=",
+          "ct": "ssI3tZuB8",
           "result": "valid"
         },
         {
@@ -17153,7 +17153,7 @@
           ],
           "key": "84fff86e7dd22bd4b3bf53279ff7c696568bb9fa6067e40a1354e3a77fdb6b31",
           "tweak": "5b443aeb87b857995abd",
-          "msg": "Gu|`T2qIs",
+          "msg": "Gv|`T2qIt",
           "ct": "~~~~h0+<1",
           "result": "valid"
         },
@@ -17165,7 +17165,7 @@
           ],
           "key": "84fff86e7dd22bd4b3bf53279ff7c696568bb9fa6067e40a1354e3a77fdb6b31",
           "tweak": "5b443aeb87b857995abd",
-          "msg": "G+qRQnztU",
+          "msg": "G+qRQnzuU",
           "ct": "0000?jR{<",
           "result": "valid"
         },
@@ -17177,7 +17177,7 @@
           ],
           "key": "5f5d8e441c7e92c8d4f15740b5e79a73d2b90fa0e8acdbc0517f4b039bab0dc0",
           "tweak": "5aa849326a17e15a",
-          "msg": ",N_3)*op*",
+          "msg": "-N_3)*op*",
           "ct": "7O{xBN{CH",
           "result": "invalid"
         },
@@ -17189,7 +17189,7 @@
           ],
           "key": "5f5d8e441c7e92c8d4f15740b5e79a73d2b90fa0e8acdbc0517f4b039bab0dc0",
           "tweak": "5aa849326a17e15a",
-          "msg": "4N_[)*op*",
+          "msg": "4N_-)*op*",
           "ct": "<5>+jfYM^",
           "result": "invalid"
         },
@@ -17201,7 +17201,7 @@
           ],
           "key": "5f5d8e441c7e92c8d4f15740b5e79a73d2b90fa0e8acdbc0517f4b039bab0dc0",
           "tweak": "5aa849326a17e15a",
-          "msg": "4N_3)*op]",
+          "msg": "4N_3)*op-",
           "ct": "o4HHi~mR?",
           "result": "invalid"
         },
@@ -17213,7 +17213,7 @@
           ],
           "key": "636284c4bd595a850feb3655ba26b3349c693b5081cf89cf9c398294a641bc42",
           "tweak": "b428f084e199ce6f",
-          "msg": "\u007fZ9Iy%8(l",
+          "msg": "-Z9Iy%8(l",
           "ct": "JI!MUHdn+",
           "result": "invalid"
         },
@@ -17225,7 +17225,7 @@
           ],
           "key": "636284c4bd595a850feb3655ba26b3349c693b5081cf89cf9c398294a641bc42",
           "tweak": "b428f084e199ce6f",
-          "msg": "VZ9\u007fy%8(l",
+          "msg": "VZ9-y%8(l",
           "ct": "2)DQn>W42",
           "result": "invalid"
         },
@@ -17237,14 +17237,14 @@
           ],
           "key": "636284c4bd595a850feb3655ba26b3349c693b5081cf89cf9c398294a641bc42",
           "tweak": "b428f084e199ce6f",
-          "msg": "VZ9Iy%8(\u007f",
+          "msg": "VZ9Iy%8(-",
           "ct": "l~jFkeJA7",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 10,
       "radix": 85,
@@ -17258,7 +17258,7 @@
           ],
           "key": "267c361cd190db6be369183a3b1a71601103f958cd6b791112928244c9402939",
           "tweak": "d00249da9e347109",
-          "msg": "n{*t?lj1zD",
+          "msg": "n{*u?lj1zD",
           "ct": ";e8O`zb9Er",
           "result": "valid"
         },
@@ -17294,8 +17294,8 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "|NtC1|NtC1",
-          "ct": "tniMqI~Gyz",
+          "msg": "|NsC1|NsC1",
+          "ct": "sniMqI~Gyz",
           "result": "valid"
         },
         {
@@ -17306,8 +17306,8 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "|NtC0|NtC0",
-          "ct": "{>_F)v0y}k",
+          "msg": "|NsC0|NsC0",
+          "ct": "{>_F)w0y}k",
           "result": "valid"
         },
         {
@@ -17330,8 +17330,8 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "AqVJg>t0QM",
-          "ct": "Rz%tQ_)%FX",
+          "msg": "AqVJg>u0QM",
+          "ct": "Rz%uQ:)%FX",
           "result": "valid"
         },
         {
@@ -17342,7 +17342,7 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "NeeD=s$29X",
+          "msg": "NeeD=t$29X",
           "ct": "6FK>4yD;c<",
           "result": "valid"
         },
@@ -17354,8 +17354,8 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "tdn_e<MtIi",
-          "ct": "7i|>ts|CG$",
+          "msg": "sdn_e<MsIi",
+          "ct": "7i|>ut|CG$",
           "result": "valid"
         },
         {
@@ -17366,7 +17366,7 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "db+RIeVv69",
+          "msg": "db+RIeVw69",
           "ct": "dT6CD}}+yJ",
           "result": "valid"
         },
@@ -17379,7 +17379,7 @@
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
           "msg": "io*Gi?~IAF",
-          "ct": "deEf3~Ptbq",
+          "ct": "deEf3~Pubq",
           "result": "valid"
         },
         {
@@ -17402,7 +17402,7 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "GTv$GmS;X#",
+          "msg": "GTw$GmS;X#",
           "ct": "F$Lg|@n_rc",
           "result": "valid"
         },
@@ -17426,7 +17426,7 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": ")9ua(r&7i}",
+          "msg": ")9va(r&7i}",
           "ct": "~~~~~~~~~~",
           "result": "valid"
         },
@@ -17438,8 +17438,8 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "Uss{SM~#%s",
-          "ct": "|NtC1|NtC1",
+          "msg": "Utt{SM~#%t",
+          "ct": "|NsC1|NsC1",
           "result": "valid"
         },
         {
@@ -17450,8 +17450,8 @@
           ],
           "key": "15d60e791980b6815b04e05c7e9df93a5cda84614ecf2a4900fe55794187c771",
           "tweak": "68801fd1e1ea4d75",
-          "msg": "4TF3!t`nRg",
-          "ct": "|NtC0|NtC0",
+          "msg": "4TF3!s`nRg",
+          "ct": "|NsC0|NsC0",
           "result": "valid"
         },
         {
@@ -17462,7 +17462,7 @@
           ],
           "key": "0e278046ac6a44c25ea36086dbd0aec5a25c16d87bd80eb380922a0e988debc8",
           "tweak": "aac963be9bb06d9c",
-          "msg": "-N}u=0C|@D",
+          "msg": "-N}v=0C|@D",
           "ct": "cryT2~Z7I(",
           "result": "invalid"
         },
@@ -17474,8 +17474,8 @@
           ],
           "key": "0e278046ac6a44c25ea36086dbd0aec5a25c16d87bd80eb380922a0e988debc8",
           "tweak": "aac963be9bb06d9c",
-          "msg": "yN},=0C|@D",
-          "ct": "z?=v%m+But",
+          "msg": "yN}-=0C|@D",
+          "ct": "z?=w%m+Bvu",
           "result": "invalid"
         },
         {
@@ -17486,7 +17486,7 @@
           ],
           "key": "0e278046ac6a44c25ea36086dbd0aec5a25c16d87bd80eb380922a0e988debc8",
           "tweak": "aac963be9bb06d9c",
-          "msg": "yN}u=0C|@:",
+          "msg": "yN}v=0C|@-",
           "ct": "AHW)eV8N3b",
           "result": "invalid"
         },
@@ -17498,7 +17498,7 @@
           ],
           "key": "06b0800ab288483c100941fb6298ea4d1acd676d7dbd6e51c911cd5d6eb79818",
           "tweak": "09e9bc141f60d425",
-          "msg": "\u007fvVW2CA+gQ",
+          "msg": "-wVW2CA+gQ",
           "ct": "+V?B(xg=yj",
           "result": "invalid"
         },
@@ -17510,8 +17510,8 @@
           ],
           "key": "06b0800ab288483c100941fb6298ea4d1acd676d7dbd6e51c911cd5d6eb79818",
           "tweak": "09e9bc141f60d425",
-          "msg": "`vV\u007f2CA+gQ",
-          "ct": "xyQmV0qn5s",
+          "msg": "`wV-2CA+gQ",
+          "ct": "xyQmV0qn5t",
           "result": "invalid"
         },
         {
@@ -17522,14 +17522,14 @@
           ],
           "key": "06b0800ab288483c100941fb6298ea4d1acd676d7dbd6e51c911cd5d6eb79818",
           "tweak": "09e9bc141f60d425",
-          "msg": "`vVW2CA+g\u007f",
+          "msg": "`wVW2CA+g-",
           "ct": "Z*HCL1#}q$",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 11,
       "radix": 85,
@@ -17579,7 +17579,7 @@
           ],
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
-          "msg": "|NtC1z`(%3$",
+          "msg": "|NsC1z`(%3$",
           "ct": "f${?#5=YqWB",
           "result": "valid"
         },
@@ -17591,7 +17591,7 @@
           ],
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
-          "msg": "|NtC0z`(%3#",
+          "msg": "|NsC0z`(%3#",
           "ct": "c`WL2$($y4n",
           "result": "valid"
         },
@@ -17603,8 +17603,8 @@
           ],
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
-          "msg": "oIaK=uD4ysV",
-          "ct": "dTf<@!@cO_#",
+          "msg": "oIaK=vD4ytV",
+          "ct": "dTf<@!@cO:#",
           "result": "valid"
         },
         {
@@ -17616,7 +17616,7 @@
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
           "msg": ";f2Y(=bGR!E",
-          "ct": ";yPd^;pk<ut",
+          "ct": ";yPd^;pk<vs",
           "result": "valid"
         },
         {
@@ -17640,7 +17640,7 @@
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
           "msg": "pIg#*>O|^ji",
-          "ct": "Tt9E=tro_{(",
+          "ct": "Tu9E=uro:{(",
           "result": "valid"
         },
         {
@@ -17664,7 +17664,7 @@
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
           "msg": "5#0MnU^037d",
-          "ct": "<eK2Z@Peks$",
+          "ct": "<eK2Z@Pekt$",
           "result": "valid"
         },
         {
@@ -17676,7 +17676,7 @@
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
           "msg": "lC$q%Cq{7aL",
-          "ct": "{PNi_ekJv`#",
+          "ct": "{PNi_ekJw`#",
           "result": "valid"
         },
         {
@@ -17687,8 +17687,8 @@
           ],
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
-          "msg": "du6?=%~x8@t",
-          "ct": "_>@x5)=bj=S",
+          "msg": "dv6?=%~x8@s",
+          "ct": ":>@x5)=bj=S",
           "result": "valid"
         },
         {
@@ -17711,7 +17711,7 @@
           ],
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
-          "msg": "cXEh*1qougp",
+          "msg": "cXEh*1qovgp",
           "ct": "~~~~~~~~~~~",
           "result": "valid"
         },
@@ -17724,7 +17724,7 @@
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
           "msg": "djD(6^VQ(Rf",
-          "ct": "|NtC1z`(%3$",
+          "ct": "|NsC1z`(%3$",
           "result": "valid"
         },
         {
@@ -17736,7 +17736,7 @@
           "key": "b4c4d6f8f3f635f7bc32228674b53331404627434bb63dbfd650bd8d9c224f6d",
           "tweak": "b72708737a746e25",
           "msg": "2SBH5O|Jrq+",
-          "ct": "|NtC0z`(%3#",
+          "ct": "|NsC0z`(%3#",
           "result": "valid"
         },
         {
@@ -17747,7 +17747,7 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "1e62b617e0369031c820",
-          "msg": "m__oufj+`oE",
+          "msg": "m:_ovfj+`oE",
           "ct": "|*OT|fx!HQT",
           "result": "valid"
         },
@@ -17759,8 +17759,8 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "1e62b617e0369031c820",
-          "msg": "jx+t`@{^DN)",
-          "ct": "pl3A_mmqYmb",
+          "msg": "jx+s`@{^DN)",
+          "ct": "pl3A:mmqYmb",
           "result": "valid"
         },
         {
@@ -17771,7 +17771,7 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "1e62b617e0369031c820",
-          "msg": "j$%tn}DX|t;",
+          "msg": "j$%un}DX|u;",
           "ct": "&SC^_3JM3#b",
           "result": "valid"
         },
@@ -17796,7 +17796,7 @@
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "ed728dfce0e5cd011116",
           "msg": "g<|XX9Y(0r(",
-          "ct": "!<cRt=Y&vRt",
+          "ct": "!<cRs=Y&wRu",
           "result": "valid"
         },
         {
@@ -17819,7 +17819,7 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "ed728dfce0e5cd011116",
-          "msg": "6u6`7XGOBUP",
+          "msg": "6v6`7XGOBUP",
           "ct": "?nmpf!?npdO",
           "result": "valid"
         },
@@ -17832,7 +17832,7 @@
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "ed728dfce0e5cd011116",
           "msg": "{;G_z(n{+I6",
-          "ct": "ms_y=J1)4|W",
+          "ct": "mt_y=J1)4|W",
           "result": "valid"
         },
         {
@@ -17855,8 +17855,8 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4aff365c7e2ce6d3a3a1",
-          "msg": "s_)0~!*Ma7n",
-          "ct": "sH~bZRQ5E0t",
+          "msg": "t:)0~!*Ma7n",
+          "ct": "tH~bZRQ5E0s",
           "result": "valid"
         },
         {
@@ -17868,7 +17868,7 @@
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4aff365c7e2ce6d3a3a1",
           "msg": "xKq{Q<mlH%d",
-          "ct": "5dLypS6s#g7",
+          "ct": "5dLypS6t#g7",
           "result": "valid"
         },
         {
@@ -17891,8 +17891,8 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4aff365c7e2ce6d3a3a1",
-          "msg": "vs4~23q_y<&",
-          "ct": "rEttPs9_T9_",
+          "msg": "wt4~23q:y<&",
+          "ct": "rEsuPt9_T9_",
           "result": "valid"
         },
         {
@@ -17904,7 +17904,7 @@
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4aff365c7e2ce6d3a3a1",
           "msg": "nJ$E<+@U2A{",
-          "ct": "CI@VtNsVltZ",
+          "ct": "CI@VuNtVluZ",
           "result": "valid"
         },
         {
@@ -17916,7 +17916,7 @@
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4aff365c7e2ce6d3a3a1",
           "msg": "b!9W&fJ>`a0",
-          "ct": "T9_v{IFhrkH",
+          "ct": "T9_w{IFhrkH",
           "result": "valid"
         },
         {
@@ -17927,8 +17927,8 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4b587a2ac774cdbb3780",
-          "msg": "$n0=&VNh`u=",
-          "ct": "C8jDtBoZ{Vd",
+          "msg": "$n0=&VNh`v=",
+          "ct": "C8jDuBoZ{Vd",
           "result": "valid"
         },
         {
@@ -17939,8 +17939,8 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4b587a2ac774cdbb3780",
-          "msg": "ki_Qjt>nv3o",
-          "ct": "CT%bch8M=th",
+          "msg": "ki:Qju>nw3o",
+          "ct": "CT%bch8M=sh",
           "result": "valid"
         },
         {
@@ -17952,7 +17952,7 @@
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4b587a2ac774cdbb3780",
           "msg": "RLxOC^E$9Sm",
-          "ct": "~SbF*T!_g$0",
+          "ct": "~SbF*T!:g$0",
           "result": "valid"
         },
         {
@@ -17963,7 +17963,7 @@
           ],
           "key": "b301403ccf58d04adee4d1e9e1ca6e113fe2ebf67e7add4e5a06bb52e63f5f2d",
           "tweak": "4b587a2ac774cdbb3780",
-          "msg": "|5m_4Vg)5~Y",
+          "msg": "|5m:4Vg)5~Y",
           "ct": "JZ9B!JJU>V3",
           "result": "valid"
         },
@@ -17975,8 +17975,8 @@
           ],
           "key": "901a4e20eafbee0bda03506d86368658c521ac7065f8b5a25fb318fa293375ab",
           "tweak": "788f47262b8e7b97",
-          "msg": ".Jk^$S@ughh",
-          "ct": "or!OsKFV^hz",
+          "msg": "-Jk^$S@vghh",
+          "ct": "or!OtKFV^hz",
           "result": "invalid"
         },
         {
@@ -17987,7 +17987,7 @@
           ],
           "key": "901a4e20eafbee0bda03506d86368658c521ac7065f8b5a25fb318fa293375ab",
           "tweak": "788f47262b8e7b97",
-          "msg": "rJk,$S@ughh",
+          "msg": "rJk-$S@vghh",
           "ct": "<FO8`LkV_A|",
           "result": "invalid"
         },
@@ -17999,7 +17999,7 @@
           ],
           "key": "901a4e20eafbee0bda03506d86368658c521ac7065f8b5a25fb318fa293375ab",
           "tweak": "788f47262b8e7b97",
-          "msg": "rJk^$S@ugh.",
+          "msg": "rJk^$S@vgh-",
           "ct": ")UDgke;FzV@",
           "result": "invalid"
         },
@@ -18011,7 +18011,7 @@
           ],
           "key": "103a0a4998e992bf4b74eb7cdebdb7b4b02045b7f702f9e741e767446bc07c75",
           "tweak": "4feb0bf613d06cbc",
-          "msg": "\u007feIvt{g^d|}",
+          "msg": "-eIws{g^d|}",
           "ct": "k9de18Ol#)U",
           "result": "invalid"
         },
@@ -18023,7 +18023,7 @@
           ],
           "key": "103a0a4998e992bf4b74eb7cdebdb7b4b02045b7f702f9e741e767446bc07c75",
           "tweak": "4feb0bf613d06cbc",
-          "msg": "(eI\u007ft{g^d|}",
+          "msg": "(eI-s{g^d|}",
           "ct": ">*Cq?W9A9)+",
           "result": "invalid"
         },
@@ -18035,14 +18035,14 @@
           ],
           "key": "103a0a4998e992bf4b74eb7cdebdb7b4b02045b7f702f9e741e767446bc07c75",
           "tweak": "4feb0bf613d06cbc",
-          "msg": "(eIvt{g^d|\u007f",
-          "ct": "t(X^_*2ttAo",
+          "msg": "(eIws{g^d|-",
+          "ct": "u(X^:*2ssAo",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 12,
       "radix": 85,
@@ -18057,7 +18057,7 @@
           "key": "2e94a84c78be80cd598366058d4f6cdf8095666dcac7a00ad832d9f33e20d13c",
           "tweak": "415e0101a302aaa6",
           "msg": "CgTS$Hq!o}^Y",
-          "ct": "PRjB!xhQ;)v5",
+          "ct": "PRjB!xhQ;)w5",
           "result": "valid"
         },
         {
@@ -18093,7 +18093,7 @@
           "key": "b60d255c76e0f50a9257acac319fb86a00570aa5b23e907c1b7109f732317d65",
           "tweak": "b44b719ef00f7276",
           "msg": "z`(%3$z`(%3$",
-          "ct": "Hru5At58~|hJ",
+          "ct": "Hrv5Au58~|hJ",
           "result": "valid"
         },
         {
@@ -18128,8 +18128,8 @@
           ],
           "key": "b60d255c76e0f50a9257acac319fb86a00570aa5b23e907c1b7109f732317d65",
           "tweak": "b44b719ef00f7276",
-          "msg": "cuck_h{zh*y$",
-          "ct": "{&vJ&kfXt}O3",
+          "msg": "cvck:h{zh*y$",
+          "ct": "{&wJ&kfXs}O3",
           "result": "valid"
         },
         {
@@ -18140,8 +18140,8 @@
           ],
           "key": "b60d255c76e0f50a9257acac319fb86a00570aa5b23e907c1b7109f732317d65",
           "tweak": "b44b719ef00f7276",
-          "msg": "ksOjT(KlEQjQ",
-          "ct": ";1_HFh^!n@m8",
+          "msg": "ktOjT(KlEQjQ",
+          "ct": ";1:HFh^!n@m8",
           "result": "valid"
         },
         {
@@ -18152,7 +18152,7 @@
           ],
           "key": "b60d255c76e0f50a9257acac319fb86a00570aa5b23e907c1b7109f732317d65",
           "tweak": "b44b719ef00f7276",
-          "msg": "e=Qtg)vGdQ(t",
+          "msg": "e=Qug)wGdQ(s",
           "ct": "z#kaDVG#<H`W",
           "result": "valid"
         },
@@ -18176,8 +18176,8 @@
           ],
           "key": "b60d255c76e0f50a9257acac319fb86a00570aa5b23e907c1b7109f732317d65",
           "tweak": "b44b719ef00f7276",
-          "msg": "V}AP4_?t`DqD",
-          "ct": "_ZZ0olbO4574",
+          "msg": "V}AP4:?u`DqD",
+          "ct": ":ZZ0olbO4574",
           "result": "valid"
         },
         {
@@ -18188,7 +18188,7 @@
           ],
           "key": "b60d255c76e0f50a9257acac319fb86a00570aa5b23e907c1b7109f732317d65",
           "tweak": "b44b719ef00f7276",
-          "msg": "~cuss>Xe!&Mt",
+          "msg": "~cvtt>Xe!&Mu",
           "ct": "&LLbIbd!zeE%",
           "result": "valid"
         },
@@ -18212,7 +18212,7 @@
           ],
           "key": "b60d255c76e0f50a9257acac319fb86a00570aa5b23e907c1b7109f732317d65",
           "tweak": "b44b719ef00f7276",
-          "msg": "_8{`5bKEak7%",
+          "msg": ":8{`5bKEak7%",
           "ct": "000000000000",
           "result": "valid"
         },
@@ -18224,7 +18224,7 @@
           ],
           "key": "b60d255c76e0f50a9257acac319fb86a00570aa5b23e907c1b7109f732317d65",
           "tweak": "b44b719ef00f7276",
-          "msg": "f?U@SEutd)Mq",
+          "msg": "f?U@SEvsd)Mq",
           "ct": "~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -18260,7 +18260,7 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "c93aa0a1fa75e4c71231",
-          "msg": "}cmt<0nZHI92",
+          "msg": "}cms<0nZHI92",
           "ct": "000000ePLnoV",
           "result": "valid"
         },
@@ -18272,7 +18272,7 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "c93aa0a1fa75e4c71231",
-          "msg": "FJm!r&@6#_(e",
+          "msg": "FJm!r&@6#:(e",
           "ct": "000001$FzmLD",
           "result": "valid"
         },
@@ -18297,7 +18297,7 @@
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "c93aa0a1fa75e4c71231",
           "msg": "Az|$Qo_3mB6Z",
-          "ct": "~~~~~~0iatjW",
+          "ct": "~~~~~~0iasjW",
           "result": "valid"
         },
         {
@@ -18308,8 +18308,8 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "8b00b9a1df7608cbfddb",
-          "msg": "l=zav@@)_cp<",
-          "ct": "*40Kmi_Pnpj4",
+          "msg": "l=zaw@@):cp<",
+          "ct": "*40Kmi:Pnpj4",
           "result": "valid"
         },
         {
@@ -18320,7 +18320,7 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "8b00b9a1df7608cbfddb",
-          "msg": "saB83uYuW%?h",
+          "msg": "taB83vYvW%?h",
           "ct": "ZQEoe(OIq7&#",
           "result": "valid"
         },
@@ -18332,8 +18332,8 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "8b00b9a1df7608cbfddb",
-          "msg": "|{KtG0~+BIR6",
-          "ct": "p3_AyW#%j_EC",
+          "msg": "|{KsG0~+BIR6",
+          "ct": "p3_AyW#%j:EC",
           "result": "valid"
         },
         {
@@ -18356,8 +18356,8 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "8b00b9a1df7608cbfddb",
-          "msg": "_ntE^~(^I$kZ",
-          "ct": "JcI`}t<zct7N",
+          "msg": ":nsE^~(^I$kZ",
+          "ct": "JcI`}s<zcu7N",
           "result": "valid"
         },
         {
@@ -18368,8 +18368,8 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "192ff34b963f884f5848",
-          "msg": "s0{0;y$_oXDZ",
-          "ct": "|vK{8`#i{~a0",
+          "msg": "t0{0;y$_oXDZ",
+          "ct": "|wK{8`#i{~a0",
           "result": "valid"
         },
         {
@@ -18380,8 +18380,8 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "192ff34b963f884f5848",
-          "msg": "24kt~UGA*)GK",
-          "ct": "|vK{8`#i{~a1",
+          "msg": "24ku~UGA*)GK",
+          "ct": "|wK{8`#i{~a1",
           "result": "valid"
         },
         {
@@ -18393,7 +18393,7 @@
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "192ff34b963f884f5848",
           "msg": "W@N|&1&z>|)W",
-          "ct": "|vK{8`~~~~~~",
+          "ct": "|wK{8`~~~~~~",
           "result": "valid"
         },
         {
@@ -18405,7 +18405,7 @@
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "192ff34b963f884f5848",
           "msg": "L_f}1DT7DFKm",
-          "ct": "|vK{8`000000",
+          "ct": "|wK{8`000000",
           "result": "valid"
         },
         {
@@ -18416,8 +18416,8 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "192ff34b963f884f5848",
-          "msg": "EUeF8ZJ+ur_1",
-          "ct": "|vK{8`ee$$d$",
+          "msg": "EUeF8ZJ+vr:1",
+          "ct": "|wK{8`ee$$d$",
           "result": "valid"
         },
         {
@@ -18428,8 +18428,8 @@
           ],
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "192ff34b963f884f5848",
-          "msg": "i?K0U2|xxitk",
-          "ct": "|vK{8`#i{~Z~",
+          "msg": "i?K0U2|xxiuk",
+          "ct": "|wK{8`#i{~Z~",
           "result": "valid"
         },
         {
@@ -18465,7 +18465,7 @@
           "key": "861999d41d37e2d41583f3ccf1d1c5c7b17e2d7e1ae424b890bf54f3bc3a8388",
           "tweak": "f5a7379bfb38a0f2b9bc",
           "msg": "`C1H;@z`(%3$",
-          "ct": "<i$X*2FtB%Rl",
+          "ct": "<i$X*2FsB%Rl",
           "result": "valid"
         },
         {
@@ -18488,7 +18488,7 @@
           ],
           "key": "0a547ba6ebfb1197879939263dc827e988ebfffb7305b8926e64a1308ad32ac3",
           "tweak": "17f2087530ca7e57",
-          "msg": "[=N`65D4T^Ah",
+          "msg": "-=N`65D4T^Ah",
           "ct": "jF%{+DRgBi?y",
           "result": "invalid"
         },
@@ -18500,7 +18500,7 @@
           ],
           "key": "0a547ba6ebfb1197879939263dc827e988ebfffb7305b8926e64a1308ad32ac3",
           "tweak": "17f2087530ca7e57",
-          "msg": "^=N`w5D4T^Ah",
+          "msg": "^=N`-5D4T^Ah",
           "ct": "LI$CUF8PCriF",
           "result": "invalid"
         },
@@ -18512,7 +18512,7 @@
           ],
           "key": "0a547ba6ebfb1197879939263dc827e988ebfffb7305b8926e64a1308ad32ac3",
           "tweak": "17f2087530ca7e57",
-          "msg": "^=N`65D4T^A[",
+          "msg": "^=N`65D4T^A-",
           "ct": "0_Bel;r41Ir5",
           "result": "invalid"
         },
@@ -18524,8 +18524,8 @@
           ],
           "key": "7c40581a06d4b952510199f33631dc976df4ee31dc337d35b80b7b223f77ca65",
           "tweak": "cd203b308b844c45",
-          "msg": "\u007f5p>uB3ZU0WS",
-          "ct": "F^;gfhieP!~t",
+          "msg": "-5p>vB3ZU0WS",
+          "ct": "F^;gfhieP!~s",
           "result": "invalid"
         },
         {
@@ -18536,8 +18536,8 @@
           ],
           "key": "7c40581a06d4b952510199f33631dc976df4ee31dc337d35b80b7b223f77ca65",
           "tweak": "cd203b308b844c45",
-          "msg": "z5p>\u007fB3ZU0WS",
-          "ct": ";fsr$MsW9YVU",
+          "msg": "z5p>-B3ZU0WS",
+          "ct": ";ftr$MtW9YVU",
           "result": "invalid"
         },
         {
@@ -18548,14 +18548,14 @@
           ],
           "key": "7c40581a06d4b952510199f33631dc976df4ee31dc337d35b80b7b223f77ca65",
           "tweak": "cd203b308b844c45",
-          "msg": "z5p>uB3ZU0W\u007f",
-          "ct": "tZ5u6yJOt3EF",
+          "msg": "z5p>vB3ZU0W-",
+          "ct": "sZ5v6yJOu3EF",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 13,
       "radix": 85,
@@ -18582,7 +18582,7 @@
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
           "msg": "0000000000000",
-          "ct": "urd_ot$5@_R*m",
+          "ct": "vrd_ou$5@_R*m",
           "result": "valid"
         },
         {
@@ -18594,7 +18594,7 @@
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
           "msg": "~~~~~~~~~~~~~",
-          "ct": "Wc)JT%BLx`nku",
+          "ct": "Wc)JT%BLx`nkv",
           "result": "valid"
         },
         {
@@ -18605,7 +18605,7 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "z`(%3$kt_1|+G",
+          "msg": "z`(%3$ks:1|+G",
           "ct": "k?R#%xcmMl1Fk",
           "result": "valid"
         },
@@ -18617,8 +18617,8 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "z`(%3#kt_1|+F",
-          "ct": "H*{~dtkKHxzEt",
+          "msg": "z`(%3#ks:1|+F",
+          "ct": "H*{~dskKHxzEu",
           "result": "valid"
         },
         {
@@ -18629,8 +18629,8 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "T}R>t2PgA%_|x",
-          "ct": ";x3GRmt;C>!0U",
+          "msg": "T}R>u2PgA%_|x",
+          "ct": ";x3GRms;C>!0U",
           "result": "valid"
         },
         {
@@ -18641,8 +18641,8 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "a>GivIMyden@(",
-          "ct": "=M+5Qaz4tVrx@",
+          "msg": "a>GiwIMyden@(",
+          "ct": "=M+5Qaz4uVrx@",
           "result": "valid"
         },
         {
@@ -18665,8 +18665,8 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": ")j=c_xuOoT5Nb",
-          "ct": "@?3%X7%b2r1tL",
+          "msg": ")j=c:xvOoT5Nb",
+          "ct": "@?3%X7%b2r1sL",
           "result": "valid"
         },
         {
@@ -18677,7 +18677,7 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "D>*!v=K16k01R",
+          "msg": "D>*!w=K16k01R",
           "ct": "JFMmD>O3o4Vx2",
           "result": "valid"
         },
@@ -18689,8 +18689,8 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "RXc~0#bDmCEKt",
-          "ct": "e%tE!P`0L>FNp",
+          "msg": "RXc~0#bDmCEKu",
+          "ct": "e%uE!P`0L>FNp",
           "result": "valid"
         },
         {
@@ -18701,7 +18701,7 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "4F`~EyUsj^5_r",
+          "msg": "4F`~EyUtj^5:r",
           "ct": "6JmedY+H^ZGFc",
           "result": "valid"
         },
@@ -18713,7 +18713,7 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "9W2px3hZ(o^s`",
+          "msg": "9W2px3hZ(o^t`",
           "ct": "Bl6cNb>eNjaD|",
           "result": "valid"
         },
@@ -18737,7 +18737,7 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "V98pXOk|p5pve",
+          "msg": "V98pXOk|p5pwe",
           "ct": "~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -18749,8 +18749,8 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "nX|0s<b?mg9gm",
-          "ct": "z`(%3$kt_1|+G",
+          "msg": "nX|0t<b?mg9gm",
+          "ct": "z`(%3$ks:1|+G",
           "result": "valid"
         },
         {
@@ -18761,8 +18761,8 @@
           ],
           "key": "ade9f36d2b83daa75a62a4a0c53a95e186c290e7a8f2c8e0911025d44bccf554",
           "tweak": "d5479b1a88388aa8",
-          "msg": "v}|R*=1l9G1NQ",
-          "ct": "z`(%3#kt_1|+F",
+          "msg": "w}|R*=1l9G1NQ",
+          "ct": "z`(%3#ks:1|+F",
           "result": "valid"
         },
         {
@@ -18773,7 +18773,7 @@
           ],
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "f021b42c018df529dc",
-          "msg": "V!DtQTjqoK!t?",
+          "msg": "V!DsQTjqoK!u?",
           "ct": "6YeJ<01Lyc~JJ",
           "result": "valid"
         },
@@ -18785,7 +18785,7 @@
           ],
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "f021b42c018df529dc",
-          "msg": "KtetID%1)Di(s",
+          "msg": "KseuID%1)Di(t",
           "ct": "!4eC~%Whz~WN_",
           "result": "valid"
         },
@@ -18797,8 +18797,8 @@
           ],
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "f021b42c018df529dc",
-          "msg": "xLEjT_1r}XM|_",
-          "ct": "o%k`JACtkRHlD",
+          "msg": "xLEjT:1r}XM|_",
+          "ct": "o%k`JACukRHlD",
           "result": "valid"
         },
         {
@@ -18809,8 +18809,8 @@
           ],
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "f021b42c018df529dc",
-          "msg": "lhMmVsXA%a_Y7",
-          "ct": "sT!ygehNv`8dj",
+          "msg": "lhMmVtXA%a_Y7",
+          "ct": "tT!ygehNw`8dj",
           "result": "valid"
         },
         {
@@ -18834,7 +18834,7 @@
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "4f63cab2b7c6983b12",
           "msg": "ZzxD7rcn5J4I!",
-          "ct": "uy9|IIY0aGaFQ",
+          "ct": "vy9|IIY0aGaFQ",
           "result": "valid"
         },
         {
@@ -18845,8 +18845,8 @@
           ],
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "4f63cab2b7c6983b12",
-          "msg": "_}VH_GWaB`<3l",
-          "ct": "zCtt8O{Wj25zB",
+          "msg": ":}VH_GWaB`<3l",
+          "ct": "zCss8O{Wj25zB",
           "result": "valid"
         },
         {
@@ -18870,7 +18870,7 @@
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "4f63cab2b7c6983b12",
           "msg": "czZ1;^cUe&@4F",
-          "ct": "EtXU`7({<(Q79",
+          "ct": "EsXU`7({<(Q79",
           "result": "valid"
         },
         {
@@ -18906,7 +18906,7 @@
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "1b21ea658251aadb1b",
           "msg": "Le30m~)o(E!#R",
-          "ct": "ihhc=zFp;t|i_",
+          "ct": "ihhc=zFp;s|i_",
           "result": "valid"
         },
         {
@@ -18930,7 +18930,7 @@
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "1b21ea658251aadb1b",
           "msg": "z`(%3$)o(E!#R",
-          "ct": "ua_cJo!zJLm6X",
+          "ct": "va_cJo!zJLm6X",
           "result": "valid"
         },
         {
@@ -18942,7 +18942,7 @@
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "1b21ea658251aadb1b",
           "msg": "~~~~~~)o(E!#R",
-          "ct": "dI^f1FuoQz$Ry",
+          "ct": "dI^f1FvoQz$Ry",
           "result": "valid"
         },
         {
@@ -18977,7 +18977,7 @@
           ],
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "77f1055c731c0d8daa",
-          "msg": "srHti1_UB6qT^",
+          "msg": "trHui1_UB6qT^",
           "ct": "OI;n@om<FIUqn",
           "result": "valid"
         },
@@ -18989,8 +18989,8 @@
           ],
           "key": "8a5595a9b6bdd44b6dcb3f4ba823c09348b1dad24b727321c2642d2aff4c914d",
           "tweak": "77f1055c731c0d8daa",
-          "msg": "=#>D9fDbv#a}^",
-          "ct": "fI8$L!4=oS<Ps",
+          "msg": "=#>D9fDbw#a}^",
+          "ct": "fI8$L!4=oS<Pt",
           "result": "valid"
         },
         {
@@ -19001,8 +19001,8 @@
           ],
           "key": "41bd4edbbcbebf09c9cbf4bb2cb2160fdd8c598a438075186f8723697e2ff002",
           "tweak": "f39c64c847f175d6",
-          "msg": ":Q6^R(+h!{%Kr",
-          "ct": "vbEdJ4GHMesGm",
+          "msg": "-Q6^R(+h!{%Kr",
+          "ct": "wbEdJ4GHMetGm",
           "result": "invalid"
         },
         {
@@ -19013,8 +19013,8 @@
           ],
           "key": "41bd4edbbcbebf09c9cbf4bb2cb2160fdd8c598a438075186f8723697e2ff002",
           "tweak": "f39c64c847f175d6",
-          "msg": "=Q6^'(+h!{%Kr",
-          "ct": "G)uW4xodZA%4}",
+          "msg": "=Q6^-(+h!{%Kr",
+          "ct": "G)vW4xodZA%4}",
           "result": "invalid"
         },
         {
@@ -19025,7 +19025,7 @@
           ],
           "key": "41bd4edbbcbebf09c9cbf4bb2cb2160fdd8c598a438075186f8723697e2ff002",
           "tweak": "f39c64c847f175d6",
-          "msg": "=Q6^R(+h!{%K,",
+          "msg": "=Q6^R(+h!{%K-",
           "ct": "%GK;#8}lGG^j#",
           "result": "invalid"
         },
@@ -19037,7 +19037,7 @@
           ],
           "key": "26a9c91c4e344a84cf50aa9849cc33dbeee68cf1f54b4b47b78a809a72617072",
           "tweak": "96b981c46f71f2da",
-          "msg": "\u007fJv4>0boh*a)3",
+          "msg": "-Jw4>0boh*a)3",
           "ct": "nZ;fD{c1MyZ_5",
           "result": "invalid"
         },
@@ -19049,7 +19049,7 @@
           ],
           "key": "26a9c91c4e344a84cf50aa9849cc33dbeee68cf1f54b4b47b78a809a72617072",
           "tweak": "96b981c46f71f2da",
-          "msg": "(Jv4\u007f0boh*a)3",
+          "msg": "(Jw4-0boh*a)3",
           "ct": "N)#JDky4L<p<C",
           "result": "invalid"
         },
@@ -19061,14 +19061,14 @@
           ],
           "key": "26a9c91c4e344a84cf50aa9849cc33dbeee68cf1f54b4b47b78a809a72617072",
           "tweak": "96b981c46f71f2da",
-          "msg": "(Jv4>0boh*a)\u007f",
+          "msg": "(Jw4>0boh*a)-",
           "ct": "{(m02b2iY)azH",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 14,
       "radix": 85,
@@ -19082,8 +19082,8 @@
           ],
           "key": "fdd21f2020d809a2930f3d6c0b2cc23e65e1240eb5e301531aecb8180808393b",
           "tweak": "104403ed1d3acccc",
-          "msg": "F5E_uFhgM7PP3Y",
-          "ct": "P0YVUnkt^S15_t",
+          "msg": "F5E_vFhgM7PP3Y",
+          "ct": "P0YVUnks^S15:u",
           "result": "valid"
         },
         {
@@ -19095,7 +19095,7 @@
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
           "msg": "00000000000000",
-          "ct": "jJfmtY08N&2PW;",
+          "ct": "jJfmsY08N&2PW;",
           "result": "valid"
         },
         {
@@ -19118,8 +19118,8 @@
           ],
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
-          "msg": "kt_1|+Gkt_1|+G",
-          "ct": "WOZAnt2C+brjt?",
+          "msg": "ks:1|+Gks:1|+G",
+          "ct": "WOZAns2C+brju?",
           "result": "valid"
         },
         {
@@ -19130,8 +19130,8 @@
           ],
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
-          "msg": "kt_1|+Fkt_1|+F",
-          "ct": "h6lPzs9_GHTiZI",
+          "msg": "ks:1|+Fks:1|+F",
+          "ct": "h6lPzt9_GHTiZI",
           "result": "valid"
         },
         {
@@ -19143,7 +19143,7 @@
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
           "msg": "62LTnrBV&Y|kgY",
-          "ct": "a?mufK_moh@nfE",
+          "ct": "a?mvfK:moh@nfE",
           "result": "valid"
         },
         {
@@ -19155,7 +19155,7 @@
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
           "msg": "FR7ZBCm}xZhS>U",
-          "ct": "qs3DB6f+sc73eq",
+          "ct": "qt3DB6f+tc73eq",
           "result": "valid"
         },
         {
@@ -19178,7 +19178,7 @@
           ],
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
-          "msg": "ohL)hf#)LiShtX",
+          "msg": "ohL)hf#)LiShuX",
           "ct": "n|{*qG%U~j~?+i",
           "result": "valid"
         },
@@ -19190,8 +19190,8 @@
           ],
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
-          "msg": "_uGxQL8Rx=l}Ds",
-          "ct": "+GMsH>30xiB#7)",
+          "msg": ":vGxQL8Rx=l}Dt",
+          "ct": "+GMtH>30xiB#7)",
           "result": "valid"
         },
         {
@@ -19203,7 +19203,7 @@
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
           "msg": "VL;pg{khU=<r8G",
-          "ct": "JyNUiQyUxMsDWL",
+          "ct": "JyNUiQyUxMtDWL",
           "result": "valid"
         },
         {
@@ -19215,7 +19215,7 @@
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
           "msg": "5>x4(Mq3Q%<81G",
-          "ct": ">_(YslXTgoe^qD",
+          "ct": ">:(YtlXTgoe^qD",
           "result": "valid"
         },
         {
@@ -19226,8 +19226,8 @@
           ],
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
-          "msg": ">O@|R$=ks6oz+?",
-          "ct": "ApR6T}sy)}U9eD",
+          "msg": ">O@|R$=kt6oz+?",
+          "ct": "ApR6T}ty)}U9eD",
           "result": "valid"
         },
         {
@@ -19250,7 +19250,7 @@
           ],
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
-          "msg": ">!#b#Nmc{~UsNp",
+          "msg": ">!#b#Nmc{~UtNp",
           "ct": "~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -19262,8 +19262,8 @@
           ],
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
-          "msg": "Kx1;TgU~)NsMUC",
-          "ct": "kt_1|+Gkt_1|+G",
+          "msg": "Kx1;TgU~)NtMUC",
+          "ct": "ks:1|+Gks:1|+G",
           "result": "valid"
         },
         {
@@ -19274,8 +19274,8 @@
           ],
           "key": "659f4710280b6825b9ea3ce86327020ae32fa2fb3c3b71743bab9fba3feaecf0",
           "tweak": "f9993f625da88752",
-          "msg": "t&$Q(Fd})tXz3R",
-          "ct": "kt_1|+Fkt_1|+F",
+          "msg": "s&$Q(Fd})sXz3R",
+          "ct": "ks:1|+Fks:1|+F",
           "result": "valid"
         },
         {
@@ -19286,7 +19286,7 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "baaf1a5fb0a65c9b64",
-          "msg": "sc0!t_sgVSnWK;",
+          "msg": "tc0!s_tgVSnWK;",
           "ct": "JNr?41Ie(;WV#4",
           "result": "valid"
         },
@@ -19298,8 +19298,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "baaf1a5fb0a65c9b64",
-          "msg": "?u~H97xv(xkb{f",
-          "ct": "3;Fx0#D9Dps}PC",
+          "msg": "?v~H97xw(xkb{f",
+          "ct": "3;Fx0#D9Dpt}PC",
           "result": "valid"
         },
         {
@@ -19322,7 +19322,7 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "baaf1a5fb0a65c9b64",
-          "msg": "gFU2ymKBvO;A@2",
+          "msg": "gFU2ymKBwO;A@2",
           "ct": "RL?l(Zc$f*~y*T",
           "result": "valid"
         },
@@ -19334,8 +19334,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "802f47fe4fc5043928",
-          "msg": "sie8H*qnT8G~`K",
-          "ct": "_>I*oJB?eI!t60",
+          "msg": "tie8H*qnT8G~`K",
+          "ct": ":>I*oJB?eI!s60",
           "result": "valid"
         },
         {
@@ -19347,7 +19347,7 @@
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "802f47fe4fc5043928",
           "msg": "YS<G0<ejk}bRB%",
-          "ct": "x%9#a!`1t2+{5g",
+          "ct": "x%9#a!`1s2+{5g",
           "result": "valid"
         },
         {
@@ -19358,8 +19358,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "802f47fe4fc5043928",
-          "msg": "RqP<YtR_!`Xs{x",
-          "ct": "r{;0vN{Jr}>tN3",
+          "msg": "RqP<YuR_!`Xt{x",
+          "ct": "r{;0wN{Jr}>sN3",
           "result": "valid"
         },
         {
@@ -19370,8 +19370,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "802f47fe4fc5043928",
-          "msg": "{5T8*%txVe#2#Y",
-          "ct": "6te!c4EQY)D4~^",
+          "msg": "{5T8*%uxVe#2#Y",
+          "ct": "6ue!c4EQY)D4~^",
           "result": "valid"
         },
         {
@@ -19382,7 +19382,7 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "802f47fe4fc5043928",
-          "msg": "^xuIR5op(|2q2Z",
+          "msg": "^xvIR5op(|2q2Z",
           "ct": "6CC8jxXk4zz2Q+",
           "result": "valid"
         },
@@ -19394,8 +19394,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "129337bcdbad2897c2",
-          "msg": "9VtC`=V%m0v_#A",
-          "ct": "?<t4R|*8W_tj_d",
+          "msg": "9VuC`=V%m0w:#A",
+          "ct": "?<u4R|*8W_uj:d",
           "result": "valid"
         },
         {
@@ -19406,8 +19406,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "129337bcdbad2897c2",
-          "msg": "R80_t(D00oY2#v",
-          "ct": "{1QnOtRc}uagdY",
+          "msg": "R80_s(D00oY2#w",
+          "ct": "{1QnOsRc}vagdY",
           "result": "valid"
         },
         {
@@ -19419,7 +19419,7 @@
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "129337bcdbad2897c2",
           "msg": "57QU604z3^%iL4",
-          "ct": ";6;Z4>_@u;h8;z",
+          "ct": ";6;Z4>:@v;h8;z",
           "result": "valid"
         },
         {
@@ -19430,8 +19430,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "129337bcdbad2897c2",
-          "msg": "BFoob!T#D6a3_C",
-          "ct": "*8LR}eQ1%ra@t0",
+          "msg": "BFoob!T#D6a3:C",
+          "ct": "*8LR}eQ1%ra@s0",
           "result": "valid"
         },
         {
@@ -19455,7 +19455,7 @@
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "129337bcdbad2897c2",
           "msg": "nD}U%0q?LH}{zf",
-          "ct": "NfvEsY3RhBFMRa",
+          "ct": "NfwEtY3RhBFMRa",
           "result": "valid"
         },
         {
@@ -19467,7 +19467,7 @@
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "f09aa6d8b9db515797",
           "msg": "*LZ;)5~foIN7U|",
-          "ct": "xtUiQ4o3_6$rhG",
+          "ct": "xuUiQ4o3_6$rhG",
           "result": "valid"
         },
         {
@@ -19478,8 +19478,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "f09aa6d8b9db515797",
-          "msg": "nhzvk6*LQz4L|f",
-          "ct": "51?i3c0ZuoNOoz",
+          "msg": "nhzwk6*LQz4L|f",
+          "ct": "51?i3c0ZvoNOoz",
           "result": "valid"
         },
         {
@@ -19491,7 +19491,7 @@
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "f09aa6d8b9db515797",
           "msg": "*%>)1YH8K=P3V2",
-          "ct": "E3}nB$`vkOe%qK",
+          "ct": "E3}nB$`wkOe%qK",
           "result": "valid"
         },
         {
@@ -19502,8 +19502,8 @@
           ],
           "key": "7aa4ce6da24d8aaa932569ec8af27545aa0cdf67d6b7f2ab8280aca78d6ea3ae",
           "tweak": "f09aa6d8b9db515797",
-          "msg": "4L5n^0)IM|?NM_",
-          "ct": "c;bnW(*xAv{DJ@",
+          "msg": "4L5n^0)IM|?NM:",
+          "ct": "c;bnW(*xAw{DJ@",
           "result": "valid"
         },
         {
@@ -19514,8 +19514,8 @@
           ],
           "key": "1466d3ff2c010295a29430998dcef0f39d9f6659a18fbac1fced707431575235",
           "tweak": "00f218eb912f6eeb",
-          "msg": "/5rALb8c8Q6>{`",
-          "ct": "sHvz|6r3NEmF@1",
+          "msg": "-5rALb8c8Q6>{`",
+          "ct": "tHwz|6r3NEmF@1",
           "result": "invalid"
         },
         {
@@ -19526,8 +19526,8 @@
           ],
           "key": "1466d3ff2c010295a29430998dcef0f39d9f6659a18fbac1fced707431575235",
           "tweak": "00f218eb912f6eeb",
-          "msg": "A5rA[b8c8Q6>{`",
-          "ct": "+^NW5=DpA{6tsg",
+          "msg": "A5rA-b8c8Q6>{`",
+          "ct": "+^NW5=DpA{6utg",
           "result": "invalid"
         },
         {
@@ -19538,8 +19538,8 @@
           ],
           "key": "1466d3ff2c010295a29430998dcef0f39d9f6659a18fbac1fced707431575235",
           "tweak": "00f218eb912f6eeb",
-          "msg": "A5rALb8c8Q6>{.",
-          "ct": "u_h%g$@e|Cs#RI",
+          "msg": "A5rALb8c8Q6>{-",
+          "ct": "v:h%g$@e|Ct#RI",
           "result": "invalid"
         },
         {
@@ -19550,8 +19550,8 @@
           ],
           "key": "76e91e7985b9d8a2c044b72b616187aa2436cf86a0bbe6568e11613024fa1e36",
           "tweak": "328614413392fde8",
-          "msg": "\u007fly9j_AU3CY41J",
-          "ct": "JQ$5|_G=LH8HL{",
+          "msg": "-ly9j:AU3CY41J",
+          "ct": "JQ$5|:G=LH8HL{",
           "result": "invalid"
         },
         {
@@ -19562,8 +19562,8 @@
           ],
           "key": "76e91e7985b9d8a2c044b72b616187aa2436cf86a0bbe6568e11613024fa1e36",
           "tweak": "328614413392fde8",
-          "msg": "Hly9\u007f_AU3CY41J",
-          "ct": "{@nn~u(sk)Qlq_",
+          "msg": "Hly9-:AU3CY41J",
+          "ct": "{@nn~v(tk)Qlq_",
           "result": "invalid"
         },
         {
@@ -19574,14 +19574,14 @@
           ],
           "key": "76e91e7985b9d8a2c044b72b616187aa2436cf86a0bbe6568e11613024fa1e36",
           "tweak": "328614413392fde8",
-          "msg": "Hly9j_AU3CY41\u007f",
-          "ct": "BfjHV+;LksiT2g",
+          "msg": "Hly9j:AU3CY41-",
+          "ct": "BfjHV+;LktiT2g",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 15,
       "radix": 85,
@@ -19595,8 +19595,8 @@
           ],
           "key": "2f9e5c52ea98009130c5c4302ab79c69e9b89a3871ef8b13d04e3cb3ab09d963",
           "tweak": "c6eca51b923fbd6f",
-          "msg": "BW^k}ihtlcQzXz^",
-          "ct": "xTWN$F6`J_1g*ff",
+          "msg": "BW^k}ihslcQzXz^",
+          "ct": "xTWN$F6`J:1g*ff",
           "result": "valid"
         },
         {
@@ -19608,7 +19608,7 @@
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
           "msg": "000000000000000",
-          "ct": "lJz57pBspNuud>{",
+          "ct": "lJz57pBtpNvvd>{",
           "result": "valid"
         },
         {
@@ -19620,7 +19620,7 @@
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
           "msg": "~~~~~~~~~~~~~~~",
-          "ct": "tiYUF3j3E$ZDx~S",
+          "ct": "uiYUF3j3E$ZDx~S",
           "result": "valid"
         },
         {
@@ -19631,7 +19631,7 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "kt_1|+G+Km`|zx8",
+          "msg": "ks:1|+G+Km`|zx8",
           "ct": "L+lRT;~3TV(opU9",
           "result": "valid"
         },
@@ -19643,8 +19643,8 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "kt_1|+F+Km`|zx7",
-          "ct": "hnvvogbd;^R>5Hg",
+          "msg": "ks:1|+F+Km`|zx7",
+          "ct": "hnwwogbd;^R>5Hg",
           "result": "valid"
         },
         {
@@ -19655,8 +19655,8 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "7O_xVx`d<W_1@Q&",
-          "ct": "yU=viMqW=@%W|;K",
+          "msg": "7O:xVx`d<W:1@Q&",
+          "ct": "yU=wiMqW=@%W|;K",
           "result": "valid"
         },
         {
@@ -19667,8 +19667,8 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "smeCHCFtttlYiEZ",
-          "ct": "PyMe&+1rv;M*K?W",
+          "msg": "tmeCHCFsuslYiEZ",
+          "ct": "PyMe&+1rw;M*K?W",
           "result": "valid"
         },
         {
@@ -19691,8 +19691,8 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "ZEEbCtQ+<+0;}ft",
-          "ct": "3jP()rp4*tNYF6F",
+          "msg": "ZEEbCuQ+<+0;}fs",
+          "ct": "3jP()rp4*sNYF6F",
           "result": "valid"
         },
         {
@@ -19727,8 +19727,8 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "B;pK_~)pZ#^EMQZ",
-          "ct": "nE{M$?mc!%dr^ms",
+          "msg": "B;pK:~)pZ#^EMQZ",
+          "ct": "nE{M$?mc!%dr^mt",
           "result": "valid"
         },
         {
@@ -19739,7 +19739,7 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "}8>KSFFqt8NP!{7",
+          "msg": "}8>KSFFqu8NP!{7",
           "ct": "2bXF3ZQ|gLS}EEz",
           "result": "valid"
         },
@@ -19751,7 +19751,7 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": ">A5tm(&$9}02gX4",
+          "msg": ">A5sm(&$9}02gX4",
           "ct": "000000000000000",
           "result": "valid"
         },
@@ -19775,8 +19775,8 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "IzMUy&0*B~#_&tX",
-          "ct": "kt_1|+G+Km`|zx8",
+          "msg": "IzMUy&0*B~#:&sX",
+          "ct": "ks:1|+G+Km`|zx8",
           "result": "valid"
         },
         {
@@ -19787,8 +19787,8 @@
           ],
           "key": "f5154d6608106f28fa5b2cdab5612dc9cd1608fc8c3c043f0bd2712e7e1fee2a",
           "tweak": "9a4d59b9efd8816a",
-          "msg": "#d2pTANuzz_#4_b",
-          "ct": "kt_1|+F+Km`|zx7",
+          "msg": "#d2pTANvzz_#4:b",
+          "ct": "ks:1|+F+Km`|zx7",
           "result": "valid"
         },
         {
@@ -19799,8 +19799,8 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "aeac75539f7d1616",
-          "msg": "u!!#X79+De+^&{J",
-          "ct": "EvjtnjW~G>kW+kY",
+          "msg": "v!!#X79+De+^&{J",
+          "ct": "EwjsnjW~G>kW+kY",
           "result": "valid"
         },
         {
@@ -19811,8 +19811,8 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "aeac75539f7d1616",
-          "msg": "@Q|u$A1LW~X7jN*",
-          "ct": "1AWbjMCX`$~T69s",
+          "msg": "@Q|v$A1LW~X7jN*",
+          "ct": "1AWbjMCX`$~T69t",
           "result": "valid"
         },
         {
@@ -19835,7 +19835,7 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "aeac75539f7d1616",
-          "msg": "+jS4A`4^a5FIsOZ",
+          "msg": "+jS4A`4^a5FItOZ",
           "ct": "hy43h7_5CJam~0^",
           "result": "valid"
         },
@@ -19848,7 +19848,7 @@
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "8faf90ee3bfaf2da",
           "msg": "0000000`R{J|WIy",
-          "ct": "jO_Xu{xIG+Dpe0*",
+          "ct": "jO:Xv{xIG+Dpe0*",
           "result": "valid"
         },
         {
@@ -19860,7 +19860,7 @@
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "8faf90ee3bfaf2da",
           "msg": "0000001`R{J|WIy",
-          "ct": "Q;gv2Os9r2tH)Xo",
+          "ct": "Q;gw2Ot9r2uH)Xo",
           "result": "valid"
         },
         {
@@ -19871,7 +19871,7 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "8faf90ee3bfaf2da",
-          "msg": "kt_1|+G`R{J|WIy",
+          "msg": "ks:1|+G`R{J|WIy",
           "ct": "I0@!!IaINL28{)x",
           "result": "valid"
         },
@@ -19884,7 +19884,7 @@
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "8faf90ee3bfaf2da",
           "msg": "~~~~~~}`R{J|WIy",
-          "ct": "5??%yppk07F2o~s",
+          "ct": "5??%yppk07F2o~t",
           "result": "valid"
         },
         {
@@ -19896,7 +19896,7 @@
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "8faf90ee3bfaf2da",
           "msg": "~~~~~~~`R{J|WIy",
-          "ct": "L`j=`Dsj$T#`)_C",
+          "ct": "L`j=`Dtj$T#`):C",
           "result": "valid"
         },
         {
@@ -19907,8 +19907,8 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "99fd7266c73a9ad9",
-          "msg": "0000000lSM&qn&t",
-          "ct": "6#pGta^gC|dro&<",
+          "msg": "0000000lSM&qn&u",
+          "ct": "6#pGua^gC|dro&<",
           "result": "valid"
         },
         {
@@ -19919,8 +19919,8 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "99fd7266c73a9ad9",
-          "msg": "0000001lSM&qn&t",
-          "ct": "s&X8Tse5Vsdm#8G",
+          "msg": "0000001lSM&qn&u",
+          "ct": "t&X8Tte5Vtdm#8G",
           "result": "valid"
         },
         {
@@ -19931,8 +19931,8 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "99fd7266c73a9ad9",
-          "msg": "kt_1|+GlSM&qn&t",
-          "ct": "zmY?U%sG#^B3p{j",
+          "msg": "ks:1|+GlSM&qn&u",
+          "ct": "zmY?U%tG#^B3p{j",
           "result": "valid"
         },
         {
@@ -19943,8 +19943,8 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "99fd7266c73a9ad9",
-          "msg": "tLe30m~lSM&qn&t",
-          "ct": "mWx_<5Cy?VFPJ@r",
+          "msg": "sLe30m~lSM&qn&u",
+          "ct": "mWx:<5Cy?VFPJ@r",
           "result": "valid"
         },
         {
@@ -19955,8 +19955,8 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "99fd7266c73a9ad9",
-          "msg": "tLe30n0lSM&qn&t",
-          "ct": "Fx)tx_7<~6xY^u&",
+          "msg": "sLe30n0lSM&qn&u",
+          "ct": "Fx)sx_7<~6xY^v&",
           "result": "valid"
         },
         {
@@ -19967,8 +19967,8 @@
           ],
           "key": "c648d0657f2dbe6e2a046b36f36bf7a6bd3098e20f495b94a33eaec80cc55ef9",
           "tweak": "99fd7266c73a9ad9",
-          "msg": "~~~~~~~lSM&qn&t",
-          "ct": "I+Ixi(_{;Hfc2#<",
+          "msg": "~~~~~~~lSM&qn&u",
+          "ct": "I+Ixi(:{;Hfc2#<",
           "result": "valid"
         },
         {
@@ -19979,8 +19979,8 @@
           ],
           "key": "6965839425a03ce60233de3285fd4e46b992ec89a8be3b20b58231ee180eb440",
           "tweak": "351b957ffa7ac601",
-          "msg": "[=z_iS{V4$T++|k",
-          "ct": "fK)tU57|?Df7Su`",
+          "msg": "-=z_iS{V4$T++|k",
+          "ct": "fK)sU57|?Df7Sv`",
           "result": "invalid"
         },
         {
@@ -19991,7 +19991,7 @@
           ],
           "key": "6965839425a03ce60233de3285fd4e46b992ec89a8be3b20b58231ee180eb440",
           "tweak": "351b957ffa7ac601",
-          "msg": "R=z_i]{V4$T++|k",
+          "msg": "R=z_i-{V4$T++|k",
           "ct": "4mR}#)fQ`=b<x<?",
           "result": "invalid"
         },
@@ -20003,7 +20003,7 @@
           ],
           "key": "6965839425a03ce60233de3285fd4e46b992ec89a8be3b20b58231ee180eb440",
           "tweak": "351b957ffa7ac601",
-          "msg": "R=z_iS{V4$T++|'",
+          "msg": "R=z_iS{V4$T++|-",
           "ct": "x2^o)PNI=LHhJfL",
           "result": "invalid"
         },
@@ -20015,7 +20015,7 @@
           ],
           "key": "0c91ec67b9ed6e825dda8e17539d76a4d83c519cdcf45731798a4c87399fd4ca",
           "tweak": "17965dfea7a8f851",
-          "msg": "\u007fO;C8cF;2~)xed&",
+          "msg": "-O;C8cF;2~)xed&",
           "ct": "mUIOxBh!9}eko6h",
           "result": "invalid"
         },
@@ -20027,8 +20027,8 @@
           ],
           "key": "0c91ec67b9ed6e825dda8e17539d76a4d83c519cdcf45731798a4c87399fd4ca",
           "tweak": "17965dfea7a8f851",
-          "msg": "XO;C8\u007fF;2~)xed&",
-          "ct": "tKP}t<P>QDC6%fe",
+          "msg": "XO;C8-F;2~)xed&",
+          "ct": "sKP}s<P>QDC6%fe",
           "result": "invalid"
         },
         {
@@ -20039,14 +20039,14 @@
           ],
           "key": "0c91ec67b9ed6e825dda8e17539d76a4d83c519cdcf45731798a4c87399fd4ca",
           "tweak": "17965dfea7a8f851",
-          "msg": "XO;C8cF;2~)xed\u007f",
+          "msg": "XO;C8cF;2~)xed-",
           "ct": ";#jFZnP9=Vjik_2",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 16,
       "radix": 85,
@@ -20060,8 +20060,8 @@
           ],
           "key": "505aa98819809ef63b9a368a1e8bc2e922da45b03ce02d9a7966b15006dba2d5",
           "tweak": "5b54b73e6af6a275",
-          "msg": "A}v!B*{@Y+e_OdnM",
-          "ct": "1=ts!hrpr0<~`+n8",
+          "msg": "A}w!B*{@Y+e_OdnM",
+          "ct": "1=ut!hrpr0<~`+n8",
           "result": "valid"
         },
         {
@@ -20109,7 +20109,7 @@
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
           "msg": "+Km`|zx7+Km`|zx7",
-          "ct": "08P6t6&7&Zq`Jh99",
+          "ct": "08P6s6&7&Zq`Jh99",
           "result": "valid"
         },
         {
@@ -20120,8 +20120,8 @@
           ],
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
-          "msg": "yyAtU&`~KDdFj$|!",
-          "ct": "RoKqqM)^@pEuk~#B",
+          "msg": "yyAuU&`~KDdFj$|!",
+          "ct": "RoKqqM)^@pEvk~#B",
           "result": "valid"
         },
         {
@@ -20133,7 +20133,7 @@
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
           "msg": "#K%g*}d%hcmOkpjV",
-          "ct": "ciu(9HaFShMK`+ch",
+          "ct": "civ(9HaFShMK`+ch",
           "result": "valid"
         },
         {
@@ -20144,8 +20144,8 @@
           ],
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
-          "msg": "LtprCz@iId&0)#}D",
-          "ct": "uX2C*DYgjq(&#{8k",
+          "msg": "LuprCz@iId&0)#}D",
+          "ct": "vX2C*DYgjq(&#{8k",
           "result": "valid"
         },
         {
@@ -20156,7 +20156,7 @@
           ],
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
-          "msg": "zKK<FZ%PIguW!e=R",
+          "msg": "zKK<FZ%PIgvW!e=R",
           "ct": "269(3eY>N9DnfX3+",
           "result": "valid"
         },
@@ -20168,8 +20168,8 @@
           ],
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
-          "msg": "e?*&MlSOxK?qAnv!",
-          "ct": "jbyULZdl2`u&M*Om",
+          "msg": "e?*&MlSOxK?qAnw!",
+          "ct": "jbyULZdl2`v&M*Om",
           "result": "valid"
         },
         {
@@ -20181,7 +20181,7 @@
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
           "msg": "=#F%;V=JdmE!1}#z",
-          "ct": "alK=S4rh{O~kt=l5",
+          "ct": "alK=S4rh{O~ku=l5",
           "result": "valid"
         },
         {
@@ -20192,8 +20192,8 @@
           ],
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
-          "msg": "RGU#3Td?RdDv7r!`",
-          "ct": "|Lt0Y?hW|@*)e0cq",
+          "msg": "RGU#3Td?RdDw7r!`",
+          "ct": "|Ls0Y?hW|@*)e0cq",
           "result": "valid"
         },
         {
@@ -20216,7 +20216,7 @@
           ],
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
-          "msg": "=#tYh%H5=KhEO3;{",
+          "msg": "=#sYh%H5=KhEO3;{",
           "ct": "0000000000000000",
           "result": "valid"
         },
@@ -20228,7 +20228,7 @@
           ],
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
-          "msg": "FyiYGxSDkToE*v_&",
+          "msg": "FyiYGxSDkToE*w_&",
           "ct": "~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -20252,7 +20252,7 @@
           ],
           "key": "3a86884c0fdac6230e5c075d6eb71ddc15498f64b497d397b48a68268d1e48db",
           "tweak": "283b7fe6bd1b14cc",
-          "msg": "%Pu;T&S_%QbBo#6u",
+          "msg": "%Pv;T&S:%QbBo#6v",
           "ct": "+Km`|zx7+Km`|zx7",
           "result": "valid"
         },
@@ -20264,8 +20264,8 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "201f43693abbe622",
-          "msg": "Otl1!7t*e>#zpLN$",
-          "ct": "s?U%U9Bit*}tYzNV",
+          "msg": "Oul1!7s*e>#zpLN$",
+          "ct": "t?U%U9Biu*}sYzNV",
           "result": "valid"
         },
         {
@@ -20277,7 +20277,7 @@
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "201f43693abbe622",
           "msg": "Pzd#15QW#9hC7)R4",
-          "ct": "(Ku4HH&%j3a{jGMY",
+          "ct": "(Kv4HH&%j3a{jGMY",
           "result": "valid"
         },
         {
@@ -20288,7 +20288,7 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "201f43693abbe622",
-          "msg": "D%I_8;!ueAd?=70$",
+          "msg": "D%I_8;!veAd?=70$",
           "ct": "#Ih24*NP};H|SEa1",
           "result": "valid"
         },
@@ -20301,7 +20301,7 @@
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "201f43693abbe622",
           "msg": "opHjp9ISP*~(jYn@",
-          "ct": "tsV7CkL^XG0FUd+k",
+          "ct": "utV7CkL^XG0FUd+k",
           "result": "valid"
         },
         {
@@ -20325,7 +20325,7 @@
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "8ee1308903593de3",
           "msg": "FZ#qa+I23#(>D6P@",
-          "ct": "2oUC7inZTLpD$|vQ",
+          "ct": "2oUC7inZTLpD$|wQ",
           "result": "valid"
         },
         {
@@ -20337,7 +20337,7 @@
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "8ee1308903593de3",
           "msg": "*RnmmFKa`AaV(9ll",
-          "ct": ";=<ptc0S!$fd(2AR",
+          "ct": ";=<puc0S!$fd(2AR",
           "result": "valid"
         },
         {
@@ -20349,7 +20349,7 @@
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "8ee1308903593de3",
           "msg": "IA<4=3Na&{gQ?0Id",
-          "ct": "eb1f1#5hVYXMtvoC",
+          "ct": "eb1f1#5hVYXMswoC",
           "result": "valid"
         },
         {
@@ -20372,8 +20372,8 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bd43604bebc7db0a",
-          "msg": "Or;?4gu2CArJg7>s",
-          "ct": "6th{99&Z4z@gElV&",
+          "msg": "Or;?4gv2CArJg7>t",
+          "ct": "6uh{99&Z4z@gElV&",
           "result": "valid"
         },
         {
@@ -20384,8 +20384,8 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bd43604bebc7db0a",
-          "msg": "<5G?za<uX7Py$OtH",
-          "ct": "~C}L*f=SqIEmCV4u",
+          "msg": "<5G?za<vX7Py$OuH",
+          "ct": "~C}L*f=SqIEmCV4v",
           "result": "valid"
         },
         {
@@ -20396,7 +20396,7 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bd43604bebc7db0a",
-          "msg": "~t=cQMql6`SDFGD&",
+          "msg": "~u=cQMql6`SDFGD&",
           "ct": "Z0Jen7iLOBlHn;#l",
           "result": "valid"
         },
@@ -20408,8 +20408,8 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bd43604bebc7db0a",
-          "msg": "W+ATm~53tH(RIBrD",
-          "ct": "mIPTpiU0i$sZm9yK",
+          "msg": "W+ATm~53sH(RIBrD",
+          "ct": "mIPTpiU0i$tZm9yK",
           "result": "valid"
         },
         {
@@ -20420,7 +20420,7 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bd43604bebc7db0a",
-          "msg": "z4N{Tt)ss~0VK1OP",
+          "msg": "z4N{Ts)tt~0VK1OP",
           "ct": "n8e4>#dM0b$CHXg<",
           "result": "valid"
         },
@@ -20432,7 +20432,7 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bd43604bebc7db0a",
-          "msg": ";Ssk3dJyn>mCI&!y",
+          "msg": ";Stk3dJyn>mCI&!y",
           "ct": "j~4FR2GB(BH?7HFR",
           "result": "valid"
         },
@@ -20445,7 +20445,7 @@
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bf5a97045edb340d",
           "msg": "mJoSNNWf00000000",
-          "ct": "KX#|{n(bVoKu?<_V",
+          "ct": "KX#|{n(bVoKv?<:V",
           "result": "valid"
         },
         {
@@ -20456,8 +20456,8 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bf5a97045edb340d",
-          "msg": "?_5;va5+00000001",
-          "ct": "{s#VD2Mv_Pxdu*o$",
+          "msg": "?:5;wa5+00000001",
+          "ct": "{t#VD2Mw_Pxdv*o$",
           "result": "valid"
         },
         {
@@ -20469,7 +20469,7 @@
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bf5a97045edb340d",
           "msg": "lZ31{3J~+Km`|zx8",
-          "ct": "9tjF?4|=b`E98@*Q",
+          "ct": "9ujF?4|=b`E98@*Q",
           "result": "valid"
         },
         {
@@ -20480,7 +20480,7 @@
           ],
           "key": "11301a0afc931ec09c7cfe457d38df6cbea378810372d80039bb0b4d8cc03668",
           "tweak": "bf5a97045edb340d",
-          "msg": "TaYx!tqv~~~~~~~~",
+          "msg": "TaYx!uqw~~~~~~~~",
           "ct": "d66ooMKHXF7BbriV",
           "result": "valid"
         },
@@ -20492,8 +20492,8 @@
           ],
           "key": "450f8c62429604aa5585843c1e21c0a1b69693237afdb2fea8eda08149ace9a7",
           "tweak": "a48cfeaa6646b0c5",
-          "msg": "-oOF)tOFVrd@)x=s",
-          "ct": "N`ptjar!Ftu5|qKK",
+          "msg": "-oOF)uOFVrd@)x=t",
+          "ct": "N`psjar!Fsv5|qKK",
           "result": "invalid"
         },
         {
@@ -20504,8 +20504,8 @@
           ],
           "key": "450f8c62429604aa5585843c1e21c0a1b69693237afdb2fea8eda08149ace9a7",
           "tweak": "a48cfeaa6646b0c5",
-          "msg": "zoOF)/OFVrd@)x=s",
-          "ct": "H`P6tk*qgy{x>vrf",
+          "msg": "zoOF)-OFVrd@)x=t",
+          "ct": "H`P6sk*qgy{x>wrf",
           "result": "invalid"
         },
         {
@@ -20516,7 +20516,7 @@
           ],
           "key": "450f8c62429604aa5585843c1e21c0a1b69693237afdb2fea8eda08149ace9a7",
           "tweak": "a48cfeaa6646b0c5",
-          "msg": "zoOF)tOFVrd@)x=\\",
+          "msg": "zoOF)uOFVrd@)x=-",
           "ct": ">&(JWeL;gD}2~{Un",
           "result": "invalid"
         },
@@ -20528,8 +20528,8 @@
           ],
           "key": "fbc4fe06b0aacde67468666a60f5b9d118f53e87213e6c0fdbd6c4b5b4f5d962",
           "tweak": "f76436e414eb20ee",
-          "msg": "\u007f_^QVnxm8o|_nu57",
-          "ct": "o_@vtIWH{#ap1Q(^",
+          "msg": "-:^QVnxm8o|_nv57",
+          "ct": "o_@wsIWH{#ap1Q(^",
           "result": "invalid"
         },
         {
@@ -20540,8 +20540,8 @@
           ],
           "key": "fbc4fe06b0aacde67468666a60f5b9d118f53e87213e6c0fdbd6c4b5b4f5d962",
           "tweak": "f76436e414eb20ee",
-          "msg": "0_^QV\u007fxm8o|_nu57",
-          "ct": "93&<BssH=v}7CuCm",
+          "msg": "0:^QV-xm8o|_nv57",
+          "ct": "93&<BttH=w}7CvCm",
           "result": "invalid"
         },
         {
@@ -20552,14 +20552,14 @@
           ],
           "key": "fbc4fe06b0aacde67468666a60f5b9d118f53e87213e6c0fdbd6c4b5b4f5d962",
           "tweak": "f76436e414eb20ee",
-          "msg": "0_^QVnxm8o|_nu5\u007f",
-          "ct": "E==CL9vPs^)DKj_5",
+          "msg": "0:^QVnxm8o|_nv5-",
+          "ct": "E==CL9wPt^)DKj:5",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 17,
       "radix": 85,
@@ -20573,7 +20573,7 @@
           ],
           "key": "abd43681541e9a9233091509ee06c648b45a34c0ddc73f39d804bcaf7bf31a0e",
           "tweak": "011400c2b81f3e50",
-          "msg": "T(ztd6@Lr+gU2^x45",
+          "msg": "T(zud6@Lr+gU2^x45",
           "ct": "^iX{eV8WVC=Pgim=C",
           "result": "valid"
         },
@@ -20586,7 +20586,7 @@
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
           "msg": "00000000000000000",
-          "ct": "IuH5Xyu7G^fC`=Lip",
+          "ct": "IvH5Xyv7G^fC`=Lip",
           "result": "valid"
         },
         {
@@ -20598,7 +20598,7 @@
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
           "msg": "~~~~~~~~~~~~~~~~~",
-          "ct": "h~?L^^RgfkBcdv6?7",
+          "ct": "h~?L^^RgfkBcdw6?7",
           "result": "valid"
         },
         {
@@ -20610,7 +20610,7 @@
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
           "msg": "+Km`|zx8q>f;|Ocg2",
-          "ct": "GB_C#<VonlWbOe8K6",
+          "ct": "GB:C#<VonlWbOe8K6",
           "result": "valid"
         },
         {
@@ -20622,7 +20622,7 @@
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
           "msg": "+Km`|zx7q>f;|Ocg1",
-          "ct": "3tS=%)Vk5$MUbf_pY",
+          "ct": "3uS=%)Vk5$MUbf:pY",
           "result": "valid"
         },
         {
@@ -20633,8 +20633,8 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "7p8tT>kBj!IcO!b`0",
-          "ct": "+shzE9^h>ONvXV1?j",
+          "msg": "7p8sT>kBj!IcO!b`0",
+          "ct": "+thzE9^h>ONwXV1?j",
           "result": "valid"
         },
         {
@@ -20645,8 +20645,8 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "ul=ASe{!a?&*LJmus",
-          "ct": "#CE_*Oq{9}Y_HtS9a",
+          "msg": "vl=ASe{!a?&*LJmvt",
+          "ct": "#CE:*Oq{9}Y_HsS9a",
           "result": "valid"
         },
         {
@@ -20657,7 +20657,7 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "nIK?tXL<86?qkf9c?",
+          "msg": "nIK?sXL<86?qkf9c?",
           "ct": "J11DZ=%!DjjJE09>;",
           "result": "valid"
         },
@@ -20669,8 +20669,8 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "mVONyL(~#Ta_G;gVt",
-          "ct": "Hsv9QSYe=Y6cII7*}",
+          "msg": "mVONyL(~#Ta_G;gVu",
+          "ct": "Htw9QSYe=Y6cII7*}",
           "result": "valid"
         },
         {
@@ -20681,8 +20681,8 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "O%vbW4J|^F9Alxnz9",
-          "ct": "7EDx~!C;@kr>0`p_1",
+          "msg": "O%wbW4J|^F9Alxnz9",
+          "ct": "7EDx~!C;@kr>0`p:1",
           "result": "valid"
         },
         {
@@ -20694,7 +20694,7 @@
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
           "msg": "7$e$VPQ}QUj4}3}5p",
-          "ct": "K&_<PEX=j_Ce0nx;%",
+          "ct": "K&:<PEX=j_Ce0nx;%",
           "result": "valid"
         },
         {
@@ -20705,8 +20705,8 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "Vo(#8Zv(~%kVg00Un",
-          "ct": "+||l2a5jRsM_XpM$T",
+          "msg": "Vo(#8Zw(~%kVg00Un",
+          "ct": "+||l2a5jRtM:XpM$T",
           "result": "valid"
         },
         {
@@ -20717,7 +20717,7 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "1?1~hdV0}xEL2DP%v",
+          "msg": "1?1~hdV0}xEL2DP%w",
           "ct": "mCOXBS+e^L)+L!P{d",
           "result": "valid"
         },
@@ -20729,7 +20729,7 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "3Hy8SYz?%_B8_B?g$",
+          "msg": "3Hy8SYz?%_B8:B?g$",
           "ct": "00000000000000000",
           "result": "valid"
         },
@@ -20741,7 +20741,7 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "f$RtFsOG^822PVrbD",
+          "msg": "f$RuFtOG^822PVrbD",
           "ct": "~~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -20753,7 +20753,7 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "LtDWK^&x(ehde;<fk",
+          "msg": "LsDWK^&x(ehde;<fk",
           "ct": "+Km`|zx8q>f;|Ocg2",
           "result": "valid"
         },
@@ -20765,7 +20765,7 @@
           ],
           "key": "b780b0dda375534b6daf5eb0088e1402f86c4af424409ffaa2609101507a028c",
           "tweak": "5921a49a5ca9233a",
-          "msg": "_;$MMfNfvyWit>a)H",
+          "msg": ":;$MMfNfwyWis>a)H",
           "ct": "+Km`|zx7q>f;|Ocg1",
           "result": "valid"
         },
@@ -20777,8 +20777,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "3bc96c6b385839",
-          "msg": "srFhs!a5f*VG2<#$!",
-          "ct": "t@&meyQ=((yid+s}c",
+          "msg": "trFht!a5f*VG2<#$!",
+          "ct": "s@&meyQ=((yid+t}c",
           "result": "valid"
         },
         {
@@ -20789,8 +20789,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "3bc96c6b385839",
-          "msg": "_Pb*WsnSJ_CDo$;4*",
-          "ct": "!j;kN&NPJv@GhHLur",
+          "msg": "_Pb*WtnSJ_CDo$;4*",
+          "ct": "!j;kN&NPJw@GhHLvr",
           "result": "valid"
         },
         {
@@ -20813,8 +20813,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "3bc96c6b385839",
-          "msg": "AYdnAHGgltvP2i=KU",
-          "ct": "j<tsSM^G?W+@3tV&h",
+          "msg": "AYdnAHGglswP2i=KU",
+          "ct": "j<utSM^G?W+@3sV&h",
           "result": "valid"
         },
         {
@@ -20825,8 +20825,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "f710f9bfed9b4a",
-          "msg": ">i_@>%lY_WP&2%`!c",
-          "ct": "vTH6^jt|T4l?xSOeh",
+          "msg": ">i:@>%lY_WP&2%`!c",
+          "ct": "wTH6^ju|T4l?xSOeh",
           "result": "valid"
         },
         {
@@ -20849,8 +20849,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "f710f9bfed9b4a",
-          "msg": "5xugMSfVnd)PiNO86",
-          "ct": "vlGC_M>q;T2gonth0",
+          "msg": "5xvgMSfVnd)PiNO86",
+          "ct": "wlGC_M>q;T2gonsh0",
           "result": "valid"
         },
         {
@@ -20861,7 +20861,7 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "f710f9bfed9b4a",
-          "msg": "4mb_DSt}i)G2BHgfE",
+          "msg": "4mb_DSu}i)G2BHgfE",
           "ct": "jb*S!%5j>ngT+YQ78",
           "result": "valid"
         },
@@ -20873,7 +20873,7 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "f710f9bfed9b4a",
-          "msg": "u#;4P|6Gc;#u)mmaJ",
+          "msg": "v#;4P|6Gc;#v)mmaJ",
           "ct": "WrLCN#jQ%nf|qTd9E",
           "result": "valid"
         },
@@ -20885,8 +20885,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "38ff2c5ba74760",
-          "msg": ")7_yR14*H@ED*v>{*",
-          "ct": "aJSP&9N^UZ`_&<Mnu",
+          "msg": ")7_yR14*H@ED*w>{*",
+          "ct": "aJSP&9N^UZ`_&<Mnv",
           "result": "valid"
         },
         {
@@ -20897,8 +20897,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "38ff2c5ba74760",
-          "msg": "2lHSpFV2{u?j$$4&^",
-          "ct": "U3sB0e2g@r1Wp2`V*",
+          "msg": "2lHSpFV2{v?j$$4&^",
+          "ct": "U3tB0e2g@r1Wp2`V*",
           "result": "valid"
         },
         {
@@ -20921,8 +20921,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "38ff2c5ba74760",
-          "msg": "#h7OrRx|s<4*1i}eE",
-          "ct": "W*AlK>u?_kuUy@Vu?",
+          "msg": "#h7OrRx|t<4*1i}eE",
+          "ct": "W*AlK>v?:kvUy@Vv?",
           "result": "valid"
         },
         {
@@ -20933,8 +20933,8 @@
           ],
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "38ff2c5ba74760",
-          "msg": "~{tNtc2@})W_~tWOK",
-          "ct": "7n181%yvSv;g8!^7V",
+          "msg": "~{sNuc2@})W_~uWOK",
+          "ct": "7n181%ywSw;g8!^7V",
           "result": "valid"
         },
         {
@@ -20946,7 +20946,7 @@
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "38ff2c5ba74760",
           "msg": "S`B>J26z{bXdkHY>;",
-          "ct": "_9*)gfx`=BNU#AW_O",
+          "ct": ":9*)gfx`=BNU#AW:O",
           "result": "valid"
         },
         {
@@ -20958,7 +20958,7 @@
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "543bfe9cb14e2e",
           "msg": "00000000y@cL3Hh4*",
-          "ct": "kCd_n|cx6_AVL*68W",
+          "ct": "kCd:n|cx6_AVL*68W",
           "result": "valid"
         },
         {
@@ -20982,7 +20982,7 @@
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "543bfe9cb14e2e",
           "msg": "+Km`|zx8y@cL3Hh4*",
-          "ct": "_D81VX;`~npmz2iJh",
+          "ct": ":D81VX;`~npmz2iJh",
           "result": "valid"
         },
         {
@@ -20994,7 +20994,7 @@
           "key": "9eac581f9cefeaac0a92cb8930c1c0b671cc99c838bd3ac7812d2080de81191a",
           "tweak": "543bfe9cb14e2e",
           "msg": "~~~~~~~~y@cL3Hh4*",
-          "ct": "8i=py~n&O__vfCaup",
+          "ct": "8i=py~n&O__wfCavp",
           "result": "valid"
         },
         {
@@ -21005,8 +21005,8 @@
           ],
           "key": "c8a37700cb818fab7444da945dfe131c6156fb9f5a034eb4bc10544399e1cedc",
           "tweak": "6460d80894ab337d",
-          "msg": "wq2@{=%o4zV8gEMg)",
-          "ct": "|SYs6>u<<nE~hY7?*",
+          "msg": "-q2@{=%o4zV8gEMg)",
+          "ct": "|SYt6>v<<nE~hY7?*",
           "result": "invalid"
         },
         {
@@ -21017,7 +21017,7 @@
           ],
           "key": "c8a37700cb818fab7444da945dfe131c6156fb9f5a034eb4bc10544399e1cedc",
           "tweak": "6460d80894ab337d",
-          "msg": "jq2@{,%o4zV8gEMg)",
+          "msg": "jq2@{-%o4zV8gEMg)",
           "ct": "YG5Jc}cU=1hz?M@@q",
           "result": "invalid"
         },
@@ -21029,8 +21029,8 @@
           ],
           "key": "c8a37700cb818fab7444da945dfe131c6156fb9f5a034eb4bc10544399e1cedc",
           "tweak": "6460d80894ab337d",
-          "msg": "jq2@{=%o4zV8gEMg/",
-          "ct": "#GEL6_ih&?x%V%0T>",
+          "msg": "jq2@{=%o4zV8gEMg-",
+          "ct": "#GEL6:ih&?x%V%0T>",
           "result": "invalid"
         },
         {
@@ -21041,7 +21041,7 @@
           ],
           "key": "32705b011da4c54eb5e78b93b343314970d888ecdf5ed060a3e42a379917352c",
           "tweak": "9d82ca7f457b1685",
-          "msg": "\u007f7YF(?~M%p4$x<sIt",
+          "msg": "-7YF(?~M%p4$x<tIs",
           "ct": "5D97*mRhGKoEn@jKX",
           "result": "invalid"
         },
@@ -21053,7 +21053,7 @@
           ],
           "key": "32705b011da4c54eb5e78b93b343314970d888ecdf5ed060a3e42a379917352c",
           "tweak": "9d82ca7f457b1685",
-          "msg": "<7YF(\u007f~M%p4$x<sIt",
+          "msg": "<7YF(-~M%p4$x<tIs",
           "ct": "*h4NYaZONT!&$`*lJ",
           "result": "invalid"
         },
@@ -21065,14 +21065,14 @@
           ],
           "key": "32705b011da4c54eb5e78b93b343314970d888ecdf5ed060a3e42a379917352c",
           "tweak": "9d82ca7f457b1685",
-          "msg": "<7YF(?~M%p4$x<sI\u007f",
+          "msg": "<7YF(?~M%p4$x<tI-",
           "ct": "1M$L11L~~<J=$e^Ap",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 18,
       "radix": 85,
@@ -21086,8 +21086,8 @@
           ],
           "key": "be748dab0203d19a98eb126a8ed6fcbd99aeea49f1cff7512529f201bf0eff67",
           "tweak": "4977c3ee944e48cb",
-          "msg": "IspQNX1$982vvQ)bqC",
-          "ct": "jo7f5azs>>_JG@)x&u",
+          "msg": "ItpQNX1$982wwQ)bqC",
+          "ct": "jo7f5azt>>_JG@)x&v",
           "result": "valid"
         },
         {
@@ -21099,7 +21099,7 @@
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
           "msg": "000000000000000000",
-          "ct": "d(i_jhth?ai6O0_jNm",
+          "ct": "d(i:jhsh?ai6O0_jNm",
           "result": "valid"
         },
         {
@@ -21111,7 +21111,7 @@
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
           "msg": "~~~~~~~~~~~~~~~~~~",
-          "ct": "olznCvG*#}nZkGjdNg",
+          "ct": "olznCwG*#}nZkGjdNg",
           "result": "valid"
         },
         {
@@ -21146,8 +21146,8 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "MfJlobqoXQ=jW;v4CI",
-          "ct": "bdO0Icu0~0{tT^ITAN",
+          "msg": "MfJlobqoXQ=jW;w4CI",
+          "ct": "bdO0Icv0~0{sT^ITAN",
           "result": "valid"
         },
         {
@@ -21158,8 +21158,8 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "vt2m?A8N}|z7osM@61",
-          "ct": ";tE0)nl3cE6(Gn!q|(",
+          "msg": "wu2m?A8N}|z7otM@61",
+          "ct": ";sE0)nl3cE6(Gn!q|(",
           "result": "valid"
         },
         {
@@ -21171,7 +21171,7 @@
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
           "msg": "?@mFyRAyI4!ZS8^l*=",
-          "ct": "yNaszcCJQ8%xXa@?JB",
+          "ct": "yNatzcCJQ8%xXa@?JB",
           "result": "valid"
         },
         {
@@ -21182,8 +21182,8 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "N#4TZ#1>AyoI>>s_IY",
-          "ct": "W2hJGxTm_SXthpc|e&",
+          "msg": "N#4TZ#1>AyoI>>t:IY",
+          "ct": "W2hJGxTm:SXshpc|e&",
           "result": "valid"
         },
         {
@@ -21194,8 +21194,8 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "qnIIdC2;zV+LQ_`VoO",
-          "ct": "(8dZI;jG5X_}E4$NyK",
+          "msg": "qnIIdC2;zV+LQ:`VoO",
+          "ct": "(8dZI;jG5X:}E4$NyK",
           "result": "valid"
         },
         {
@@ -21206,7 +21206,7 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "z37teZjgAGEz#bl#$4",
+          "msg": "z37seZjgAGEz#bl#$4",
           "ct": "+@*>R&YgEHAr2~94=*",
           "result": "valid"
         },
@@ -21218,8 +21218,8 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "@fy_fGDrAUK3f@?;Yj",
-          "ct": "?nne!0ZSV)B_($_*Q7",
+          "msg": "@fy:fGDrAUK3f@?;Yj",
+          "ct": "?nne!0ZSV)B:($_*Q7",
           "result": "valid"
         },
         {
@@ -21230,7 +21230,7 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "|PM(MMrPQRO_7q>HF6",
+          "msg": "|PM(MMrPQRO:7q>HF6",
           "ct": "JHx+CGBf#Z~znI~(H$",
           "result": "valid"
         },
@@ -21254,7 +21254,7 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "x!9_)oZi))NSx=L}dj",
+          "msg": "x!9:)oZi))NSx=L}dj",
           "ct": "~~~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -21266,7 +21266,7 @@
           ],
           "key": "da3d504e93a044a068732c297c51badbab8e58b79727cc656a115cdf2d9ec1df",
           "tweak": "b2fbca44db9eaec7",
-          "msg": "8c|M{uWPCa5ruL7+RZ",
+          "msg": "8c|M{vWPCa5rvL7+RZ",
           "ct": "q>f;|Ocg2q>f;|Ocg2",
           "result": "valid"
         },
@@ -21290,8 +21290,8 @@
           ],
           "key": "e717e230c81494129fdbebde2ed53769e3b3aa69024750b3b37ef8cb80bcb5f1",
           "tweak": "0a101469ce8bdd",
-          "msg": "1h6eWQY*#;C=+_90tv",
-          "ct": "coWt{Oeh~~~~~~~~~~",
+          "msg": "1h6eWQY*#;C=+_90uw",
+          "ct": "coWs{Oeh~~~~~~~~~~",
           "result": "valid"
         },
         {
@@ -21302,8 +21302,8 @@
           ],
           "key": "e717e230c81494129fdbebde2ed53769e3b3aa69024750b3b37ef8cb80bcb5f1",
           "tweak": "0a101469ce8bdd",
-          "msg": "DHkzcKW_jmVf+lHFk7",
-          "ct": "coWt{Oeh~000000000",
+          "msg": "DHkzcKW:jmVf+lHFk7",
+          "ct": "coWs{Oeh~000000000",
           "result": "valid"
         },
         {
@@ -21315,7 +21315,7 @@
           "key": "e717e230c81494129fdbebde2ed53769e3b3aa69024750b3b37ef8cb80bcb5f1",
           "tweak": "0a101469ce8bdd",
           "msg": "nk{2{o?*i)H^L<HY$`",
-          "ct": "coWt{Oeh~q>f;|Ocg1",
+          "ct": "coWs{Oeh~q>f;|Ocg1",
           "result": "valid"
         },
         {
@@ -21326,8 +21326,8 @@
           ],
           "key": "e717e230c81494129fdbebde2ed53769e3b3aa69024750b3b37ef8cb80bcb5f1",
           "tweak": "0a101469ce8bdd",
-          "msg": "oM1Ic7FBJNYhytxf?#",
-          "ct": "coWt{Oeh~~~~~~~~~}",
+          "msg": "oM1Ic7FBJNYhyuxf?#",
+          "ct": "coWs{Oeh~~~~~~~~~}",
           "result": "valid"
         },
         {
@@ -21338,8 +21338,8 @@
           ],
           "key": "b530bd2069d1f093344cdc835ec23d306c195165886fd909e48683cf85022db2",
           "tweak": "ff61916e9620be47",
-          "msg": "w_m?WSgpt2mkbYESIF",
-          "ct": "`Tf=_YPmWC*}a#T;4s",
+          "msg": "-:m?WSgpu2mkbYESIF",
+          "ct": "`Tf=_YPmWC*}a#T;4t",
           "result": "invalid"
         },
         {
@@ -21350,8 +21350,8 @@
           ],
           "key": "b530bd2069d1f093344cdc835ec23d306c195165886fd909e48683cf85022db2",
           "tweak": "ff61916e9620be47",
-          "msg": "?_m?WS.pt2mkbYESIF",
-          "ct": "2qD}IJSU8d;G3<v_gD",
+          "msg": "?:m?WS-pu2mkbYESIF",
+          "ct": "2qD}IJSU8d;G3<w_gD",
           "result": "invalid"
         },
         {
@@ -21362,8 +21362,8 @@
           ],
           "key": "b530bd2069d1f093344cdc835ec23d306c195165886fd909e48683cf85022db2",
           "tweak": "ff61916e9620be47",
-          "msg": "?_m?WSgpt2mkbYESI-",
-          "ct": "iV6;r^=`%1HSG!t1X4",
+          "msg": "?:m?WSgpu2mkbYESI-",
+          "ct": "iV6;r^=`%1HSG!u1X4",
           "result": "invalid"
         },
         {
@@ -21374,7 +21374,7 @@
           ],
           "key": "741973caf64915a2095e8b6ba7a7f8be9186dab061ae364b631f3f2bdae0cdba",
           "tweak": "5f0105947df07c9f",
-          "msg": "\u007f4yNi4&b{D&j_%E<&C",
+          "msg": "-4yNi4&b{D&j:%E<&C",
           "ct": "}JXL5S3aoRXh2OVd?K",
           "result": "invalid"
         },
@@ -21386,8 +21386,8 @@
           ],
           "key": "741973caf64915a2095e8b6ba7a7f8be9186dab061ae364b631f3f2bdae0cdba",
           "tweak": "5f0105947df07c9f",
-          "msg": "$4yNi4\u007fb{D&j_%E<&C",
-          "ct": "HM$~&Lc`OjtTuWy^4z",
+          "msg": "$4yNi4-b{D&j:%E<&C",
+          "ct": "HM$~&Lc`OjuTvWy^4z",
           "result": "invalid"
         },
         {
@@ -21398,14 +21398,14 @@
           ],
           "key": "741973caf64915a2095e8b6ba7a7f8be9186dab061ae364b631f3f2bdae0cdba",
           "tweak": "5f0105947df07c9f",
-          "msg": "$4yNi4&b{D&j_%E<&\u007f",
+          "msg": "$4yNi4&b{D&j:%E<&-",
           "ct": "$+?)K_WQ}o90_+|QVZ",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 19,
       "radix": 85,
@@ -21419,8 +21419,8 @@
           ],
           "key": "1ba9f170be79c755e07202291871538a2c1b47600b59ec264c04d27f61cd3c28",
           "tweak": "c8655169a0f80a05",
-          "msg": "Ykt8Fd0KxmAC(fZ&)Ih",
-          "ct": "nTsDCNUGCf>A_(KUIr)",
+          "msg": "Yks8Fd0KxmAC(fZ&)Ih",
+          "ct": "nTtDCNUGCf>A_(KUIr)",
           "result": "valid"
         },
         {
@@ -21432,7 +21432,7 @@
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
           "msg": "0000000000000000000",
-          "ct": "T6gp1NX|C41`v_?g_=g",
+          "ct": "T6gp1NX|C41`w:?g_=g",
           "result": "valid"
         },
         {
@@ -21444,7 +21444,7 @@
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
           "msg": "~~~~~~~~~~~~~~~~~~~",
-          "ct": "_mt_El}0pH0W&Y+)yYx",
+          "ct": ":mu:El}0pH0W&Y+)yYx",
           "result": "valid"
         },
         {
@@ -21455,8 +21455,8 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "q>f;|Ocg2_tv2=@*|O1",
-          "ct": "@u<rjJOgLn&@_zPnDBu",
+          "msg": "q>f;|Ocg2_sw2=@*|O1",
+          "ct": "@v<rjJOgLn&@_zPnDBv",
           "result": "valid"
         },
         {
@@ -21467,8 +21467,8 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "q>f;|Ocg1_tv2=@*|O0",
-          "ct": "va462b;`R;We`_LoQ_H",
+          "msg": "q>f;|Ocg1_sw2=@*|O0",
+          "ct": "wa462b;`R;We`_LoQ:H",
           "result": "valid"
         },
         {
@@ -21479,8 +21479,8 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "3{d@v$cNg^))*DvoK{D",
-          "ct": "^}2tPPF#$_ZyJ5Tarbu",
+          "msg": "3{d@w$cNg^))*DwoK{D",
+          "ct": "^}2uPPF#$:ZyJ5Tarbv",
           "result": "valid"
         },
         {
@@ -21491,7 +21491,7 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "tuNfm(f6=Y(QUCSE+DR",
+          "msg": "uvNfm(f6=Y(QUCSE+DR",
           "ct": "DQ}zH(+T3dip&1*1R2>",
           "result": "valid"
         },
@@ -21503,8 +21503,8 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "5m)Qvl$;RFTtgSBE&rN",
-          "ct": "gBt5Tjt>*y!Xo_Zo)1&",
+          "msg": "5m)Qwl$;RFTsgSBE&rN",
+          "ct": "gBs5Tjs>*y!Xo_Zo)1&",
           "result": "valid"
         },
         {
@@ -21515,8 +21515,8 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "7g1V(u=HkbA4YlkMoL{",
-          "ct": "cI1<gnQoDI#yxpA_ztW",
+          "msg": "7g1V(v=HkbA4YlkMoL{",
+          "ct": "cI1<gnQoDI#yxpA:zsW",
           "result": "valid"
         },
         {
@@ -21527,8 +21527,8 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "8#x$}_xSjtNxQ2&^lnj",
-          "ct": "qta{XG_<?RgLazO=cSD",
+          "msg": "8#x$}:xSjuNxQ2&^lnj",
+          "ct": "qsa{XG_<?RgLazO=cSD",
           "result": "valid"
         },
         {
@@ -21539,7 +21539,7 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "<8tfdg*Z63Zg{5d0r0X",
+          "msg": "<8ufdg*Z63Zg{5d0r0X",
           "ct": "aGc*aRxgz9~7XnzUF=(",
           "result": "valid"
         },
@@ -21551,8 +21551,8 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "4~Z_TXt<X=s=X<G*bjZ",
-          "ct": "^a`{6+(q>>#5_3c+uY=",
+          "msg": "4~Z_TXu<X=t=X<G*bjZ",
+          "ct": "^a`{6+(q>>#5_3c+vY=",
           "result": "valid"
         },
         {
@@ -21564,7 +21564,7 @@
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
           "msg": "(pq3elLPQzf^~c}Ai;M",
-          "ct": "(1ECkM1aNt`?JOie?HP",
+          "ct": "(1ECkM1aNs`?JOie?HP",
           "result": "valid"
         },
         {
@@ -21587,7 +21587,7 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "uyn!Cu_rH+OIJsjgmCe",
+          "msg": "vyn!Cv_rH+OIJtjgmCe",
           "ct": "~~~~~~~~~~~~~~~~~~~",
           "result": "valid"
         },
@@ -21600,7 +21600,7 @@
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
           "msg": "@8l(93>V!6$S2mpbY&4",
-          "ct": "q>f;|Ocg2_tv2=@*|O1",
+          "ct": "q>f;|Ocg2_sw2=@*|O1",
           "result": "valid"
         },
         {
@@ -21611,8 +21611,8 @@
           ],
           "key": "d687c1f63b1cf0abc4f6d973bdb741a74dc6f859244d24b32ae01fa152312f5d",
           "tweak": "8aba2989a0fe4e14",
-          "msg": "|xI4($LjCgJ*vyBIruT",
-          "ct": "q>f;|Ocg1_tv2=@*|O0",
+          "msg": "|xI4($LjCgJ*wyBIrvT",
+          "ct": "q>f;|Ocg1_sw2=@*|O0",
           "result": "valid"
         },
         {
@@ -21636,7 +21636,7 @@
           "key": "167cc199e65e3bad56536bb2e1910e8219311289e2fb3442d6de51ec038f1a67",
           "tweak": "67ecefb0537545bed9984dcbbe01f4582fe05f39eef3",
           "msg": "000000001=Ykf`@BI8W",
-          "ct": "gT0toKXc{SP<<?&2yu?",
+          "ct": "gT0uoKXc{SP<<?&2yv?",
           "result": "valid"
         },
         {
@@ -21648,7 +21648,7 @@
           "key": "167cc199e65e3bad56536bb2e1910e8219311289e2fb3442d6de51ec038f1a67",
           "tweak": "67ecefb0537545bed9984dcbbe01f4582fe05f39eef3",
           "msg": "q>f;|Ocg2=Ykf`@BI8W",
-          "ct": "cg#Q>R`6eqQf>_)uUt2",
+          "ct": "cg#Q>R`6eqQf>:)vUu2",
           "result": "valid"
         },
         {
@@ -21671,7 +21671,7 @@
           ],
           "key": "90af2fc415b43c929c9caacc73858d45c2abb6643ccc4a2949f97d009b7d81f0",
           "tweak": "9561fc88a8ee3dda",
-          "msg": "]@3WH?R9N^yBDlZ&;MI",
+          "msg": "-@3WH?R9N^yBDlZ&;MI",
           "ct": "Pq+#ro>WPEB$C~O)HXX",
           "result": "invalid"
         },
@@ -21684,7 +21684,7 @@
           "key": "90af2fc415b43c929c9caacc73858d45c2abb6643ccc4a2949f97d009b7d81f0",
           "tweak": "9561fc88a8ee3dda",
           "msg": "U@3WH?-9N^yBDlZ&;MI",
-          "ct": "6JKy>u|c<^#}de(kkXi",
+          "ct": "6JKy>v|c<^#}de(kkXi",
           "result": "invalid"
         },
         {
@@ -21695,8 +21695,8 @@
           ],
           "key": "90af2fc415b43c929c9caacc73858d45c2abb6643ccc4a2949f97d009b7d81f0",
           "tweak": "9561fc88a8ee3dda",
-          "msg": "U@3WH?R9N^yBDlZ&;Mw",
-          "ct": "H#J2Yf(JmDa|cchis{J",
+          "msg": "U@3WH?R9N^yBDlZ&;M-",
+          "ct": "H#J2Yf(JmDa|cchit{J",
           "result": "invalid"
         },
         {
@@ -21707,8 +21707,8 @@
           ],
           "key": "6116d1f688dcd9116690f7ca60a10beb9077800aa22209f904f246dc284d2418",
           "tweak": "91ec6cf356973837",
-          "msg": "\u007fRUQO0^ZBth7%mG89gU",
-          "ct": "zi*ZsXI$&XjYQ{0E8(}",
+          "msg": "-RUQO0^ZBuh7%mG89gU",
+          "ct": "zi*ZtXI$&XjYQ{0E8(}",
           "result": "invalid"
         },
         {
@@ -21719,8 +21719,8 @@
           ],
           "key": "6116d1f688dcd9116690f7ca60a10beb9077800aa22209f904f246dc284d2418",
           "tweak": "91ec6cf356973837",
-          "msg": "cRUQO0\u007fZBth7%mG89gU",
-          "ct": "eRq6tv{2Ir1_6Bp&?HL",
+          "msg": "cRUQO0-ZBuh7%mG89gU",
+          "ct": "eRq6uw{2Ir1_6Bp&?HL",
           "result": "invalid"
         },
         {
@@ -21731,14 +21731,14 @@
           ],
           "key": "6116d1f688dcd9116690f7ca60a10beb9077800aa22209f904f246dc284d2418",
           "tweak": "91ec6cf356973837",
-          "msg": "cRUQO0^ZBth7%mG89g\u007f",
-          "ct": "v!108(><srcgmP|j1Fy",
+          "msg": "cRUQO0^ZBuh7%mG89g-",
+          "ct": "w!108(><trcgmP|j1Fy",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 20,
       "radix": 85,
@@ -21759,7 +21759,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 21,
       "radix": 85,
@@ -21773,14 +21773,14 @@
           ],
           "key": "c0e4c4a9b86c17e4efe9a12733e7aff4",
           "tweak": "f71b48c8172125d4",
-          "msg": "0ilFfsY_$s5`YYz43fM?M",
-          "ct": "V~vQd`ptlc`;UlWKA4{j1",
+          "msg": "0ilFftY_$t5`YYz43fM?M",
+          "ct": "V~wQd`pslc`;UlWKA4{j1",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 22,
       "radix": 85,
@@ -21794,14 +21794,14 @@
           ],
           "key": "9ed2a54df9219a3d61b5f1758b73bda6",
           "tweak": "5ecd852b587b8148",
-          "msg": "Cuo=ms;;Kkl)_PWqxJe6*^",
-          "ct": "J=Yr1t5x0ta|<}Xq(0+}*C",
+          "msg": "Cvo=mt;;Kkl)_PWqxJe6*^",
+          "ct": "J=Yr1s5x0sa|<}Xq(0+}*C",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 23,
       "radix": 85,
@@ -21815,14 +21815,14 @@
           ],
           "key": "b9259b7f8c36246e73802b650cec0f3a",
           "tweak": "338104fb3b076bc4",
-          "msg": "#B>aL%?muc$|a_x6Ie5}rUl",
-          "ct": "MZ%EKnPslu%>n!rt{dTS`9g",
+          "msg": "#B>aL%?mvc$|a_x6Ie5}rUl",
+          "ct": "MZ%EKnPtlv%>n!rs{dTS`9g",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 24,
       "radix": 85,
@@ -21836,14 +21836,14 @@
           ],
           "key": "904e573e4691681dc2db245bb369404a",
           "tweak": "dc83f04ef1a5fc92",
-          "msg": "LNupm=XLk=^6*hLY)iATFF~f",
+          "msg": "LNvpm=XLk=^6*hLY)iATFF~f",
           "ct": "yN8DT~R^+$$5h+4gnSz=Cd5g",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 25,
       "radix": 85,
@@ -21857,14 +21857,14 @@
           ],
           "key": "4605865b047c33cafb0c30500253573f",
           "tweak": "a8b27f391744d48a",
-          "msg": "t3ce2afZQolgrUv;HgrsKRY<F",
-          "ct": "HDXB7F+OYInq&xVZ;tosp_%%Y",
+          "msg": "s3ce2afZQolgrUw;HgrtKRY<F",
+          "ct": "HDXB7F+OYInq&xVZ;sotp:%%Y",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 26,
       "radix": 85,
@@ -21879,13 +21879,13 @@
           "key": "0fb1979af3a9860c485e2ef06c6010c3",
           "tweak": "60de513786f3f0a6",
           "msg": "SmUOV~nWqq4|%d+HC5=6WQHPZj",
-          "ct": "DlO>u@D<4xD<?Z`NA@gG5`Cb_}",
+          "ct": "DlO>v@D<4xD<?Z`NA@gG5`Cb:}",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 27,
       "radix": 85,
@@ -21906,7 +21906,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 28,
       "radix": 85,
@@ -21920,14 +21920,14 @@
           ],
           "key": "1480e7206367c3365ec5a9b11f61261e",
           "tweak": "895ad94343672108",
-          "msg": "EZpq6iT6kxyb^M*k4E$=@sSHj|+U",
-          "ct": "yGZ4j8jZ2~h+!sGXyoJRe6dnTK^N",
+          "msg": "EZpq6iT6kxyb^M*k4E$=@tSHj|+U",
+          "ct": "yGZ4j8jZ2~h+!tGXyoJRe6dnTK^N",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 29,
       "radix": 85,
@@ -21941,14 +21941,14 @@
           ],
           "key": "a8ed8a1627e4ea301c4d007a30a7fd71",
           "tweak": "dbbf38e615dc2fee",
-          "msg": "8#l~VqrajD6rrt>pJ$0dN+_JW3Ank",
+          "msg": "8#l~VqrajD6rru>pJ$0dN+_JW3Ank",
           "ct": "KXY0i!G~y~PTQxaczK6d$Czon<?@H",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 30,
       "radix": 85,
@@ -21962,14 +21962,14 @@
           ],
           "key": "abbd25e59680efd575c00d24e9fdcad8",
           "tweak": "070cffc4a9b88ee7",
-          "msg": "_LKZty6sJZ8^q9J};#|d^opt}ttDmy",
-          "ct": "t|k3sSlyFCYKK*I*46O`_jk)fN!|Rd",
+          "msg": "_LKZsy6tJZ8^q9J};#|d^opu}ssDmy",
+          "ct": "u|k3tSlyFCYKK*I*46O`_jk)fN!|Rd",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 31,
       "radix": 85,
@@ -21983,14 +21983,14 @@
           ],
           "key": "cb4b74bac0ecce5c21f47f39c22ae70c",
           "tweak": "dd1e66e61ea45250",
-          "msg": "lJ&yGc1kWBmOfU4|Qn_b}g&Ek4Jib8g",
-          "ct": "~>rzFDqHEa;99tIE?9U?EP||7)9rKzH",
+          "msg": "lJ&yGc1kWBmOfU4|Qn:b}g&Ek4Jib8g",
+          "ct": "~>rzFDqHEa;99uIE?9U?EP||7)9rKzH",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 32,
       "radix": 85,
@@ -22004,14 +22004,14 @@
           ],
           "key": "1ee98a204d8de6bc2fb2416fa2efe03f",
           "tweak": "302f76d9825d6eb5",
-          "msg": "XN)X>d~;u*y0gMq|`s{LVi)rzj>>7aB)",
-          "ct": "acm~FpaKJ(2#(c*bzjphT5E_q4o;!bK?",
+          "msg": "XN)X>d~;v*y0gMq|`t{LVi)rzj>>7aB)",
+          "ct": "acm~FpaKJ(2#(c*bzjphT5E:q4o;!bK?",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 33,
       "radix": 85,
@@ -22025,14 +22025,14 @@
           ],
           "key": "df76fc71b7d899068b43f16bc5858dbd",
           "tweak": "8e55911ef156dfe2",
-          "msg": "F%n&9gSX9O8ilBzy_?tCZ1>RxUnmy~>Ua",
+          "msg": "F%n&9gSX9O8ilBzy:?uCZ1>RxUnmy~>Ua",
           "ct": "H76Z{!mcnx<P~Z%MG{AFTgSDjVNjRx5&z",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 38,
       "radix": 85,
@@ -22046,14 +22046,14 @@
           ],
           "key": "1882ed1962852c6fc7c2218ba48d3c58",
           "tweak": "25e032b39da50d1e",
-          "msg": "`C2Otik<l~pAa1Wc+a!hP3!1zSCF;_0X#Nh!1e",
-          "ct": "|sk~70*_~$V_l`eV}h*l$Uz);r_6iN88t+W!Z4",
+          "msg": "`C2Ouik<l~pAa1Wc+a!hP3!1zSCF;:0X#Nh!1e",
+          "ct": "|tk~70*_~$V:l`eV}h*l$Uz);r:6iN88u+W!Z4",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 39,
       "radix": 85,
@@ -22067,14 +22067,14 @@
           ],
           "key": "bc6cef918ac6324a4b8d61e094ff570e",
           "tweak": "c17cf59fe1e5421c",
-          "msg": "nvO+}dGv5mt!$JDxX!W?Z#=Yb+t4xV&+$unCSk2",
-          "ct": "ftc<i1?cyC%Na5W1bn4JzZAYG>=zB8po5x&ZuQq",
+          "msg": "nwO+}dGw5mu!$JDxX!W?Z#=Yb+s4xV&+$vnCSk2",
+          "ct": "fuc<i1?cyC%Na5W1bn4JzZAYG>=zB8po5x&ZvQq",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 40,
       "radix": 85,
@@ -22088,14 +22088,14 @@
           ],
           "key": "ebac6d5741e58a3af7fd72a5db46b863",
           "tweak": "fb13dc638ef728e5",
-          "msg": "u{x^_~j%Gum_+K(m8<RC9|sHe)rXkx<1}NnkzO+P",
-          "ct": "=!7*>=MI@Q_0E!mIxc`t?lg|S820+dAghGM?O6eD",
+          "msg": "v{x^:~j%Gvm:+K(m8<RC9|tHe)rXkx<1}NnkzO+P",
+          "ct": "=!7*>=MI@Q_0E!mIxc`u?lg|S820+dAghGM?O6eD",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 48,
       "radix": 85,
@@ -22109,14 +22109,14 @@
           ],
           "key": "b122a8953185d78aef9ca69a5b8309fb",
           "tweak": "0acd7c7f71f36caf",
-          "msg": "hfVyL}@f##09!G2Y_tE$iZZErWFIC>Og}BY8Xj92WKEXtjRC",
-          "ct": "sVe>f~nC!NK0rcQO~tfb&noXDs%L6hgEh2K1%qm5~OeLIT8W",
+          "msg": "hfVyL}@f##09!G2Y_uE$iZZErWFIC>Og}BY8Xj92WKEXujRC",
+          "ct": "tVe>f~nC!NK0rcQO~ufb&noXDt%L6hgEh2K1%qm5~OeLIT8W",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 49,
       "radix": 85,
@@ -22130,14 +22130,14 @@
           ],
           "key": "6751213d1d6566b27655e74db9e1f864",
           "tweak": "06fa9494a1f7d501",
-          "msg": "(yHSQcje`;5hM`q<C9IJ%_kcq{*_?T>e!TQH`ag#8~qqH5I89",
-          "ct": "$V>6T(HFb@8P!Gb8TYSK8q(3RFs_Y!4j^tn(rdZ2xyH_3U#MX",
+          "msg": "(yHSQcje`;5hM`q<C9IJ%_kcq{*:?T>e!TQH`ag#8~qqH5I89",
+          "ct": "$V>6T(HFb@8P!Gb8TYSK8q(3RFt_Y!4j^sn(rdZ2xyH_3U#MX",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 58,
       "radix": 85,
@@ -22151,14 +22151,14 @@
           ],
           "key": "997ec1bbf9557633a5c9a99d37185e8a",
           "tweak": "c11c04f7f10a4848",
-          "msg": "c5$tc})4;JL4q+A?{!!`GPEybWttix_|$t5jnA`pA3y52#)Ll5iVBzAM;!",
-          "ct": "0GVl>hJOAj#n5AzB@3nqc^J2mA?e#P%!fRqt$Qj!x*UtYC;!9Ui$5z$vvj",
+          "msg": "c5$sc})4;JL4q+A?{!!`GPEybWuuix:|$s5jnA`pA3y52#)Ll5iVBzAM;!",
+          "ct": "0GVl>hJOAj#n5AzB@3nqc^J2mA?e#P%!fRqs$Qj!x*UsYC;!9Ui$5z$wwj",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 59,
       "radix": 85,
@@ -22172,14 +22172,14 @@
           ],
           "key": "1655f3273931a90c8d16b03ce5290b1c",
           "tweak": "ebf8df2d2411a948",
-          "msg": "iHRv?+`5gOoxlx1X_cucUYkTTRz+!Anp_}OBiMrEv_qhG@r?pLdi}n5;ZrC",
-          "ct": "bH02tOg+B@;+j{`zvXX0hs8Ju{H7vfmOBWf0*`n+xI!H*lZSiJrl*uzeNOO",
+          "msg": "iHRw?+`5gOoxlx1X:cvcUYkTTRz+!Anp:}OBiMrEw:qhG@r?pLdi}n5;ZrC",
+          "ct": "bH02sOg+B@;+j{`zwXX0ht8Jv{H7wfmOBWf0*`n+xI!H*lZSiJrl*vzeNOO",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 64,
       "radix": 85,
@@ -22193,14 +22193,14 @@
           ],
           "key": "908bc4120a20f0043e43376761b2735e",
           "tweak": "841888c5b9be1c84",
-          "msg": "z`fRas9&QU8x8cM`l8URQQ4yzBCX4KrLT#;9#TFb|SCgZ_<j>O3ffX#8irD#lM4X",
-          "ct": "aAFvkL!_a9X@)Q$igx9KMBgQ%|ej{7FX)IF77^W;S<V){?m0FV1dhkPdn_?ki<B=",
+          "msg": "z`fRat9&QU8x8cM`l8URQQ4yzBCX4KrLT#;9#TFb|SCgZ:<j>O3ffX#8irD#lM4X",
+          "ct": "aAFwkL!_a9X@)Q$igx9KMBgQ%|ej{7FX)IF77^W;S<V){?m0FV1dhkPdn:?ki<B=",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 68,
       "radix": 85,
@@ -22214,14 +22214,14 @@
           ],
           "key": "ca677ccfa3c198e7be51d82298ee78f1",
           "tweak": "a80a4cb0ff29b919",
-          "msg": "pjgAc*iS(`@$#Snz;54ihn;q=;KpX0>kDF)D9kt)L>DI)U|6o&<W<e8Ze`DG)oJDhztM",
-          "ct": "Am6!d|$%2e4&s60pq6^W)g4U?yY0{*7pt;%5!Qc)l+cxf*UR)TKV}G$Iq4R#Fa2HP!4_",
+          "msg": "pjgAc*iS(`@$#Snz;54ihn;q=;KpX0>kDF)D9ku)L>DI)U|6o&<W<e8Ze`DG)oJDhzsM",
+          "ct": "Am6!d|$%2e4&t60pq6^W)g4U?yY0{*7ps;%5!Qc)l+cxf*UR)TKV}G$Iq4R#Fa2HP!4:",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 69,
       "radix": 85,
@@ -22235,14 +22235,14 @@
           ],
           "key": "099edd6a1055819ad5acf1ceab36a227",
           "tweak": "7c8f9cf12edb4b1a",
-          "msg": "rC18;Xu5416s{8@<+8*Cil<?5_Msqe{3f9AEU!$Lk?>qf5?x$L(DSlF_GCUrrK6|xl$Uc",
-          "ct": "0CRQ_G8cjtC&YomadJS4KMx&6KoD~BQC3XRJ2NiH_mGV_l)jGc;i(P?~9V|8gi!@FjcDZ",
+          "msg": "rC18;Xv5416t{8@<+8*Cil<?5:Mtqe{3f9AEU!$Lk?>qf5?x$L(DSlF:GCUrrK6|xl$Uc",
+          "ct": "0CRQ:G8cjsC&YomadJS4KMx&6KoD~BQC3XRJ2NiH:mGV_l)jGc;i(P?~9V|8gi!@FjcDZ",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 78,
       "radix": 85,
@@ -22256,14 +22256,14 @@
           ],
           "key": "c7566b8d510ca5525d88195d396a71e3",
           "tweak": "7abb76d50351235f",
-          "msg": "s`G6sWeuHjZW72da15S6{eeXM8h}X5tm4|4LL0E?P6SvCA+WEqLUtv*ZzNnavUf2K584M}uIVugEn%",
-          "ct": "zqplp~>)mp(^_SQYuQE2LvjXur}ZjVq?hi)#lF&I%cCkn<Xhus_daXK}CprdqaX#mz_y{^xRmOjR1a",
+          "msg": "t`G6tWevHjZW72da15S6{eeXM8h}X5um4|4LL0E?P6SwCA+WEqLUuw*ZzNnawUf2K584M}vIVvgEn%",
+          "ct": "zqplp~>)mp(^_SQYvQE2LwjXvr}ZjVq?hi)#lF&I%cCkn<Xhvt:daXK}CprdqaX#mz_y{^xRmOjR1a",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 80,
       "radix": 85,
@@ -22277,14 +22277,14 @@
           ],
           "key": "f763833eb5dcad3df492092080b404b6",
           "tweak": "46dc6b38a24f7002",
-          "msg": "#j0f_0Bs}$+Gzp(cEGej(SD*S18Eu`he@xr7mu=^DhEYIoLbdo_B*Fa)GR<iPWY+LblE3SJ}I9k&%akO",
-          "ct": "(qm_39Q6a8S#>NbVZVNTteLATbPD`v=(t=W`)iGBPP!&0etm6_S}~Ui1ME3G2#}#gh2y!<uQ7Pd<v8i9",
+          "msg": "#j0f:0Bt}$+Gzp(cEGej(SD*S18Ev`he@xr7mv=^DhEYIoLbdo_B*Fa)GR<iPWY+LblE3SJ}I9k&%akO",
+          "ct": "(qm:39Q6a8S#>NbVZVNTseLATbPD`w=(u=W`)iGBPP!&0eum6_S}~Ui1ME3G2#}#gh2y!<vQ7Pd<w8i9",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 128,
       "radix": 85,
@@ -22298,14 +22298,14 @@
           ],
           "key": "6e2c702c4dd6ac18054df9905a2a6d63",
           "tweak": "245070546cc82a65",
-          "msg": "$>^1Rf2+1xbYg~$jyL?0qZpm<CBz_WlV4L~oePQ9U}6K<1$i|BotdX#_kK=aF;MbOzRL1cnegy`3&W_i<ER_EFY||HYdq}gpZmu@eLFo&z{oJ9k;(F9J{b_trCgT7*4g",
-          "ct": "m$iQ|H_S(XQ)>@(qgt`5@2xJ;s45V<ku`lZ7M70YraErN*|JDzTP9}dr_<8&S)WGgNi%;L*Q5t9eI}WuN!@us4qC5}Z@lQBoO_07WpzHI5?6p$_^DeCW!^G8rrd((4K!",
+          "msg": "$>^1Rf2+1xbYg~$jyL?0qZpm<CBz:WlV4L~oePQ9U}6K<1$i|BosdX#:kK=aF;MbOzRL1cnegy`3&W_i<ER_EFY||HYdq}gpZmv@eLFo&z{oJ9k;(F9J{b:urCgT7*4g",
+          "ct": "m$iQ|H:S(XQ)>@(qgs`5@2xJ;t45V<kv`lZ7M70YraErN*|JDzTP9}dr:<8&S)WGgNi%;L*Q5u9eI}WvN!@vt4qC5}Z@lQBoO_07WpzHI5?6p$:^DeCW!^G8rrd((4K!",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 128,
       "msgSize": 260,
       "radix": 85,
@@ -22319,14 +22319,14 @@
           ],
           "key": "39fd85d1a418270e382f927fa7d69afe",
           "tweak": "3a0bb251adfea53c",
-          "msg": "#ZT1$l5gMM)mq`O7)^s>WQj71a2?$uZJ0<F)%}}WzZexIuI!EOrNmQr_fXvm7<$P%*V%(|6G67_ykJF+e7*JqfKlcvl)9*DCg6uW`cZ*tQ_r*1GQZ%E)3QRt}Kvh47<)rOoV2fh_+slStevOZEJyl!<%cO=N9|}hr!*7xi52E~5Y2Wv8m86+e8ZysV^Obz|_!@~Rtx`LHFN8<Gv1P~>Cp`XSy<1Ltm_?oEdt?sl<2>xDLM=B>Ko{lx^E)A`kdu_>{kNa",
-          "ct": "T!|~th^Tmo|2*)t4tyBWqvq|7xA$2$F#jr>IT34OK^9g7Uqx;<qI@14(4YNSoMk#zFqiaOp=5e01H_Cnsuq6#B72ymz8@mnyc2Q;v4_B+)q&~krk$b~!`{vmPCG(G<?rmX>aTW{3hLihClUy}qot1SBe8;X<m%i%d>F=1l)VMD;(WtsD<f<7v>#yn!XG2zsQQ9CRXe7j}T1oZ<S0y8&>M>EX9m1#htf=;2#@sT4Px1Q&$p#SQAxiee%Q^ozj_x70R4;6",
+          "msg": "#ZT1$l5gMM)mq`O7)^t>WQj71a2?$vZJ0<F)%}}WzZexIvI!EOrNmQr_fXwm7<$P%*V%(|6G67_ykJF+e7*JqfKlcwl)9*DCg6vW`cZ*uQ_r*1GQZ%E)3QRu}Kwh47<)rOoV2fh:+tlSsewOZEJyl!<%cO=N9|}hr!*7xi52E~5Y2Ww8m86+e8ZytV^Obz|:!@~Rux`LHFN8<Gw1P~>Cp`XSy<1Lsm:?oEds?tl<2>xDLM=B>Ko{lx^E)A`kdv:>{kNa",
+          "ct": "T!|~sh^Tmo|2*)u4syBWqwq|7xA$2$F#jr>IT34OK^9g7Uqx;<qI@14(4YNSoMk#zFqiaOp=5e01H_Cntvq6#B72ymz8@mnyc2Q;w4:B+)q&~krk$b~!`{wmPCG(G<?rmX>aTW{3hLihClUy}qos1SBe8;X<m%i%d>F=1l)VMD;(WutD<f<7w>#yn!XG2ztQQ9CRXe7j}T1oZ<S0y8&>M>EX9m1#hsf=;2#@tT4Px1Q&$p#SQAxiee%Q^ozj_x70R4;6",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 20,
       "radix": 85,
@@ -22340,14 +22340,14 @@
           ],
           "key": "141107e15df419395d338f34ef63f1e80d20b2dad04e5b54",
           "tweak": "b069e365f5a623ff",
-          "msg": "EW)QuKK#K>l?i}z<1s{N",
-          "ct": "`*xKR>c_fbOu_s+J}boP",
+          "msg": "EW)QvKK#K>l?i}z<1t{N",
+          "ct": "`*xKR>c:fbOv:t+J}boP",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 21,
       "radix": 85,
@@ -22361,14 +22361,14 @@
           ],
           "key": "c3bb552dddc77917376b930dc911345e533a17542ddbf421",
           "tweak": "2780a38c74385db3",
-          "msg": "CvixcnBlvVK7SUsIt70tI",
+          "msg": "CwixcnBlwVK7SUtIs70sI",
           "ct": "2Nx;aK>#N{9iXOPWkIrZQ",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 22,
       "radix": 85,
@@ -22382,14 +22382,14 @@
           ],
           "key": "00bdb5e8b811c9617b0c07c9ed50b6d067ac817cbe06e44a",
           "tweak": "d92d8fd1572665ab",
-          "msg": "DdPk8*tx5~_i{e>r|_U%~%",
-          "ct": "Ag0EQHlC_mFF%<fTO8BhAu",
+          "msg": "DdPk8*ux5~_i{e>r|:U%~%",
+          "ct": "Ag0EQHlC:mFF%<fTO8BhAv",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 23,
       "radix": 85,
@@ -22403,14 +22403,14 @@
           ],
           "key": "c7697b0dbeb87d7f395505c37c7aa8851539af55cf9ff48d",
           "tweak": "81c250277f86145e",
-          "msg": "ssF@_2*QUh{ltQvO1|138U{",
+          "msg": "ttF@:2*QUh{lsQwO1|138U{",
           "ct": "1Td!m1}l6)H3!h=G(j@99E<",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 24,
       "radix": 85,
@@ -22424,14 +22424,14 @@
           ],
           "key": "ac7947235faeb09f47808bcdb7c28894767149cfe71948d9",
           "tweak": "f7e5b4f29221b2aa",
-          "msg": "9A=<t3i8ZVq=_;|T5Jc~A;Oq",
+          "msg": "9A=<s3i8ZVq=_;|T5Jc~A;Oq",
           "ct": ";1L(e&e_Jx1~HSo>KMOxyY*X",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 25,
       "radix": 85,
@@ -22445,14 +22445,14 @@
           ],
           "key": "d3cc660039922e4edf19ee000bf0190aa4a974e2af2df506",
           "tweak": "c1eb1cd08201924c",
-          "msg": "fRygpACfBgkI+#RWuRCb>G@4H",
+          "msg": "fRygpACfBgkI+#RWvRCb>G@4H",
           "ct": "*@Dh*=j%2xUcxfjVM*cy2AB05",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 26,
       "radix": 85,
@@ -22466,14 +22466,14 @@
           ],
           "key": "a08b283fbb882bc35ad665f439ba1ba3cb45faa7ef953e75",
           "tweak": "a8bad0d760a36482",
-          "msg": "ITd_$N1tR^Tbp5>l=J&DmZ?@f9",
-          "ct": "`B8%y!Kie@Y`+XhZk_vpE+l{OR",
+          "msg": "ITd_$N1sR^Tbp5>l=J&DmZ?@f9",
+          "ct": "`B8%y!Kie@Y`+XhZk_wpE+l{OR",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 27,
       "radix": 85,
@@ -22487,14 +22487,14 @@
           ],
           "key": "bc8a31cd3bf14b148eb6519268b2bd472de9cce165061efd",
           "tweak": "f62b70082bb992d2",
-          "msg": "8@vJQ>7d*fU>W&^lPrij8Mzyutz",
-          "ct": "^FJVL2UZ_ZB0cv7&&VADhfE*7U@",
+          "msg": "8@wJQ>7d*fU>W&^lPrij8Mzyvuz",
+          "ct": "^FJVL2UZ_ZB0cw7&&VADhfE*7U@",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 28,
       "radix": 85,
@@ -22508,14 +22508,14 @@
           ],
           "key": "0c6561b42c5cde205f8ba1b4fe71ac110ff2807958a069d4",
           "tweak": "1b2ce7022ea31126",
-          "msg": "sShY^_sKxC7q7H_Tp;=foN9J)ABP",
+          "msg": "tShY^_tKxC7q7H_Tp;=foN9J)ABP",
           "ct": "H{@YbEG++i@I;Z+AK*WmZS_SmOkS",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 29,
       "radix": 85,
@@ -22529,14 +22529,14 @@
           ],
           "key": "4e08042735575708e4a9a0df5ae920c4fd181e38e731eb2e",
           "tweak": "36502a1e0aeca248",
-          "msg": ")`+K!K)?R8_E>8|i@(8<j{&>VQiJ8",
+          "msg": ")`+K!K)?R8:E>8|i@(8<j{&>VQiJ8",
           "ct": "QjhMiXNho)c}h`Ci=EGp=o}ALL0Nx",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 30,
       "radix": 85,
@@ -22550,14 +22550,14 @@
           ],
           "key": "5fd8e11413d7659bc1b0be8e8febf6d6342060aa9a91d63d",
           "tweak": "f249815599506c40",
-          "msg": "6qKAaPfE5hX$f^_>gNIAJ_xN~1Qx!!",
+          "msg": "6qKAaPfE5hX$f^_>gNIAJ:xN~1Qx!!",
           "ct": "ghykXxeY+h_De2B7Bo+f(&5zd+Sh}&",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 31,
       "radix": 85,
@@ -22571,14 +22571,14 @@
           ],
           "key": "77b5e0675cc0ecffd9a187798870ce49ce4a9b6807e14b2b",
           "tweak": "dc5996a3061cff92",
-          "msg": "^_kgvAe`A7%QN2H~o%kx~TsJ9P_>;rB",
-          "ct": "ta>%d=&aTiC_U$It3v0}VD0}tif4F1$",
+          "msg": "^_kgwAe`A7%QN2H~o%kx~TtJ9P:>;rB",
+          "ct": "ua>%d=&aTiC_U$Iu3w0}VD0}sif4F1$",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 32,
       "radix": 85,
@@ -22592,14 +22592,14 @@
           ],
           "key": "51bc85303caaaad311ecfdbad7b6d390f51de4de32beeb24",
           "tweak": "5ba80100c8ec15b3",
-          "msg": "HN{`c_<c{OZg$k3@OT%rNiZY5(3Zx%$|",
-          "ct": "_gHRFo={=|AHmTkRtIZvg=B5s{lin<MA",
+          "msg": "HN{`c:<c{OZg$k3@OT%rNiZY5(3Zx%$|",
+          "ct": ":gHRFo={=|AHmTkRsIZwg=B5t{lin<MA",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 33,
       "radix": 85,
@@ -22614,13 +22614,13 @@
           "key": "c873cf24452bb6d1ac26d53a77387c345eb0d8567f49d5ea",
           "tweak": "b46136fc98b7e9f8",
           "msg": "cq?rM~968h}g5g`DFIxo>KQ2i?LDL=Ke0",
-          "ct": "F$fYVR}#2}Ph=)_$#az@0<xt}AEnq=|(2",
+          "ct": "F$fYVR}#2}Ph=)_$#az@0<xs}AEnq=|(2",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 38,
       "radix": 85,
@@ -22634,14 +22634,14 @@
           ],
           "key": "53604548a0e8efc31ac3036e9cd142b0d201fff86faa3a4a",
           "tweak": "d8aca824d25129ed",
-          "msg": "%UgJ=jgfpAbfA#XD(ulUFSu=R1|;ns`XL5t_9D",
-          "ct": "2=YS1AXy$e^2vneF`TmH|h!}hmE=~8r<zrsY4o",
+          "msg": "%UgJ=jgfpAbfA#XD(vlUFSv=R1|;nt`XL5u_9D",
+          "ct": "2=YS1AXy$e^2wneF`TmH|h!}hmE=~8r<zrtY4o",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 39,
       "radix": 85,
@@ -22655,14 +22655,14 @@
           ],
           "key": "f41a007fe8c306f6bf580b158a5b4c87c6f460e843f8d372",
           "tweak": "722e8d6d7b738fef",
-          "msg": "CLaFEbMIadzCJ`_mE3qMO|1cLhu)6`s&iaYrQ@<",
+          "msg": "CLaFEbMIadzCJ`:mE3qMO|1cLhv)6`t&iaYrQ@<",
           "ct": "jNeZ~l2UFd|TT5jTVm<A(9LaCW~UeA+iII=a27R",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 40,
       "radix": 85,
@@ -22676,14 +22676,14 @@
           ],
           "key": "874c932451575931e99c482805c40441d978af9c68bd82af",
           "tweak": "f4a660ef48089bb0",
-          "msg": "QK{0>@O~g|AY5W0SUIO}a~6z0vbNi+u#4eh*nXxF",
-          "ct": "Xo%Et*xNgyeO6%o{1jz@V@p!HAGkk*JHk4XJ#Y5Z",
+          "msg": "QK{0>@O~g|AY5W0SUIO}a~6z0wbNi+v#4eh*nXxF",
+          "ct": "Xo%Eu*xNgyeO6%o{1jz@V@p!HAGkk*JHk4XJ#Y5Z",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 48,
       "radix": 85,
@@ -22697,14 +22697,14 @@
           ],
           "key": "f0a4bbd84f16dad36be4373b711070c4124c18bcdfab8c2a",
           "tweak": "6142f782175ce964",
-          "msg": "nEcOlt0=@T_o5%Ts=ZKOPl3mZ<7du^?4iqSfbrhG%_+>0s5R",
-          "ct": "tqNO|Njn{Nv!&n}AC!6oBi@HBZo&}!XIE8;QATAVtH4Ly_hx",
+          "msg": "nEcOlu0=@T:o5%Tt=ZKOPl3mZ<7dv^?4iqSfbrhG%_+>0t5R",
+          "ct": "uqNO|Njn{Nw!&n}AC!6oBi@HBZo&}!XIE8;QATAVsH4Ly_hx",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 49,
       "radix": 85,
@@ -22718,14 +22718,14 @@
           ],
           "key": "65ef34b1d89420481ba84d3bfc848142fd8b8605643463ad",
           "tweak": "9b2b3168b04da219",
-          "msg": "5ZN)>A|nq>q7S3&_q*Z`=E+$d4#g&j0+Zx|(gxIVD^IOu6O1&",
-          "ct": "YS^P$o~kV^sV?t+s4ekx?_tmIxR_tzWFIvJYtl7KFb6~+(sMg",
+          "msg": "5ZN)>A|nq>q7S3&_q*Z`=E+$d4#g&j0+Zx|(gxIVD^IOv6O1&",
+          "ct": "YS^P$o~kV^tV?s+t4ekx?:umIxR_uzWFIwJYul7KFb6~+(tMg",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 58,
       "radix": 85,
@@ -22739,14 +22739,14 @@
           ],
           "key": "fb6b34a0e0dca9cbbdb7b57f51434e84e498282fb5b3c0c2",
           "tweak": "c2bc4a6e78431c4e",
-          "msg": "aZFl%B?U(#A{D>4$thuhd}rN(x5hAtMf}bUr^L^pRy9zn2hbXF<N&ja&Q1",
-          "ct": "5OrYXio5?2fmhG^Jz}ncQ~8n$L*#&s{p(aOnhq%f(t9O|iTN$$=<%!`KZ7",
+          "msg": "aZFl%B?U(#A{D>4$uhvhd}rN(x5hAsMf}bUr^L^pRy9zn2hbXF<N&ja&Q1",
+          "ct": "5OrYXio5?2fmhG^Jz}ncQ~8n$L*#&t{p(aOnhq%f(u9O|iTN$$=<%!`KZ7",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 59,
       "radix": 85,
@@ -22760,14 +22760,14 @@
           ],
           "key": "63e08f95842e48c314492cb1fe62db93c7aeadc87a16d98b",
           "tweak": "01de076e751ae220",
-          "msg": "Y(4A&tIr_(ioZ@_z@Xd~LIl{5B*^Wp_{Sk>~#UPsSSz}^mvD5l1zoHe3mxg",
-          "ct": "%MDJBh2ctp&C3ZW~AhO2AAd1~3*30${>79%1gPDY=Z|*YzTFqu7_NYhjOz&",
+          "msg": "Y(4A&sIr_(ioZ@_z@Xd~LIl{5B*^Wp:{Sk>~#UPtSSz}^mwD5l1zoHe3mxg",
+          "ct": "%MDJBh2csp&C3ZW~AhO2AAd1~3*30${>79%1gPDY=Z|*YzTFqv7_NYhjOz&",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 64,
       "radix": 85,
@@ -22781,14 +22781,14 @@
           ],
           "key": "e4c130f163d45035558190d51f439765679a202370a0ce7f",
           "tweak": "d99a093ac4bd3488",
-          "msg": "Ebtd8K_}VsQL>qE*tY$MU<J2ceCbaTHc|>9^tx%FNl6=<umcc^o{aJ4XB1)<e0h0",
-          "ct": "KC|i+(Z_{DBvR<efA_a{1*8?r)p*Ce90XB0F#J?~s4_QF5Ho1Y_RFM!77cL?(vyW",
+          "msg": "Ebsd8K:}VtQL>qE*sY$MU<J2ceCbaTHc|>9^sx%FNl6=<vmcc^o{aJ4XB1)<e0h0",
+          "ct": "KC|i+(Z:{DBwR<efA:a{1*8?r)p*Ce90XB0F#J?~t4_QF5Ho1Y:RFM!77cL?(wyW",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 68,
       "radix": 85,
@@ -22802,14 +22802,14 @@
           ],
           "key": "1b98c79886bbc3110a5c046e7ad344c9ba3099bf14324fb8",
           "tweak": "da83a906c085c408",
-          "msg": "BKPa9!>{HBkY%Ixuq=fH3sDOhZqmie8+ra3_f>idXstoYjt}kbcTg2gN>%(APM@;it~m",
-          "ct": "@yW}fA1^upAAY_9>cIOZOT{>v(KloD4~CNgM|M{MX;A|i=bAV`JgD#jeWn~a&%$Jx}on",
+          "msg": "BKPa9!>{HBkY%Ixvq=fH3tDOhZqmie8+ra3:f>idXtuoYju}kbcTg2gN>%(APM@;is~m",
+          "ct": "@yW}fA1^vpAAY_9>cIOZOT{>w(KloD4~CNgM|M{MX;A|i=bAV`JgD#jeWn~a&%$Jx}on",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 69,
       "radix": 85,
@@ -22823,14 +22823,14 @@
           ],
           "key": "ae9ef2d2c4423f0d94e1177ad6a87b631895261a331c7a3b",
           "tweak": "84cdd7f9d16186e4",
-          "msg": "VzF3(mSyJVWLu*mngbAG+6a0ZU1BX8VCWp~&bE{L%Ox0PQaqY!E$%1`tyktT%3b3>5fD;",
-          "ct": "G2t_t+<LaAemLE*~f`^Sx)~Tb&CZr9OuO7oN8Fkb}j{R|c<kq{ig!yPuNK!N#L9bpsP@`",
+          "msg": "VzF3(mSyJVWLv*mngbAG+6a0ZU1BX8VCWp~&bE{L%Ox0PQaqY!E$%1`sykuT%3b3>5fD;",
+          "ct": "G2s:s+<LaAemLE*~f`^Sx)~Tb&CZr9OvO7oN8Fkb}j{R|c<kq{ig!yPvNK!N#L9bptP@`",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 78,
       "radix": 85,
@@ -22844,14 +22844,14 @@
           ],
           "key": "f4ba58959b818668ddd196c2b2efa097b10eba916de3edcf",
           "tweak": "847e9e6712fcb751",
-          "msg": "z#sB0^HHTNE8!LoEI|Cod6`d@?9_53dIezJt5Gq*>vYCPhke>;E#PXYB<PH;3oIa51<h#3kVZN0oD6",
-          "ct": "|xg?<t`m`li((nl)B>i=a8ps}lGZ}bM_5q&y=9=qF;;&MA&_If<JN4s(1Kvp&6|1o8qDjD>5EEMEix",
+          "msg": "z#tB0^HHTNE8!LoEI|Cod6`d@?9:53dIezJu5Gq*>wYCPhke>;E#PXYB<PH;3oIa51<h#3kVZN0oD6",
+          "ct": "|xg?<s`m`li((nl)B>i=a8pt}lGZ}bM_5q&y=9=qF;;&MA&:If<JN4t(1Kwp&6|1o8qDjD>5EEMEix",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 80,
       "radix": 85,
@@ -22865,14 +22865,14 @@
           ],
           "key": "c3290a053478ca018533e702e2d0bf805933488260457c79",
           "tweak": "c814a8fb2641f8ef",
-          "msg": "Z|ybf_%1;I%G`L2T>l_z!kqSM>ykpsUF>x}__ct5TzhVz!EWX3f16xJ6SM`3|dGd99nc8;H#I1X6Kfif",
-          "ct": "gQ=WsS~zAajpviOW!8?+d|BpB9JKTjzc6<3)&g37BZ&*SEp1;0O{kK0EPyUU__>m>pxKzrE63`NIi+3u",
+          "msg": "Z|ybf_%1;I%G`L2T>l_z!kqSM>ykptUF>x}__cs5TzhVz!EWX3f16xJ6SM`3|dGd99nc8;H#I1X6Kfif",
+          "ct": "gQ=WtS~zAajpwiOW!8?+d|BpB9JKTjzc6<3)&g37BZ&*SEp1;0O{kK0EPyUU:_>m>pxKzrE63`NIi+3v",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 128,
       "radix": 85,
@@ -22886,14 +22886,14 @@
           ],
           "key": "f38798eb8567d4a7f70c50782361b5a6261d07e43c8b54ca",
           "tweak": "36c24b7c62ee3538",
-          "msg": "2Uxb~z{utU|9ER2HdGp^MBxT2_4XQS<`r~5OgJ||)1%H>}~(OyQeocxb_9M(kPX>GDNT@>$DPS^NFvkT24n_A7SjNb}Fa>*eB#_^4btxv6qS9KW=s@^F^ZOmn_lGjzvn",
-          "ct": "FVmzI2QStEQqcx=0XK=+MnuMrDrWXLULzzSD(|5pd#~Y>+sSjCMKKGGV0tt!7E$3nBMO$>xYl)vc>xLDax1Li`Al?Hz@hod~`>Hl`~|J!|V)UvDCtL9SB2q9_<~k;f~x",
+          "msg": "2Uxb~z{vsU|9ER2HdGp^MBxT2:4XQS<`r~5OgJ||)1%H>}~(OyQeocxb_9M(kPX>GDNT@>$DPS^NFwkT24n_A7SjNb}Fa>*eB#_^4bsxw6qS9KW=t@^F^ZOmn:lGjzwn",
+          "ct": "FVmzI2QSuEQqcx=0XK=+MnvMrDrWXLULzzSD(|5pd#~Y>+tSjCMKKGGV0us!7E$3nBMO$>xYl)wc>xLDax1Li`Al?Hz@hod~`>Hl`~|J!|V)UwDCsL9SB2q9_<~k;f~x",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 192,
       "msgSize": 260,
       "radix": 85,
@@ -22907,14 +22907,14 @@
           ],
           "key": "ddf845415ef282ad312951d506329229d34582b869cec20f",
           "tweak": "fa3a2a07855bde0b",
-          "msg": "P&?7&U1kHt5&c_5`SzLPV|C``+y^_t8KSxj6c!9PH&Dolf50deE&R_7}mp_uMY+ouyq?Kot=tl1Viinm>EsN{M0h=f4q>1Bp=ql=bURBoeJL6fM%ST=jbv8TY`{56F5##5cmj$DAzr@&0RT+&ibUlWit^D5R*h_;d5HY|clPbrlk)W1rj8QOhD<sH10#)Z!uMqDtGiqBvV^4gelciaJWFi1__v)<BKAxxH#`mUi%1X@TNBgL9q|xfHM1K^6V1V_`_=pv",
-          "ct": "5tIgGjEfg=r&sjH$I7&tcO@44bbc(Y@_f?%C;J4dQ__})Z{5G2U+<$B<lQzZ3F&c}HN8<y%S9u#6atk5%CU`#d{iTGI5z$PB1j{t&R?!cS$*dNjAME4_y_d6OhC*R#P$$RXG)UgO`vbRyBtRo7n}15TD+PYl%+Mh#CYpU8UI6N#bbNXDzVF_M1tg)i>sB;T{OH>x9OiWG<dpr}J_33dt#+cCuKQB5aL@;zf9QO0Ty8d5tOPVqlXGef4ZEOJp3l{ED<5C",
+          "msg": "P&?7&U1kHu5&c:5`SzLPV|C``+y^:s8KSxj6c!9PH&Dolf50deE&R_7}mp:vMY+ovyq?Kou=sl1Viinm>EtN{M0h=f4q>1Bp=ql=bURBoeJL6fM%ST=jbw8TY`{56F5##5cmj$DAzr@&0RT+&ibUlWis^D5R*h_;d5HY|clPbrlk)W1rj8QOhD<tH10#)Z!vMqDuGiqBwV^4gelciaJWFi1:_w)<BKAxxH#`mUi%1X@TNBgL9q|xfHM1K^6V1V_`:=pw",
+          "ct": "5sIgGjEfg=r&tjH$I7&ucO@44bbc(Y@_f?%C;J4dQ_:})Z{5G2U+<$B<lQzZ3F&c}HN8<y%S9v#6auk5%CU`#d{iTGI5z$PB1j{u&R?!cS$*dNjAME4:y:d6OhC*R#P$$RXG)UgO`wbRyBsRo7n}15TD+PYl%+Mh#CYpU8UI6N#bbNXDzVF:M1sg)i>tB;T{OH>x9OiWG<dpr}J:33du#+cCvKQB5aL@;zf9QO0Ty8d5sOPVqlXGef4ZEOJp3l{ED<5C",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 20,
       "radix": 85,
@@ -22928,14 +22928,14 @@
           ],
           "key": "4c4c444584b22485ca88c6afcdbb7beb70c7271f1dece986e93f8c26dceedde2",
           "tweak": "be2f2b3534bdde03",
-          "msg": "^@*hN`Tp&~_}jsD>E0AV",
-          "ct": "Hh|*1?*S6Ht+M)0mAH=C",
+          "msg": "^@*hN`Tp&~_}jtD>E0AV",
+          "ct": "Hh|*1?*S6Hu+M)0mAH=C",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 21,
       "radix": 85,
@@ -22949,14 +22949,14 @@
           ],
           "key": "dda27ee12a33f1e1d641185aa62d77f8788cb29adf7c1d869e5476e04cf8d6a2",
           "tweak": "a07df02be247e7f9",
-          "msg": "_=B+ar)sM8*qWr7}n~AT0",
-          "ct": "&_&oLi|+ZcE}NQ%G5WaS}",
+          "msg": "_=B+ar)tM8*qWr7}n~AT0",
+          "ct": "&:&oLi|+ZcE}NQ%G5WaS}",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 22,
       "radix": 85,
@@ -22970,14 +22970,14 @@
           ],
           "key": "e4d7316dc8f207a390bb0975ae78c2a506361b7a3c762dc970dff471d015a634",
           "tweak": "457e89bd400af1ab",
-          "msg": "t`<Q2*G={bsG;_1M6aBt;1",
-          "ct": "I~Ugn;C6CNnAk1~KsBn<h@",
+          "msg": "s`<Q2*G={btG;_1M6aBs;1",
+          "ct": "I~Ugn;C6CNnAk1~KtBn<h@",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 23,
       "radix": 85,
@@ -22991,14 +22991,14 @@
           ],
           "key": "0d3ce9853bb4fc12233e5c394be7fa40a52f13ce1a348b3ebf7656fb5dd4357b",
           "tweak": "bf83b0337f56f7bf",
-          "msg": "hRiUC=oxSqv!`_Y!Yx)em(9",
-          "ct": "tzdOZ$5%Dq*)8~tt_R_phTH",
+          "msg": "hRiUC=oxSqw!`_Y!Yx)em(9",
+          "ct": "uzdOZ$5%Dq*)8~us:R_phTH",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 24,
       "radix": 85,
@@ -23013,13 +23013,13 @@
           "key": "6dd6f146d834e25b75f7cde4071293e1cb4ed6be6f3e93a1338f21699c844fef",
           "tweak": "a043702fce39a1ce",
           "msg": "qEM=Umiy8=l_;iMOQ6eiJ*#p",
-          "ct": "`uP(vGF3~^PNFhg(!e_}QL?5",
+          "ct": "`vP(wGF3~^PNFhg(!e_}QL?5",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 25,
       "radix": 85,
@@ -23033,14 +23033,14 @@
           ],
           "key": "e0325d51f62ed182ca91eb839e255cae9917f657cb90ac5c9f891c4ecbfb44ba",
           "tweak": "6a15097e7edd42a0",
-          "msg": "b3r`NnlVa0Z0Z$tl@UnjrZ@Ng",
-          "ct": "tfMzBAT9#TP&_|@tp`t!)ibi3",
+          "msg": "b3r`NnlVa0Z0Z$ul@UnjrZ@Ng",
+          "ct": "sfMzBAT9#TP&:|@sp`s!)ibi3",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 26,
       "radix": 85,
@@ -23054,14 +23054,14 @@
           ],
           "key": "219dd3d491cb992c6c8c4d4292b5ee76784b4b383fc415b654f09d600248858b",
           "tweak": "6434003b257c6b31",
-          "msg": "L!Y(Ze68R=K)F>p3XF>T{|_{jD",
-          "ct": "`57VESzJu(7}v8rkK0vXB_5KGL",
+          "msg": "L!Y(Ze68R=K)F>p3XF>T{|:{jD",
+          "ct": "`57VESzJv(7}w8rkK0wXB:5KGL",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 27,
       "radix": 85,
@@ -23075,14 +23075,14 @@
           ],
           "key": "89dcb7b56207898e6bbf9275e00e68d7f08eee8ef17be1a0359b5f15a4c7f476",
           "tweak": "2146a4ee0ca89f28",
-          "msg": "z`Q`_I2;JnRyS#H3^K{&$yd7otu",
-          "ct": "!FYvYeE%Ti$&|{Cha6j*Qek47SS",
+          "msg": "z`Q`:I2;JnRyS#H3^K{&$yd7osv",
+          "ct": "!FYwYeE%Ti$&|{Cha6j*Qek47SS",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 28,
       "radix": 85,
@@ -23096,14 +23096,14 @@
           ],
           "key": "56b5a4449c4eab69ba4deb8094c02b97de3992b606485185334642bf8626dcee",
           "tweak": "46ab2623206bced3",
-          "msg": "IQTT68!c~=bsg~T~7u^Uc>T6g?xU",
-          "ct": "#Vp4rM<E+;&AtRh~Pt81^6>400W2",
+          "msg": "IQTT68!c~=btg~T~7v^Uc>T6g?xU",
+          "ct": "#Vp4rM<E+;&AsRh~Ps81^6>400W2",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 29,
       "radix": 85,
@@ -23117,14 +23117,14 @@
           ],
           "key": "289b50c9fef3028eebb6d8121536042e818bcf1ce7829d123daf3704c95a803d",
           "tweak": "6fc54bb5ade03038",
-          "msg": "MLYT*|O>5s@g#yS}For`p6W3t=!^A",
-          "ct": "25^^Z_p$%3}Q!^Pvp8Y0<7>R$YeG;",
+          "msg": "MLYT*|O>5t@g#yS}For`p6W3u=!^A",
+          "ct": "25^^Z:p$%3}Q!^Pwp8Y0<7>R$YeG;",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 30,
       "radix": 85,
@@ -23139,13 +23139,13 @@
           "key": "73fb9509d5105cc23dc27665da2603ae368bb7472ee6faba1f50369cd283944e",
           "tweak": "5cbf2c8926102868",
           "msg": "K~A^*0|$U~=eqY95_R;0|Op!ZI&P*j",
-          "ct": "U<I8_vFY~WLyl&J{R=^S%IBZfGurvX",
+          "ct": "U<I8_wFY~WLyl&J{R=^S%IBZfGvrwX",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 31,
       "radix": 85,
@@ -23159,14 +23159,14 @@
           ],
           "key": "c469e6908749a713e6ef407c557cea98515c3e931222e22d13b85ea1f6071231",
           "tweak": "47b8d0890cbc7d4d",
-          "msg": "}iW@0`{%(J_odbNoh$x&6FA4r}H1et%",
-          "ct": ";tBlk*7V$*n8@cgK}g8_aC7yF64LN1n",
+          "msg": "}iW@0`{%(J:odbNoh$x&6FA4r}H1eu%",
+          "ct": ";uBlk*7V$*n8@cgK}g8:aC7yF64LN1n",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 32,
       "radix": 85,
@@ -23180,14 +23180,14 @@
           ],
           "key": "233e4fdee70bcc20235b6977ddfc05b0df66f5635d827c66e5a63cdb16a24938",
           "tweak": "1b6819798da15c7a",
-          "msg": "gO6*U<l@>RL0!?H4MlUlY*_6Com76|PM",
-          "ct": "gSQhg^BXZ@9@n%8xL=~TvF6t|<BK#9_d",
+          "msg": "gO6*U<l@>RL0!?H4MlUlY*:6Com76|PM",
+          "ct": "gSQhg^BXZ@9@n%8xL=~TwF6s|<BK#9_d",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 33,
       "radix": 85,
@@ -23201,14 +23201,14 @@
           ],
           "key": "ff5595a976430f9c424459d7206cfa55562f5f2328f12e31232499fb1e7c49b4",
           "tweak": "2d1ad468fddd0754",
-          "msg": "UH(TFF|>WF<JVIYt6W_&$KYmbgd`2zRpK",
-          "ct": "&}0*_xA@h{Na@T+T)>Ieu4C|rZB(b;8XQ",
+          "msg": "UH(TFF|>WF<JVIYs6W_&$KYmbgd`2zRpK",
+          "ct": "&}0*:xA@h{Na@T+T)>Iev4C|rZB(b;8XQ",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 38,
       "radix": 85,
@@ -23222,14 +23222,14 @@
           ],
           "key": "0e7e9058a2bad0b221380073334245863a3806b40db72f97123830b3cf2049f0",
           "tweak": "bd44d8a87bbe2d54",
-          "msg": "+tW~YfNZ6|LdcO=@5i>SL<4Sc1DI%AZcj=plMm",
-          "ct": "vQ)tX<tRg2N6lBYtD&tdNtZ<$8j*IV|lJ2CoJP",
+          "msg": "+sW~YfNZ6|LdcO=@5i>SL<4Sc1DI%AZcj=plMm",
+          "ct": "wQ)uX<sRg2N6lBYuD&sdNsZ<$8j*IV|lJ2CoJP",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 39,
       "radix": 85,
@@ -23243,14 +23243,14 @@
           ],
           "key": "11e30ec3090687f70bb498193541ded7d7accc0b6a8e5106fdf2ca38d34a6ffa",
           "tweak": "c1aec33763cc79cf",
-          "msg": "z8SkQNJDleG>#n?5Itb$3tc60}Kk+|p7<iNebH>",
-          "ct": "V6zxntaOC<Rcbx?>KOx>ZaVfD<!Rut!z;l(vUl|",
+          "msg": "z8SkQNJDleG>#n?5Isb$3sc60}Kk+|p7<iNebH>",
+          "ct": "V6zxnuaOC<Rcbx?>KOx>ZaVfD<!Rvs!z;l(wUl|",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 40,
       "radix": 85,
@@ -23264,14 +23264,14 @@
           ],
           "key": "44d6353fd4623666bb7617a2235ebe645e1685dc11e084d7408c75042d94c06c",
           "tweak": "e0b69ccb91ebb7a3",
-          "msg": "4{(1VafPn#il24L`FlLaYzf=HL~3_;LBhG4Ke4bM",
+          "msg": "4{(1VafPn#il24L`FlLaYzf=HL~3:;LBhG4Ke4bM",
           "ct": "Kbxq4PSzmI!&j_SRVm&hcX(;B+8cEzBF|Gl~h_Sp",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 48,
       "radix": 85,
@@ -23285,14 +23285,14 @@
           ],
           "key": "9a5e26267dd78bbdea69154e593bea02777e9638b8d5b074f2ea690ab8992a4c",
           "tweak": "6dc4c5a01eba799d",
-          "msg": "}*VlL&O!~spBBiDG}Eclu9WRfBEh?|4xt7UGRJ_3~qL+vDM%",
-          "ct": "HkQ!WG_nzIZj!79RE;$$_A#`rD)U@GQa#Pd3CZ!R}ap{TKjb",
+          "msg": "}*VlL&O!~tpBBiDG}Eclv9WRfBEh?|4xs7UGRJ:3~qL+wDM%",
+          "ct": "HkQ!WG:nzIZj!79RE;$$:A#`rD)U@GQa#Pd3CZ!R}ap{TKjb",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 49,
       "radix": 85,
@@ -23306,14 +23306,14 @@
           ],
           "key": "6a63c0ec794a508540f5c63d051a5896850a05a6369b402740a4d48c9a3efddb",
           "tweak": "44f02092cfa81cc3",
-          "msg": "MBygC;Ik87VljYYFL8+xMV(Q&!9F}HmAtlFWp!W{O)SE`iH@e",
-          "ct": "bqzpnnqqxuD546TXXr~$fO;EM_IDx{<d8nzO3Vq>o;_<dbZ_5",
+          "msg": "MBygC;Ik87VljYYFL8+xMV(Q&!9F}HmAslFWp!W{O)SE`iH@e",
+          "ct": "bqzpnnqqxvD546TXXr~$fO;EM_IDx{<d8nzO3Vq>o;:<dbZ:5",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 58,
       "radix": 85,
@@ -23327,14 +23327,14 @@
           ],
           "key": "9470d5bd345466cc72bb04eeb3659dc0ce05c6b6ae4fed60138293d600b1b560",
           "tweak": "9065dfbafcd302a1",
-          "msg": "g*Wo<zR{T1zDR6u)B(PxPKSvP<s(OYx1r^rfCkp1?Q(LlyEo#UqkFI_yfX",
-          "ct": "2he3~91X$acgdsNyd?Bb73L9KlE#ay=I!Z)|y)G&5<`n6yS}+npA7Z^2t`",
+          "msg": "g*Wo<zR{T1zDR6v)B(PxPKSwP<t(OYx1r^rfCkp1?Q(LlyEo#UqkFI_yfX",
+          "ct": "2he3~91X$acgdtNyd?Bb73L9KlE#ay=I!Z)|y)G&5<`n6yS}+npA7Z^2u`",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 59,
       "radix": 85,
@@ -23348,14 +23348,14 @@
           ],
           "key": "1c69b6fe4ceee234ba4118111d64f7ec730ea42e6795e66cb99792c22b0a5fd4",
           "tweak": "34932658fa797462",
-          "msg": "@fE}n)c2Vt_Uof}>vAJFXXVQPtJTF3>QO5<6pX0@cZ_2Zd40j9^T&_H_ag>",
-          "ct": "UG_GZCNi1B_)4zEtqWt#(etXuXY~`<62B;ok`lU7Tou0hI#EDIf9%o$tZ6^",
+          "msg": "@fE}n)c2Vs_Uof}>wAJFXXVQPuJTF3>QO5<6pX0@cZ_2Zd40j9^T&_H:ag>",
+          "ct": "UG:GZCNi1B_)4zEuqWs#(euXvXY~`<62B;ok`lU7Tov0hI#EDIf9%o$sZ6^",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 64,
       "radix": 85,
@@ -23369,14 +23369,14 @@
           ],
           "key": "2f18635c07eefa940f9f24050f44a9ef0a635c87a70897eaceeeeef15fefe1f8",
           "tweak": "4ccb9dd3441d2cfb",
-          "msg": "kiJ@3ih_3N_t{8G34%Ud_3&p%d?{S*V0toJ1G55aBZ#d_9!mIlDa~~pE#<F*DiMo",
-          "ct": "D~bYzVJ}ZI;>z%(nsdz3kGt?OGyJC<&T~vv<zYWAyt{9`I+SRE}j0&~k1j#*U8hI",
+          "msg": "kiJ@3ih:3N:s{8G34%Ud_3&p%d?{S*V0uoJ1G55aBZ#d_9!mIlDa~~pE#<F*DiMo",
+          "ct": "D~bYzVJ}ZI;>z%(ntdz3kGu?OGyJC<&T~ww<zYWAys{9`I+SRE}j0&~k1j#*U8hI",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 68,
       "radix": 85,
@@ -23390,14 +23390,14 @@
           ],
           "key": "696beed5ea99032382d21ed1585d2022eb191f5f7bcb970fe9c8775a8360a4e5",
           "tweak": "66e49596e549e1e2",
-          "msg": "dF!O%ih%1C{n|Ly4VBxaQ{Ib`{tn@g2polXpy_p6H19Wg>DETO=Q%m~P$!Py~5%HpKo?",
-          "ct": "cp7QP)G9OC_=9m7dghUbLFXueD0eED$v#Gd5drcq!Cp#+E1y^?$~Ta>#rBFE8~3^RIAx",
+          "msg": "dF!O%ih%1C{n|Ly4VBxaQ{Ib`{un@g2polXpy:p6H19Wg>DETO=Q%m~P$!Py~5%HpKo?",
+          "ct": "cp7QP)G9OC:=9m7dghUbLFXveD0eED$w#Gd5drcq!Cp#+E1y^?$~Ta>#rBFE8~3^RIAx",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 69,
       "radix": 85,
@@ -23411,14 +23411,14 @@
           ],
           "key": "95c633bee16462726a6856e32fe75cb59d0a3571ca21cbb3038055c7348c8e91",
           "tweak": "e55ce677906b2726",
-          "msg": "l+JX@@`EY%y*U(ZA0Vq?3ej*nO;25@?d?_>EUz5Y}+uTP~6A3bNudy|a_(&o<yTxeMh1b",
-          "ct": "1T6i6P}ksd%|0b2TdtW>eeS{$s5EF}v@A+01NgE{7#l68H>Fyc!tgEX1P{k_+IN5s_yyf",
+          "msg": "l+JX@@`EY%y*U(ZA0Vq?3ej*nO;25@?d?:>EUz5Y}+vTP~6A3bNvdy|a:(&o<yTxeMh1b",
+          "ct": "1T6i6P}ktd%|0b2TdsW>eeS{$t5EF}w@A+01NgE{7#l68H>Fyc!ugEX1P{k:+IN5t_yyf",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 78,
       "radix": 85,
@@ -23432,14 +23432,14 @@
           ],
           "key": "a4f82e06f7bf65c929cfef10d4fde0226a552f95d2cd5ab14973440250ddaf2f",
           "tweak": "829dbff60b3eb6a3",
-          "msg": "<yLc+#^+2tYqo}Op?n#X8|Vvou2iU?0vgMT>Gjxz_{sN&E{I`Xrj5&9>NPSH&&I}J@rSHc7Y@UPlW{",
-          "ct": "oDc|IFJOx#I2o4*il8e2!O}_9Fm}uUPn;u2K<nTD`8&Lt{04kmoRBy43&Bh1<)y8>`_(|QA&F}YK*q",
+          "msg": "<yLc+#^+2sYqo}Op?n#X8|Vwov2iU?0wgMT>Gjxz_{tN&E{I`Xrj5&9>NPSH&&I}J@rSHc7Y@UPlW{",
+          "ct": "oDc|IFJOx#I2o4*il8e2!O}_9Fm}vUPn;v2K<nTD`8&Ls{04kmoRBy43&Bh1<)y8>`:(|QA&F}YK*q",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 80,
       "radix": 85,
@@ -23453,14 +23453,14 @@
           ],
           "key": "4c21f21cf45f61eea701cdae4a3e06a74cd18fd63eec698b49b3a21f4e1c3bf9",
           "tweak": "0ec0a2520507286d",
-          "msg": "Cy_YD#*`6A1<T!0RR8GXVn&jp&W`eU|FT+#jl5S_vnd1CcnDHUm@0Fzyn84bK+J0K7(Wn5yc#DL@b4`!",
-          "ct": "5PU~4G!QnWIFaTlxoRmt18n#|5rKDjU2K_uPJspVuyPnxXTqjx>yttWRWO;{=pk4P1oDO;6&LEP+_+4}",
+          "msg": "Cy_YD#*`6A1<T!0RR8GXVn&jp&W`eU|FT+#jl5S_wnd1CcnDHUm@0Fzyn84bK+J0K7(Wn5yc#DL@b4`!",
+          "ct": "5PU~4G!QnWIFaTlxoRmu18n#|5rKDjU2K_vPJtpVvyPnxXTqjx>yssWRWO;{=pk4P1oDO;6&LEP+_+4}",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 128,
       "radix": 85,
@@ -23474,14 +23474,14 @@
           ],
           "key": "0a04c284ea0028d71c986b4e547c0e03cc8969ac81ec89dacf67df23bf72d461",
           "tweak": "fdb7b6eda7cdb93c",
-          "msg": "?F4tb7%VaF6GYfYWO!7)G@_01=IgO8s^XRRGDDr!5mN(+@6V^1g+k|5*MSUM@cX}r9k~&n2D3z*t3fi`vBI}E{X)*Mjz3MtJpQYkL!1#vcPX_y;3`4P$(QUzk7VW9Zl5",
-          "ct": "r9dtqCZ@P;#36LH`P~||(&tHd?BtvG8_vyYfr^78Uj5DH6N8bThl_RkcoizYt#NK(b5C_A&eZ;%x$Xp^Y{P}vEzHey5llzH2<c>5qkU#_A3ig`XLGMYK~RMVIs{4J`;&",
+          "msg": "?F4sb7%VaF6GYfYWO!7)G@:01=IgO8t^XRRGDDr!5mN(+@6V^1g+k|5*MSUM@cX}r9k~&n2D3z*u3fi`wBI}E{X)*Mjz3MsJpQYkL!1#wcPX:y;3`4P$(QUzk7VW9Zl5",
+          "ct": "r9duqCZ@P;#36LH`P~||(&uHd?BswG8_wyYfr^78Uj5DH6N8bThl:RkcoizYs#NK(b5C:A&eZ;%x$Xp^Y{P}wEzHey5llzH2<c>5qkU#:A3ig`XLGMYK~RMVIt{4J`;&",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 256,
       "msgSize": 260,
       "radix": 85,
@@ -23495,14 +23495,14 @@
           ],
           "key": "e3009a081a300a5d2c99b076d69e8479ab2e040342b7558d4fb8c6cf978e809f",
           "tweak": "ae2aa7fbd0c4542d",
-          "msg": "Fbm29<}&RGb{I&mWWUOd$}6DJJE7g()hm#xj4?!HU0$a#;srNam_1jP*N_+RCUZ*(L!rSyyscNs@`7qaD<F+$I6iOreIB^+K51zgGaBzhu_czcV>)?Br%Gn)N}o0cnB!t1)JyxPeYA%5b6tX*!T4`5FjpyL=mYQ}zKv%5eK9I`!o1udPZ(Qqz88q=vi#6y=fg26%jl+glu;#eZoX2~ADRxpzPxD*`)kHyJ!$1J_V}{Q7+EYxzrvA0PEy?WaX{93Ym<fN",
-          "ct": "q|E>pG4nk8@qdlzGUACVmRW2>_RaoHOmKt5mLC5gdu;11pdbb}!B68{U5zPT`z#57>b;UUVIx3csm_C%#4f?*mA4)N!)t_>e5o&iBtmSY5A^fz~|l;<GUy&V<ufiYg~+QqPXVUFQ@=FFT|e8i#_y`r*6FJ1I^G0cX~x(n5v4Mt=j;qL@<{=T<oNE!<t2dbC{%`Z;Q#Stz_KkH9U3^Xlv?)dg%a4{%8Qbtaha&Wqfd1$T>+gAFvhK_#?Izf?{A_tJD_Q0",
+          "msg": "Fbm29<}&RGb{I&mWWUOd$}6DJJE7g()hm#xj4?!HU0$a#;trNam:1jP*N_+RCUZ*(L!rSyytcNt@`7qaD<F+$I6iOreIB^+K51zgGaBzhv_czcV>)?Br%Gn)N}o0cnB!s1)JyxPeYA%5b6sX*!T4`5FjpyL=mYQ}zKw%5eK9I`!o1vdPZ(Qqz88q=wi#6y=fg26%jl+glv;#eZoX2~ADRxpzPxD*`)kHyJ!$1J:V}{Q7+EYxzrwA0PEy?WaX{93Ym<fN",
+          "ct": "q|E>pG4nk8@qdlzGUACVmRW2>_RaoHOmKs5mLC5gdv;11pdbb}!B68{U5zPT`z#57>b;UUVIx3ctm_C%#4f?*mA4)N!)s:>e5o&iBumSY5A^fz~|l;<GUy&V<vfiYg~+QqPXVUFQ@=FFT|e8i#:y`r*6FJ1I^G0cX~x(n5w4Ms=j;qL@<{=T<oNE!<u2dbC{%`Z;Q#Ssz:KkH9U3^Xlw?)dg%a4{%8Qbuaha&Wqfd1$T>+gAFwhK_#?Izf?{A:uJD:Q0",
           "result": "valid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 0,
       "msgSize": 4,
       "radix": 85,
@@ -23523,7 +23523,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 8,
       "msgSize": 4,
       "radix": 85,
@@ -23544,7 +23544,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 64,
       "msgSize": 4,
       "radix": 85,
@@ -23558,14 +23558,14 @@
           ],
           "key": "1f22cd7ded80f7a8",
           "tweak": "f40e82cd7c24eee2",
-          "msg": "MauE",
+          "msg": "MavE",
           "ct": "",
           "result": "invalid"
         }
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 160,
       "msgSize": 4,
       "radix": 85,
@@ -23586,7 +23586,7 @@
       ]
     },
     {
-      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrtstuvxyz!#$%&()*+_;<=>?@^_`{|}~",
+      "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+:;<=>?@^_`{|}~",
       "keySize": 320,
       "msgSize": 4,
       "radix": 85,
@@ -23600,7 +23600,7 @@
           ],
           "key": "9a1b29efd5efb6504153004d40c73dba3157f7aa627104918b6d1abf5723830f4d106d3178a59209",
           "tweak": "c91e67905cb51765",
-          "msg": "&9_r",
+          "msg": "&9:r",
           "ct": "",
           "result": "invalid"
         }


### PR DESCRIPTION
Implements the fixed vectors offered by @dspdon in https://github.com/C2SP/wycheproof/issues/239

* Corrects the base85 alphabet. Previously it was only 83 distinct characters: `s`/`t` were transposed, w was omitted, and `_` appeared twice.
* Standardizes the invalid-plaintext sentinels. Previously digit `-1` was rendered inconsistently as one of 10 different out-of-alphabet characters `(', ,, -, ., /, :, [, \, ], w)`, and digit 85 was rendered as `\x7f` (non-printable DEL). The updated vectors use `-` for both (which is not in the new alphabet, so the test cases remain invalid).

I did a quick sanity pass on the other `aes_ff1_*` testvectors and didn't spot any similar issues in their alphabets. Further review input welcome.

Resolves #239 