### PR TITLE
Add reference to leancrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ cryptography projects and libraries. In no particular order these include:
 * [Zig](https://github.com/ziglang/zig)
 * [liboqs](https://github.com/open-quantum-safe/liboqs)
 * [bc-rust](https://github.com/bcgit/bc-rust)
+* [leancrypto](https://github.com/smuellerDD/leancrypto)
 
 If your project uses test vectors from Wycheproof, feel free to open a PR
 to add it to the list above!


### PR DESCRIPTION
The leancrypto library applies the Wycheproof testing as outlined in [1]. The Wycheproof testing is run during each commit with the Github action [2].

[1] https://leancrypto.org/leancrypto/rust/wycheproof/index.html

[2] https://github.com/smuellerDD/leancrypto/actions/workflows/rust.yml