### PR TITLE
Add reference to Odin

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ cryptography projects and libraries. In no particular order these include:
 * [liboqs](https://github.com/open-quantum-safe/liboqs)
 * [bc-rust](https://github.com/bcgit/bc-rust)
 * [leancrypto](https://github.com/smuellerDD/leancrypto)
+* [Odin](https://github.com/odin-lang/odin)
 
 If your project uses test vectors from Wycheproof, feel free to open a PR
 to add it to the list above!


### PR DESCRIPTION
The Odin language standard library has been using wycheproof as part of the development and testing process for quite a while, first as an external test harness, and now integrated[1] as part of CI[2].

[1]: https://github.com/odin-lang/Odin/tree/master/tests/core/crypto/wycheproof
[2]: https://github.com/odin-lang/Odin/blob/master/.github/workflows/ci.yml