### PR TITLE
eddsa: test vector clarifications + extra test case

### DIFF
--- a/testvectors_v1/ed25519_test.json
+++ b/testvectors_v1/ed25519_test.json
@@ -554,7 +554,7 @@
       "tests": [
         {
           "tcId": 42,
-          "comment": "modified bit 0 in R",
+          "comment": "modified bit 0 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -564,7 +564,7 @@
         },
         {
           "tcId": 43,
-          "comment": "modified bit 1 in R",
+          "comment": "modified bit 1 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -574,7 +574,7 @@
         },
         {
           "tcId": 44,
-          "comment": "modified bit 2 in R",
+          "comment": "modified bit 2 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -584,7 +584,7 @@
         },
         {
           "tcId": 45,
-          "comment": "modified bit 7 in R",
+          "comment": "modified bit 7 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -594,7 +594,7 @@
         },
         {
           "tcId": 46,
-          "comment": "modified bit 8 in R",
+          "comment": "modified bit 8 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -604,7 +604,7 @@
         },
         {
           "tcId": 47,
-          "comment": "modified bit 16 in R",
+          "comment": "modified bit 16 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -614,7 +614,7 @@
         },
         {
           "tcId": 48,
-          "comment": "modified bit 31 in R",
+          "comment": "modified bit 31 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -624,7 +624,7 @@
         },
         {
           "tcId": 49,
-          "comment": "modified bit 32 in R",
+          "comment": "modified bit 32 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -634,7 +634,7 @@
         },
         {
           "tcId": 50,
-          "comment": "modified bit 63 in R",
+          "comment": "modified bit 63 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -644,7 +644,7 @@
         },
         {
           "tcId": 51,
-          "comment": "modified bit 64 in R",
+          "comment": "modified bit 64 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -654,7 +654,7 @@
         },
         {
           "tcId": 52,
-          "comment": "modified bit 97 in R",
+          "comment": "modified bit 97 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -664,7 +664,7 @@
         },
         {
           "tcId": 53,
-          "comment": "modified bit 127 in R",
+          "comment": "modified bit 127 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -674,7 +674,7 @@
         },
         {
           "tcId": 54,
-          "comment": "modified bit 240 in R",
+          "comment": "modified bit 240 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -684,7 +684,7 @@
         },
         {
           "tcId": 55,
-          "comment": "modified bit 247 in R",
+          "comment": "modified bit 247 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -694,7 +694,7 @@
         },
         {
           "tcId": 56,
-          "comment": "modified bit 248 in R",
+          "comment": "modified bit 248 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -704,7 +704,7 @@
         },
         {
           "tcId": 57,
-          "comment": "modified bit 253 in R",
+          "comment": "modified bit 253 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -714,7 +714,7 @@
         },
         {
           "tcId": 58,
-          "comment": "modified bit 254 in R",
+          "comment": "modified bit 254 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -724,7 +724,7 @@
         },
         {
           "tcId": 59,
-          "comment": "modified bit 255 in R",
+          "comment": "modified bit 255 in R. This flips the sign of x and yields the canonical encoding of the negated R point. Accepted only by verifiers that ignore the sign of x when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],

--- a/testvectors_v1/ed25519_test.json
+++ b/testvectors_v1/ed25519_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "EDDSA",
   "schema": "eddsa_verify_schema_v1.json",
-  "numberOfTests": 150,
+  "numberOfTests": 151,
   "header": [
     "Test vectors of type EddsaVerify are intended for testing"
   ],
@@ -3320,6 +3320,39 @@
           "msg": "44530b0b34f598767a7b875b0caee3c7b9c502d1",
           "sig": "cfbd450a2c83cb8436c348822fe3ee347d4ee937b7f2ea11ed755cc52852407c9eec2c1fa30d2f9aef90e89b2cc3bcef2b1b9ca59f712110d19894a9cf6a2802",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/cpu/eddsazerosigngen",
+        "version": "1.0"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+      },
+      "publicKeyDer": "302a300506032b6570032100d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "kid": "none",
+        "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+      },
+      "tests": [
+        {
+          "tcId": 151,
+          "comment": "R encodes y = 1 with the sign bit of x set. The only point with y = 1 has x = 0, so decoding must fail (RFC 8032, Section 5.1.3). Accepted only by verifiers that ignore the sign of x.",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "0100000000000000000000000000000000000000000000000000000000000080c803ee1f2342aa96ff698a393d1ab5e66f3eda101d6d120b394c3fd32c117d0a",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ed25519_test.json
+++ b/testvectors_v1/ed25519_test.json
@@ -787,7 +787,7 @@
       "tests": [
         {
           "tcId": 63,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + L. The scalar is unchanged mod L. Accepted only by verifiers that fail to enforce s < L. See RFC 8032, Section 5.1.7.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -797,7 +797,7 @@
         },
         {
           "tcId": 64,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 2L. The scalar is unchanged mod L. Accepted only by verifiers that fail to enforce s < L. See RFC 8032, Section 5.1.7.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -807,7 +807,7 @@
         },
         {
           "tcId": 65,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 4L. The scalar is unchanged mod L. Accepted only by verifiers that fail to enforce s < L. See RFC 8032, Section 5.1.7.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -817,7 +817,7 @@
         },
         {
           "tcId": 66,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 8L. The scalar is unchanged mod L. Accepted only by verifiers that fail to enforce s < L. See RFC 8032, Section 5.1.7.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -827,7 +827,7 @@
         },
         {
           "tcId": 67,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 2^253. The scalar differs from the valid s mod L, so verification fails even without a range check on s. Accepted only by parsers that silently clear bit 253 of s.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -837,7 +837,7 @@
         },
         {
           "tcId": 68,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 2^254. The scalar differs from the valid s mod L, so verification fails even without a range check on s. Accepted only by parsers that silently clear bit 254 of s.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -847,7 +847,7 @@
         },
         {
           "tcId": 69,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 2^255. The scalar differs from the valid s mod L, so verification fails even without a range check on s. Accepted only by parsers that silently clear bit 255 of s.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -857,7 +857,7 @@
         },
         {
           "tcId": 70,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + p where p is the field prime 2^255 - 19. The scalar differs from the valid s mod L, so verification fails even without a range check on s. Accepted only by verifiers that reduce s mod p instead of checking s < L.",
           "flags": [
             "SignatureMalleability"
           ],

--- a/testvectors_v1/ed25519_test.json
+++ b/testvectors_v1/ed25519_test.json
@@ -13,8 +13,8 @@
     },
     "InvalidEncoding": {
       "bugType": "CAN_OF_WORMS",
-      "description": "The test vector contains a signature with an invalid encoding of the values. The vector checks that invalid encodings are not accepted.",
-      "effect": "The effect of accepting such signatures is unclear. It could lead to signature malleability, be benign, or hide something more severe."
+      "description": "The test vector contains a signature with an invalid encoding of the values. The vector checks that invalid encodings are not accepted. For the vectors that modify the encoding of R, S has been recomputed so that the hash matches the modified R and the R recovered from S and the hash equals the original R. Such vectors are accepted only by verifiers that decode R leniently or that compare R to the recovered R incompletely.",
+      "effect": "Accepting such signatures means the encoding of a signature is not unique. A holder of the private key can generate multiple distinct signatures for the same message, and different verifiers can disagree about which signatures are valid."
     },
     "InvalidKtv": {
       "bugType": "UNKNOWN",

--- a/testvectors_v1/ed25519_test.json
+++ b/testvectors_v1/ed25519_test.json
@@ -31,11 +31,11 @@
     },
     "SignatureMalleability": {
       "bugType": "SIGNATURE_MALLEABILITY",
-      "description": "EdDSA signatures are non-malleable, if implemented correctly. If an implementation fails to check the range of S then it may be possible to modify a signature in such a way that it still verifies. See RFC 8032, Section 5.2.7 and Section 8.4."
+      "description": "EdDSA signatures are non-malleable, if implemented correctly. If an implementation fails to check the range of S then it may be possible to modify a signature in such a way that it still verifies. See RFC 8032, Section 5.1.7 and Section 8.4."
     },
     "SignatureWithGarbage": {
       "bugType": "SIGNATURE_MALLEABILITY",
-      "description": "The test vector contains a signature with additional content. EdDSA signature are expected to be non-malleable. Signatures of the wrong length should be rejected. See RFC 8032, Section 5.2.7 and Section 8.4."
+      "description": "The test vector contains a signature with additional content. EdDSA signature are expected to be non-malleable. Signatures of the wrong length should be rejected. See RFC 8032, Section 5.1.7 and Section 8.4."
     },
     "TinkOverflow": {
       "bugType": "KNOWN_BUG",

--- a/testvectors_v1/ed448_test.json
+++ b/testvectors_v1/ed448_test.json
@@ -550,7 +550,7 @@
       "tests": [
         {
           "tcId": 42,
-          "comment": "modified bit 0 in R",
+          "comment": "modified bit 0 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -560,7 +560,7 @@
         },
         {
           "tcId": 43,
-          "comment": "modified bit 1 in R",
+          "comment": "modified bit 1 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -570,7 +570,7 @@
         },
         {
           "tcId": 44,
-          "comment": "modified bit 2 in R",
+          "comment": "modified bit 2 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -580,7 +580,7 @@
         },
         {
           "tcId": 45,
-          "comment": "modified bit 7 in R",
+          "comment": "modified bit 7 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -590,7 +590,7 @@
         },
         {
           "tcId": 46,
-          "comment": "modified bit 8 in R",
+          "comment": "modified bit 8 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -600,7 +600,7 @@
         },
         {
           "tcId": 47,
-          "comment": "modified bit 16 in R",
+          "comment": "modified bit 16 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -610,7 +610,7 @@
         },
         {
           "tcId": 48,
-          "comment": "modified bit 31 in R",
+          "comment": "modified bit 31 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -620,7 +620,7 @@
         },
         {
           "tcId": 49,
-          "comment": "modified bit 32 in R",
+          "comment": "modified bit 32 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -630,7 +630,7 @@
         },
         {
           "tcId": 50,
-          "comment": "modified bit 63 in R",
+          "comment": "modified bit 63 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -640,7 +640,7 @@
         },
         {
           "tcId": 51,
-          "comment": "modified bit 64 in R",
+          "comment": "modified bit 64 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -650,7 +650,7 @@
         },
         {
           "tcId": 52,
-          "comment": "modified bit 97 in R",
+          "comment": "modified bit 97 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -660,7 +660,7 @@
         },
         {
           "tcId": 53,
-          "comment": "modified bit 127 in R",
+          "comment": "modified bit 127 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -670,7 +670,7 @@
         },
         {
           "tcId": 54,
-          "comment": "modified bit 240 in R",
+          "comment": "modified bit 240 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -680,7 +680,7 @@
         },
         {
           "tcId": 55,
-          "comment": "modified bit 247 in R",
+          "comment": "modified bit 247 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -690,7 +690,7 @@
         },
         {
           "tcId": 56,
-          "comment": "modified bit 248 in R",
+          "comment": "modified bit 248 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -700,7 +700,7 @@
         },
         {
           "tcId": 57,
-          "comment": "modified bit 253 in R",
+          "comment": "modified bit 253 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -710,7 +710,7 @@
         },
         {
           "tcId": 58,
-          "comment": "modified bit 254 in R",
+          "comment": "modified bit 254 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -720,7 +720,7 @@
         },
         {
           "tcId": 59,
-          "comment": "modified bit 255 in R",
+          "comment": "modified bit 255 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -730,7 +730,7 @@
         },
         {
           "tcId": 60,
-          "comment": "modified bit 440 in R",
+          "comment": "modified bit 440 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -740,7 +740,7 @@
         },
         {
           "tcId": 61,
-          "comment": "modified bit 441 in R",
+          "comment": "modified bit 441 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -750,7 +750,7 @@
         },
         {
           "tcId": 62,
-          "comment": "modified bit 447 in R",
+          "comment": "modified bit 447 in R. Accepted only by verifiers that ignore this bit when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -760,7 +760,7 @@
         },
         {
           "tcId": 63,
-          "comment": "modified bit 448 in R",
+          "comment": "modified bit 448 in R. Bits 448 to 454 of R are unused and must be zero, so the modified R is an invalid encoding. Accepted only by parsers that ignore the unused bits of R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -770,7 +770,7 @@
         },
         {
           "tcId": 64,
-          "comment": "modified bit 449 in R",
+          "comment": "modified bit 449 in R. Bits 448 to 454 of R are unused and must be zero, so the modified R is an invalid encoding. Accepted only by parsers that ignore the unused bits of R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -780,7 +780,7 @@
         },
         {
           "tcId": 65,
-          "comment": "modified bit 454 in R",
+          "comment": "modified bit 454 in R. Bits 448 to 454 of R are unused and must be zero, so the modified R is an invalid encoding. Accepted only by parsers that ignore the unused bits of R.",
           "flags": [
             "InvalidEncoding"
           ],
@@ -790,7 +790,7 @@
         },
         {
           "tcId": 66,
-          "comment": "modified bit 455 in R",
+          "comment": "modified bit 455 in R. This flips the sign of x and yields the canonical encoding of the negated R point. Accepted only by verifiers that ignore the sign of x when comparing R to the recovered R.",
           "flags": [
             "InvalidEncoding"
           ],

--- a/testvectors_v1/ed448_test.json
+++ b/testvectors_v1/ed448_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "EDDSA",
   "schema": "eddsa_verify_schema_v1.json",
-  "numberOfTests": 86,
+  "numberOfTests": 87,
   "header": [
     "Test vectors of type EddsaVerify are intended for testing"
   ],
@@ -1227,6 +1227,39 @@
           "msg": "6ddf802e1aae4986935f7f981ba3f0351d6273c0a0c22c9c0e8339168e675412a3debfaf435ed651558007db4384b650fcc07e3b586a27a4f7a00ac8a6fec2cd86ae4bf1570c41e6a40c931db27b2faa15a8cedd52cff7362c4e6e23daec0fbc3a79b6806e316efcc7b68119bf46bc76a26067a53f296dafdbdc11c77f7777e972660cf4b6a9b369a6665f02e0cc9b6edfad136b4fabe723d2813db3136cfde9b6d044322fee2947952e031b73ab5c603349b307bdc27bc6cb8b8bbd7bd323219b8033a581b59eadebb09b3c4f3d2277d4f0343624acc817804728b25ab797172b4c5c21a22f9c7839d64300232eb66e53f31c723fa37fe387c7d3e50bdf9813a30e5bb12cf4cd930c40cfb4e1fc622592a49588794494d56d24ea4b40c89fc0596cc9ebb961c8cb10adde976a5d602b1c3f85b9b9a001ed3c6a4d3b1437f52096cd1956d042a597d561a596ecd3d1735a8d570ea0ec27225a2c4aaff26306d1526c1af3ca6d9cf5a2c98f47e1c46db9a33234cfd4d81f2c98538a09ebe76998d0d8fd25997c7d255c6d66ece6fa56f11144950f027795e653008f4bd7ca2dee85d8e90f3dc315130ce2a00375a318c7c3d97be2c8ce5b6db41a6254ff264fa6155baee3b0773c0f497c573f19bb4f4240281f0b1f4f7be857a4e59d416c06b4c50fa09e1810ddc6b1467baeac5a3668d11b6ecaa901440016f389f80acc4db977025e7f5924388c7e340a732e554440e76570f8dd71b7d640b3450d1fd5f0410a18f9a3494f707c717b79b4bf75c98400b096b21653b5d217cf3565c9597456f70703497a078763829bc01bb1cbc8fa04eadc9a6e3f6699587a9e75c94e5bab0036e0b2e711392cff0047d0d6b05bd2a588bc109718954259f1d86678a579a3120f19cfb2963f177aeb70f2d4844826262e51b80271272068ef5b3856fa8535aa2a88b2d41f2a0e2fda7624c2850272ac4a2f561f8f2f7a318bfd5caf9696149e4ac824ad3460538fdc25421beec2cc6818162d06bbed0c40a387192349db67a118bada6cd5ab0140ee273204f628aad1c135f770279a651e24d8c14d75a6059d76b96a6fd857def5e0b354b27ab937a5815d16b5fae407ff18222c6d1ed263be68c95f32d908bd895cd76207ae726487567f9a67dad79abec316f683b17f2d02bf07e0ac8b5bc6162cf94697b3c27cd1fea49b27f23ba2901871962506520c392da8b6ad0d99f7013fbc06c2c17a569500c8a7696481c1cd33e9b14e40b82e79a5f5db82571ba97bae3ad3e0479515bb0e2b0f3bfcd1fd33034efc6245eddd7ee2086ddae2600d8ca73e214e8c2b0bdb2b047c6a464a562ed77b73d2d841c4b34973551257713b753632efba348169abc90a68f42611a40126d7cb21b58695568186f7e569d2ff0f9e745d0487dd2eb997cafc5abf9dd102e62ff66cba87",
           "sig": "e301345a41a39a4d72fff8df69c98075a0cc082b802fc9b2b6bc503f926b65bddf7f4c8f1cb49f6396afc8a70abe6d8aef0db478d4c6b2970076c6a0484fe76d76b3a97625d79f1ce240e7c576750d295528286f719b413de9ada3e8eb78ed573603ce30d8bb761785dc30dbc320869e1a00",
           "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/cpu/eddsazerosigngen",
+        "version": "1.0"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards448",
+        "keySize": 448,
+        "pk": "5fd7449b59b461fd2ce787ec616ad46a1da1342485a70e1f8a0ea75d80e96778edf124769b46c7061bd6783df1e50f6cd1fa1abeafe8256180"
+      },
+      "publicKeyDer": "3043300506032b6571033a005fd7449b59b461fd2ce787ec616ad46a1da1342485a70e1f8a0ea75d80e96778edf124769b46c7061bd6783df1e50f6cd1fa1abeafe8256180",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMEMwBQYDK2VxAzoAX9dEm1m0Yf0s54fsYWrUah2hNCSFpw4fig6nXYDpZ3jt8SR2\nm0bHBhvWeD3x5Q9s0foavq/oJWGA\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed448",
+        "kid": "none",
+        "x": "X9dEm1m0Yf0s54fsYWrUah2hNCSFpw4fig6nXYDpZ3jt8SR2m0bHBhvWeD3x5Q9s0foavq_oJWGA"
+      },
+      "tests": [
+        {
+          "tcId": 87,
+          "comment": "R encodes y = 1 with the sign bit of x set. The only point with y = 1 has x = 0, so decoding must fail (RFC 8032, Section 5.2.3). Accepted only by verifiers that ignore the sign of x.",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008091f5b9d3cd6099f02315ceb7c46200fd14cc3a15d40ab348932f9b7765a96c2f0833cc81f90c8c48a13d7df4298301067e5f5f850467f81600",
+          "result": "invalid"
         }
       ]
     }

--- a/testvectors_v1/ed448_test.json
+++ b/testvectors_v1/ed448_test.json
@@ -853,7 +853,7 @@
       "tests": [
         {
           "tcId": 70,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + L. The scalar is unchanged mod L. Accepted only by verifiers that fail to enforce s < L. See RFC 8032, Section 5.2.7.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -863,7 +863,7 @@
         },
         {
           "tcId": 71,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 2L. The scalar is unchanged mod L. Accepted only by verifiers that fail to enforce s < L. See RFC 8032, Section 5.2.7.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -873,7 +873,7 @@
         },
         {
           "tcId": 72,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 4L. The scalar is unchanged mod L. Accepted only by verifiers that fail to enforce s < L. See RFC 8032, Section 5.2.7.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -883,7 +883,7 @@
         },
         {
           "tcId": 73,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 8L. The scalar is unchanged mod L. Accepted only by verifiers that fail to enforce s < L. See RFC 8032, Section 5.2.7.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -893,7 +893,7 @@
         },
         {
           "tcId": 74,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 2^446. The scalar differs from the valid s mod L, so verification fails even without a range check on s. Accepted only by parsers that silently clear bit 446 of s.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -903,7 +903,7 @@
         },
         {
           "tcId": 75,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 2^447. The scalar differs from the valid s mod L, so verification fails even without a range check on s. Accepted only by parsers that silently clear bit 447 of s.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -913,7 +913,7 @@
         },
         {
           "tcId": 76,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + 2^448, making the final byte of s nonzero. The scalar differs from the valid s mod L, so verification fails even without a range check on s. Accepted only by parsers that ignore the final byte of s.",
           "flags": [
             "SignatureMalleability"
           ],
@@ -923,7 +923,7 @@
         },
         {
           "tcId": 77,
-          "comment": "checking malleability ",
+          "comment": "the encoded s was replaced by s + p where p is the field prime 2^448 - 2^224 - 1. The scalar differs from the valid s mod L, so verification fails even without a range check on s. Accepted only by verifiers that reduce s mod p instead of checking s < L.",
           "flags": [
             "SignatureMalleability"
           ],

--- a/testvectors_v1/ed448_test.json
+++ b/testvectors_v1/ed448_test.json
@@ -13,8 +13,8 @@
     },
     "InvalidEncoding": {
       "bugType": "CAN_OF_WORMS",
-      "description": "The test vector contains a signature with an invalid encoding of the values. The vector checks that invalid encodings are not accepted.",
-      "effect": "The effect of accepting such signatures is unclear. It could lead to signature malleability, be benign, or hide something more severe."
+      "description": "The test vector contains a signature with an invalid encoding of the values. The vector checks that invalid encodings are not accepted. For the vectors that modify the encoding of R, S has been recomputed so that the hash matches the modified R and the R recovered from S and the hash equals the original R. Such vectors are accepted only by verifiers that decode R leniently or that compare R to the recovered R incompletely.",
+      "effect": "Accepting such signatures means the encoding of a signature is not unique. A holder of the private key can generate multiple distinct signatures for the same message, and different verifiers can disagree about which signatures are valid."
     },
     "InvalidKtv": {
       "bugType": "UNKNOWN",


### PR DESCRIPTION
Informed by #259 this branch tries to add a bit more clarify to some existing vectors, and adds one new one ([rough generator code here](https://github.com/C2SP/wycheproof/commit/40874f47c5394c7350698951817365ad9e83c564)).

Resolves https://github.com/C2SP/wycheproof/issues/259