### PR TITLE
go.mod: raise go directive to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/c2sp/wycheproof
 
-go 1.24.0
+go 1.26.4
 
 require (
 	filippo.io/edwards25519 v1.1.0


### PR DESCRIPTION
Addresses [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) and [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) flagged by govulncheck [in CI](https://github.com/C2SP/wycheproof/actions/runs/26882219589/job/79284923825).

Given the limited downstream use of our module it seemed preferable to bump the `go` directive vs using a `toolchain` directive but I'm open to revisiting this.