### PR TITLE
ascon: clarfiy vectors are for v1.2 (not SP 800-232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ including
 - AES-GCM
 - AES-SIV
 - ARIA
-- ASCON
+- ASCON v1.2 (not yet SP 800-232)
 - Camellia
 - ChaCha20-Poly1305
 - XChaCha20-Poly1305

--- a/testvectors_v1/ascon128_test.json
+++ b/testvectors_v1/ascon128_test.json
@@ -3,6 +3,11 @@
   "schema": "aead_test_schema_v1.json",
   "numberOfTests": 192,
   "header": [
+    "These test vectors implement Ascon-128 v1.2, the final-round submission to the",
+    "NIST Lightweight Cryptography competition. This variant was NOT standardized:",
+    "NIST SP 800-232 defines only Ascon-AEAD128, which is a distinct algorithm and",
+    "is not interoperable with Ascon-128. These vectors are not suitable for",
+    "testing an SP 800-232 implementation.",
     "Test vectors of type AeadTest test authenticated encryption with additional data.",
     "The test vectors are intended for testing both encryption and decryption.",
     "Test vectors with \"result\" : \"valid\" are valid encryptions.",

--- a/testvectors_v1/ascon128a_test.json
+++ b/testvectors_v1/ascon128a_test.json
@@ -3,6 +3,12 @@
   "schema": "aead_test_schema_v1.json",
   "numberOfTests": 192,
   "header": [
+    "These test vectors implement Ascon-128a v1.2, the final-round submission to",
+    "the NIST Lightweight Cryptography competition. Ascon-AEAD128 as standardized",
+    "in NIST SP 800-232 is derived from Ascon-128a but is NOT interoperable with",
+    "it: initialization vector, byte ordering, padding, and domain separation are",
+    "different. As a result these vectors are not suitable for testing an SP 800-232",
+    "implementation.",
     "Test vectors of type AeadTest test authenticated encryption with additional data.",
     "The test vectors are intended for testing both encryption and decryption.",
     "Test vectors with \"result\" : \"valid\" are valid encryptions.",

--- a/testvectors_v1/ascon80pq_test.json
+++ b/testvectors_v1/ascon80pq_test.json
@@ -3,6 +3,11 @@
   "schema": "aead_test_schema_v1.json",
   "numberOfTests": 192,
   "header": [
+    "These test vectors implement Ascon-80pq v1.2, the final-round submission to",
+    "the NIST Lightweight Cryptography competition. This variant was NOT",
+    "standardized: NIST SP 800-232 defines only Ascon-AEAD128, which is a distinct",
+    "algorithm and is not interoperable with Ascon-80pq. These vectors are not",
+    "suitable for testing an SP 800-232 implementation.",
     "Test vectors of type AeadTest test authenticated encryption with additional data.",
     "The test vectors are intended for testing both encryption and decryption.",
     "Test vectors with \"result\" : \"valid\" are valid encryptions.",


### PR DESCRIPTION
Add mention to the `ascon128_test.json`, `ascon128a_test.json`, and `ascon80pq_test.json` vector headers that they implement Ascon-128, Ascon-128a, and Ascon-80pq v1.2, the final-round submission to the NIST LWC competition. They are **not** interoperable with the SP 800-232 standardized algorithm.

For reference, see [ascon.py](https://github.com/C2SP/wycheproof/blob/cff6adf42662469a1871e57303a0ad1d758ed8c0/src/ascon.py) and [gen_ascon.py](https://github.com/C2SP/wycheproof/blob/cff6adf42662469a1871e57303a0ad1d758ed8c0/src/gen_ascon.py) from [google-wycheproof/v0.9](https://github.com/C2SP/wycheproof/releases/tag/google-wycheproof%2Fv0.9).

We should replace/augment these with SP 800-232 compatible vectors as follow-up. In the meantime, try to avoid potential confusion.

Updates https://github.com/C2SP/wycheproof/issues/262