### PR TITLE
ed25519, ristretto: more test coverage

### DIFF
--- a/schemas/eddsa_to_xdh_schema_v1.json
+++ b/schemas/eddsa_to_xdh_schema_v1.json
@@ -1,0 +1,109 @@
+{
+  "type": "object",
+  "definitions": {
+    "EddsaToXdhTestGroup": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "EddsaToXdh"
+          ]
+        },
+        "source": {
+          "$ref": "common.json#/definitions/Source"
+        },
+        "edwardsCurve": {
+          "type": "string",
+          "format": "EcCurve",
+          "description": "the source Edwards curve"
+        },
+        "montgomeryCurve": {
+          "type": "string",
+          "format": "EcCurve",
+          "description": "the destination Montgomery curve"
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EddsaToXdhTestVector"
+          }
+        }
+      },
+      "required": ["type", "source", "edwardsCurve", "montgomeryCurve", "tests"],
+      "additionalProperties": false
+    },
+    "EddsaToXdhTestVector": {
+      "type": "object",
+      "properties": {
+        "tcId": {
+          "type": "integer",
+          "description": "Identifier of the test case"
+        },
+        "comment": {
+          "type": "string",
+          "description": "A brief description of the test case"
+        },
+        "publicKey": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the encoded Edwards public key"
+        },
+        "convertedPublicKey": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the expected encoded Montgomery public key"
+        },
+        "result": {
+          "$ref": "common.json#/definitions/Result"
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of flags"
+        }
+      },
+      "required": ["tcId", "comment", "publicKey", "result", "flags"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "algorithm": {
+      "type": "string",
+      "description": "the primitive tested in the test file"
+    },
+    "generatorVersion": {
+      "type": "string",
+      "description": "DEPRECATED: prefer \"source\" property in test group",
+      "deprecated": true
+    },
+    "header": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "additional documentation"
+    },
+    "notes": {
+      "$ref": "common.json#/definitions/Notes"
+    },
+    "numberOfTests": {
+      "type": "integer",
+      "description": "the number of test vectors in this test"
+    },
+    "schema": {
+      "enum": [
+        "eddsa_to_xdh_schema_v1.json"
+      ]
+    },
+    "testGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EddsaToXdhTestGroup"
+      }
+    }
+  },
+  "required": ["algorithm", "header", "notes", "numberOfTests", "schema", "testGroups"],
+  "additionalProperties": false
+}

--- a/schemas/ristretto_scalar_test_schema_v1.json
+++ b/schemas/ristretto_scalar_test_schema_v1.json
@@ -1,0 +1,109 @@
+{
+  "type": "object",
+  "definitions": {
+    "RistrettoScalarTestGroup": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "RistrettoScalarTest"
+          ]
+        },
+        "source": {
+          "$ref": "common.json#/definitions/Source"
+        },
+        "curve": {
+          "enum": [
+            "ristretto255"
+          ]
+        },
+        "operation": {
+          "enum": [
+            "invert"
+          ]
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RistrettoScalarTestVector"
+          }
+        }
+      },
+      "required": ["type", "source", "curve", "operation", "tests"],
+      "additionalProperties": false
+    },
+    "RistrettoScalarTestVector": {
+      "type": "object",
+      "properties": {
+        "tcId": {
+          "type": "integer",
+          "description": "Identifier of the test case"
+        },
+        "comment": {
+          "type": "string",
+          "description": "A brief description of the test case"
+        },
+        "scalar": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the scalar in canonical little-endian form"
+        },
+        "resultScalar": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the expected inverse; omitted for invalid tests"
+        },
+        "result": {
+          "$ref": "common.json#/definitions/Result"
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of flags"
+        }
+      },
+      "required": ["tcId", "comment", "scalar", "result", "flags"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "algorithm": {
+      "type": "string",
+      "description": "the primitive tested in the test file"
+    },
+    "generatorVersion": {
+      "type": "string",
+      "description": "DEPRECATED: prefer \"source\" property in test group",
+      "deprecated": true
+    },
+    "header": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "additional documentation"
+    },
+    "notes": {
+      "$ref": "common.json#/definitions/Notes"
+    },
+    "numberOfTests": {
+      "type": "integer",
+      "description": "the number of test vectors in this test"
+    },
+    "schema": {
+      "enum": [
+        "ristretto_scalar_test_schema_v1.json"
+      ]
+    },
+    "testGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RistrettoScalarTestGroup"
+      }
+    }
+  },
+  "required": ["algorithm", "header", "notes", "numberOfTests", "schema", "testGroups"],
+  "additionalProperties": false
+}

--- a/schemas/secretstream_test_schema_v1.json
+++ b/schemas/secretstream_test_schema_v1.json
@@ -1,0 +1,143 @@
+{
+  "type": "object",
+  "definitions": {
+    "SecretStreamState": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the current 32-byte subkey"
+        },
+        "counter": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the 32-bit counter in little-endian order"
+        },
+        "inonce": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the 12-byte logical internal nonce"
+        }
+      },
+      "required": ["key", "counter", "inonce"],
+      "additionalProperties": false
+    },
+    "SecretStreamTestGroup": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "SecretStreamTest"
+          ]
+        },
+        "source": {
+          "$ref": "common.json#/definitions/Source"
+        },
+        "operation": {
+          "enum": [
+            "push"
+          ]
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecretStreamTestVector"
+          }
+        }
+      },
+      "required": ["type", "source", "operation", "tests"],
+      "additionalProperties": false
+    },
+    "SecretStreamTestVector": {
+      "type": "object",
+      "properties": {
+        "tcId": {
+          "type": "integer",
+          "description": "Identifier of the test case"
+        },
+        "comment": {
+          "type": "string",
+          "description": "A brief description of the test case"
+        },
+        "initialState": {
+          "$ref": "#/definitions/SecretStreamState"
+        },
+        "tag": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
+          "description": "the secretstream message tag"
+        },
+        "aad": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the associated data"
+        },
+        "msg": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the plaintext"
+        },
+        "ct": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the expected ciphertext including the encrypted tag and authenticator"
+        },
+        "expectedState": {
+          "$ref": "#/definitions/SecretStreamState"
+        },
+        "result": {
+          "$ref": "common.json#/definitions/Result"
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of flags"
+        }
+      },
+      "required": ["tcId", "comment", "initialState", "tag", "aad", "msg", "ct", "expectedState", "result", "flags"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "algorithm": {
+      "type": "string",
+      "description": "the primitive tested in the test file"
+    },
+    "generatorVersion": {
+      "type": "string",
+      "description": "DEPRECATED: prefer \"source\" property in test group",
+      "deprecated": true
+    },
+    "header": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "additional documentation"
+    },
+    "notes": {
+      "$ref": "common.json#/definitions/Notes"
+    },
+    "numberOfTests": {
+      "type": "integer",
+      "description": "the number of test vectors in this test"
+    },
+    "schema": {
+      "enum": [
+        "secretstream_test_schema_v1.json"
+      ]
+    },
+    "testGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SecretStreamTestGroup"
+      }
+    }
+  },
+  "required": ["algorithm", "header", "notes", "numberOfTests", "schema", "testGroups"],
+  "additionalProperties": false
+}

--- a/schemas/stream_cipher_test_schema_v1.json
+++ b/schemas/stream_cipher_test_schema_v1.json
@@ -1,0 +1,130 @@
+{
+  "type": "object",
+  "definitions": {
+    "StreamCipherTestGroup": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "StreamCipherTest"
+          ]
+        },
+        "source": {
+          "$ref": "common.json#/definitions/Source"
+        },
+        "algorithm": {
+          "type": "string",
+          "description": "the stream cipher variant"
+        },
+        "keySize": {
+          "type": "integer",
+          "description": "the key size in bits"
+        },
+        "ivSize": {
+          "type": "integer",
+          "description": "the IV size in bits"
+        },
+        "counterSize": {
+          "type": "integer",
+          "description": "the counter size in bits"
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StreamCipherTestVector"
+          }
+        }
+      },
+      "required": ["type", "source", "algorithm", "keySize", "ivSize", "counterSize", "tests"],
+      "additionalProperties": false
+    },
+    "StreamCipherTestVector": {
+      "type": "object",
+      "properties": {
+        "tcId": {
+          "type": "integer",
+          "description": "Identifier of the test case"
+        },
+        "comment": {
+          "type": "string",
+          "description": "A brief description of the test case"
+        },
+        "key": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the key"
+        },
+        "iv": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the initialization vector"
+        },
+        "initialCounter": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the fixed-width initial counter in little-endian order"
+        },
+        "msg": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the plaintext"
+        },
+        "ct": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "the expected ciphertext; omitted for invalid tests"
+        },
+        "result": {
+          "$ref": "common.json#/definitions/Result"
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of flags"
+        }
+      },
+      "required": ["tcId", "comment", "key", "iv", "initialCounter", "msg", "result", "flags"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "algorithm": {
+      "type": "string",
+      "description": "the primitive tested in the test file"
+    },
+    "generatorVersion": {
+      "type": "string",
+      "description": "DEPRECATED: prefer \"source\" property in test group",
+      "deprecated": true
+    },
+    "header": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "additional documentation"
+    },
+    "notes": {
+      "$ref": "common.json#/definitions/Notes"
+    },
+    "numberOfTests": {
+      "type": "integer",
+      "description": "the number of test vectors in this test"
+    },
+    "schema": {
+      "enum": [
+        "stream_cipher_test_schema_v1.json"
+      ]
+    },
+    "testGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/StreamCipherTestGroup"
+      }
+    }
+  },
+  "required": ["algorithm", "header", "notes", "numberOfTests", "schema", "testGroups"],
+  "additionalProperties": false
+}

--- a/testvectors_v1/chacha20_counter_test.json
+++ b/testvectors_v1/chacha20_counter_test.json
@@ -1,0 +1,582 @@
+{
+  "algorithm": "CHACHA20",
+  "header": [
+    "Test vectors for raw ChaCha20 counter carry and exhaustion boundaries."
+  ],
+  "notes": {
+    "CounterCarry": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "The vector crosses the low 32-bit counter boundary and requires carry into the high word.",
+      "effect": "Dropping the carry can repeat a keystream block."
+    },
+    "CounterOverflow": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "The vector exercises the final legal counter block or requires rejection before counter wrap.",
+      "effect": "Counter wrap reuses a keystream block."
+    }
+  },
+  "numberOfTests": 42,
+  "schema": "stream_cipher_test_schema_v1.json",
+  "testGroups": [
+    {
+      "type": "StreamCipherTest",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "algorithm": "XChaCha20",
+      "keySize": 256,
+      "ivSize": 192,
+      "counterSize": 64,
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "XChaCha20 counter 0x00000000fffffffe with 0-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffff00000000",
+          "msg": "",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 2,
+          "comment": "XChaCha20 counter 0x00000000fffffffe with 1-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffff00000000",
+          "msg": "00",
+          "ct": "34",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 3,
+          "comment": "XChaCha20 counter 0x00000000fffffffe with 63-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffff00000000",
+          "msg": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "347f6b183c05b876222d3f3ddcaea04418d45d11a1d532ffa9954a649885c26e7f4e8c63476193b9be331495aa17b678fd792c616d167d09335674bafe4e91",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 4,
+          "comment": "XChaCha20 counter 0x00000000fffffffe with 64-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffff00000000",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "347f6b183c05b876222d3f3ddcaea04418d45d11a1d532ffa9954a649885c26e7f4e8c63476193b9be331495aa17b678fd792c616d167d09335674bafe4e9172",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 5,
+          "comment": "XChaCha20 counter 0x00000000fffffffe with 65-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffff00000000",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "347f6b183c05b876222d3f3ddcaea04418d45d11a1d532ffa9954a649885c26e7f4e8c63476193b9be331495aa17b678fd792c616d167d09335674bafe4e9172b9",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 6,
+          "comment": "XChaCha20 counter 0x00000000fffffffe with 127-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffff00000000",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "347f6b183c05b876222d3f3ddcaea04418d45d11a1d532ffa9954a649885c26e7f4e8c63476193b9be331495aa17b678fd792c616d167d09335674bafe4e9172b95212612451119424ff54b88064f035a0ef69b53a28c634b679ebf6b319c5483769a7f22742571d18b0e2faebb1df1ca70225752d4f68f24ad58a4d2dc5c3",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 7,
+          "comment": "XChaCha20 counter 0x00000000fffffffe with 128-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffff00000000",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "347f6b183c05b876222d3f3ddcaea04418d45d11a1d532ffa9954a649885c26e7f4e8c63476193b9be331495aa17b678fd792c616d167d09335674bafe4e9172b95212612451119424ff54b88064f035a0ef69b53a28c634b679ebf6b319c5483769a7f22742571d18b0e2faebb1df1ca70225752d4f68f24ad58a4d2dc5c32b",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 8,
+          "comment": "XChaCha20 counter 0x00000000ffffffff with 0-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffff00000000",
+          "msg": "",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 9,
+          "comment": "XChaCha20 counter 0x00000000ffffffff with 1-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffff00000000",
+          "msg": "00",
+          "ct": "b9",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 10,
+          "comment": "XChaCha20 counter 0x00000000ffffffff with 63-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffff00000000",
+          "msg": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "b95212612451119424ff54b88064f035a0ef69b53a28c634b679ebf6b319c5483769a7f22742571d18b0e2faebb1df1ca70225752d4f68f24ad58a4d2dc5c3",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 11,
+          "comment": "XChaCha20 counter 0x00000000ffffffff with 64-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffff00000000",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "b95212612451119424ff54b88064f035a0ef69b53a28c634b679ebf6b319c5483769a7f22742571d18b0e2faebb1df1ca70225752d4f68f24ad58a4d2dc5c32b",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 12,
+          "comment": "XChaCha20 counter 0x00000000ffffffff with 65-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffff00000000",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "b95212612451119424ff54b88064f035a0ef69b53a28c634b679ebf6b319c5483769a7f22742571d18b0e2faebb1df1ca70225752d4f68f24ad58a4d2dc5c32b88",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 13,
+          "comment": "XChaCha20 counter 0x00000000ffffffff with 127-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffff00000000",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "b95212612451119424ff54b88064f035a0ef69b53a28c634b679ebf6b319c5483769a7f22742571d18b0e2faebb1df1ca70225752d4f68f24ad58a4d2dc5c32b8861043ec0724c04837eae0f33750fa790db2548bff4511f1cb4c548297f6a06a4c0ddd43adf8183802b9b0be9a5f743d308dc699c31ef984f610bf0ad56d9",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 14,
+          "comment": "XChaCha20 counter 0x00000000ffffffff with 128-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffff00000000",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "b95212612451119424ff54b88064f035a0ef69b53a28c634b679ebf6b319c5483769a7f22742571d18b0e2faebb1df1ca70225752d4f68f24ad58a4d2dc5c32b8861043ec0724c04837eae0f33750fa790db2548bff4511f1cb4c548297f6a06a4c0ddd43adf8183802b9b0be9a5f743d308dc699c31ef984f610bf0ad56d9d6",
+          "result": "valid",
+          "flags": [
+            "CounterCarry"
+          ]
+        },
+        {
+          "tcId": 15,
+          "comment": "XChaCha20 counter 0xfffffffffffffffe with 0-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffffffffffff",
+          "msg": "",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 16,
+          "comment": "XChaCha20 counter 0xfffffffffffffffe with 1-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffffffffffff",
+          "msg": "00",
+          "ct": "d5",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 17,
+          "comment": "XChaCha20 counter 0xfffffffffffffffe with 63-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffffffffffff",
+          "msg": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "d5bb6f1da1ca5acc1b841af1809f0241ac1bb523c70def8480b06f5a19d17589b960f3f15269afdc0f051991930aa59502adc50da2e91a1c1c8adbb10ef6c4",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 18,
+          "comment": "XChaCha20 counter 0xfffffffffffffffe with 64-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffffffffffff",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "d5bb6f1da1ca5acc1b841af1809f0241ac1bb523c70def8480b06f5a19d17589b960f3f15269afdc0f051991930aa59502adc50da2e91a1c1c8adbb10ef6c454",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 19,
+          "comment": "XChaCha20 counter 0xfffffffffffffffe with 65-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffffffffffff",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "d5bb6f1da1ca5acc1b841af1809f0241ac1bb523c70def8480b06f5a19d17589b960f3f15269afdc0f051991930aa59502adc50da2e91a1c1c8adbb10ef6c4540e",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 20,
+          "comment": "XChaCha20 counter 0xfffffffffffffffe with 127-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffffffffffff",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "d5bb6f1da1ca5acc1b841af1809f0241ac1bb523c70def8480b06f5a19d17589b960f3f15269afdc0f051991930aa59502adc50da2e91a1c1c8adbb10ef6c4540edc309d13c5a1acd1698335fb5e24f615d749ebcd7e9d5262835c906442eb5f1eef3d24cd0d63cb02f1df74bd1de2551f8588044545f0212d267431a80990",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 21,
+          "comment": "XChaCha20 counter 0xfffffffffffffffe with 128-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "feffffffffffffff",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "d5bb6f1da1ca5acc1b841af1809f0241ac1bb523c70def8480b06f5a19d17589b960f3f15269afdc0f051991930aa59502adc50da2e91a1c1c8adbb10ef6c4540edc309d13c5a1acd1698335fb5e24f615d749ebcd7e9d5262835c906442eb5f1eef3d24cd0d63cb02f1df74bd1de2551f8588044545f0212d267431a80990f9",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 22,
+          "comment": "XChaCha20 counter 0xffffffffffffffff with 0-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffffffffffff",
+          "msg": "",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 23,
+          "comment": "XChaCha20 counter 0xffffffffffffffff with 1-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffffffffffff",
+          "msg": "00",
+          "ct": "0e",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 24,
+          "comment": "XChaCha20 counter 0xffffffffffffffff with 63-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffffffffffff",
+          "msg": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "0edc309d13c5a1acd1698335fb5e24f615d749ebcd7e9d5262835c906442eb5f1eef3d24cd0d63cb02f1df74bd1de2551f8588044545f0212d267431a80990",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 25,
+          "comment": "XChaCha20 counter 0xffffffffffffffff with 64-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffffffffffff",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "0edc309d13c5a1acd1698335fb5e24f615d749ebcd7e9d5262835c906442eb5f1eef3d24cd0d63cb02f1df74bd1de2551f8588044545f0212d267431a80990f9",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 26,
+          "comment": "XChaCha20 counter 0xffffffffffffffff with 65-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffffffffffff",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 27,
+          "comment": "XChaCha20 counter 0xffffffffffffffff with 127-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffffffffffff",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 28,
+          "comment": "XChaCha20 counter 0xffffffffffffffff with 128-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000000000000000000000000000",
+          "initialCounter": "ffffffffffffffff",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "StreamCipherTest",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "algorithm": "ChaCha20-IETF",
+      "keySize": 256,
+      "ivSize": 96,
+      "counterSize": 32,
+      "tests": [
+        {
+          "tcId": 29,
+          "comment": "ChaCha20-IETF counter 0xfffffffe with 0-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "feffffff",
+          "msg": "",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 30,
+          "comment": "ChaCha20-IETF counter 0xfffffffe with 1-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "feffffff",
+          "msg": "00",
+          "ct": "03",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 31,
+          "comment": "ChaCha20-IETF counter 0xfffffffe with 63-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "feffffff",
+          "msg": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "032cc123482c31711f94c941af5ab1f4155784332ed5348fe79aec5ead4c06c3f13c280d8cc49925e4a6a5922ec80e13a4cdfa840c70a1427a3cb699166991",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 32,
+          "comment": "ChaCha20-IETF counter 0xfffffffe with 64-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "feffffff",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "032cc123482c31711f94c941af5ab1f4155784332ed5348fe79aec5ead4c06c3f13c280d8cc49925e4a6a5922ec80e13a4cdfa840c70a1427a3cb699166991a5",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 33,
+          "comment": "ChaCha20-IETF counter 0xfffffffe with 65-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "feffffff",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "032cc123482c31711f94c941af5ab1f4155784332ed5348fe79aec5ead4c06c3f13c280d8cc49925e4a6a5922ec80e13a4cdfa840c70a1427a3cb699166991a5ac",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 34,
+          "comment": "ChaCha20-IETF counter 0xfffffffe with 127-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "feffffff",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "032cc123482c31711f94c941af5ab1f4155784332ed5348fe79aec5ead4c06c3f13c280d8cc49925e4a6a5922ec80e13a4cdfa840c70a1427a3cb699166991a5ace4cd09e294d1912d4ad205d06f95d9c2f2bfcf453e8753f128765b62215f4d92c74f2f626c6a640c0b1284d839ec81f1696281dafc3e684593937023b58b",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 35,
+          "comment": "ChaCha20-IETF counter 0xfffffffe with 128-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "feffffff",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "032cc123482c31711f94c941af5ab1f4155784332ed5348fe79aec5ead4c06c3f13c280d8cc49925e4a6a5922ec80e13a4cdfa840c70a1427a3cb699166991a5ace4cd09e294d1912d4ad205d06f95d9c2f2bfcf453e8753f128765b62215f4d92c74f2f626c6a640c0b1284d839ec81f1696281dafc3e684593937023b58b1d",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 36,
+          "comment": "ChaCha20-IETF counter 0xffffffff with 0-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "ffffffff",
+          "msg": "",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 37,
+          "comment": "ChaCha20-IETF counter 0xffffffff with 1-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "ffffffff",
+          "msg": "00",
+          "ct": "ac",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 38,
+          "comment": "ChaCha20-IETF counter 0xffffffff with 63-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "ffffffff",
+          "msg": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "ace4cd09e294d1912d4ad205d06f95d9c2f2bfcf453e8753f128765b62215f4d92c74f2f626c6a640c0b1284d839ec81f1696281dafc3e684593937023b58b",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 39,
+          "comment": "ChaCha20-IETF counter 0xffffffff with 64-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "ffffffff",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "ct": "ace4cd09e294d1912d4ad205d06f95d9c2f2bfcf453e8753f128765b62215f4d92c74f2f626c6a640c0b1284d839ec81f1696281dafc3e684593937023b58b1d",
+          "result": "valid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 40,
+          "comment": "ChaCha20-IETF counter 0xffffffff with 65-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "ffffffff",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 41,
+          "comment": "ChaCha20-IETF counter 0xffffffff with 127-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "ffffffff",
+          "msg": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        },
+        {
+          "tcId": 42,
+          "comment": "ChaCha20-IETF counter 0xffffffff with 128-byte message",
+          "key": "0000000000000000000000000000000000000000000000000000000000000000",
+          "iv": "000000000000000000000000",
+          "initialCounter": "ffffffff",
+          "msg": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "CounterOverflow"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testvectors_v1/ed25519_test.json
+++ b/testvectors_v1/ed25519_test.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "EDDSA",
   "schema": "eddsa_verify_schema_v1.json",
-  "numberOfTests": 151,
+  "numberOfTests": 210,
   "header": [
     "Test vectors of type EddsaVerify are intended for testing"
   ],
@@ -49,6 +49,19 @@
     "Valid": {
       "bugType": "BASIC",
       "description": "The test vector is an ordinary valid signature."
+    },
+    "SmallOrderPublicKey": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The public key is a canonical point in the Ed25519 torsion subgroup.",
+      "effect": "Accepting the vector permits signatures that are not bound to a private key."
+    },
+    "MixedOrderPublicKey": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The public key has a nonzero torsion component and is not in the prime-order subgroup.",
+      "effect": "Accepting the vector can cause verifier disagreement or a signature-validation bypass.",
+      "links": [
+        "https://github.com/paragonie/sodium_compat/commit/e4d4933af9463a96a1a3cbaeb94327b90e3350ca"
+      ]
     }
   },
   "testGroups": [
@@ -3352,6 +3365,1157 @@
           ],
           "msg": "313233343030",
           "sig": "0100000000000000000000000000000000000000000000000000000000000080c803ee1f2342aa96ff698a393d1ab5e66f3eda101d6d120b394c3fd32c117d0a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "0100000000000000000000000000000000000000000000000000000000000000"
+      },
+      "publicKeyDer": "302a300506032b65700321000100000000000000000000000000000000000000000000000000000000000000",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 152,
+          "comment": "identity public key universal forgery",
+          "flags": [
+            "SmallOrderPublicKey"
+          ],
+          "msg": "6d657373616765",
+          "sig": "58666666666666666666666666666666666666666666666666666666666666660100000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a"
+      },
+      "publicKeyDer": "302a300506032b6570032100c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAxxdqcD1N2E+6PAt2DRBnDyogU/osOczGTsf9d5KsA3o=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 153,
+          "comment": "canonical Ed25519 torsion point 1 of 7 (order 8)",
+          "flags": [
+            "SmallOrderPublicKey"
+          ],
+          "msg": "746f7273696f6e2d312d3134",
+          "sig": "b63dd4baa9c75ea9f3f1021ada3bf7dd6872e4cfbdac9653965ef78c4be9845d27df2ce4101220ec96bc5ccbcefa1336871b76e6ef52a0fb35745bb187b1a10d",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "0000000000000000000000000000000000000000000000000000000000000080"
+      },
+      "publicKeyDer": "302a300506032b65700321000000000000000000000000000000000000000000000000000000000000000080",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIA=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 154,
+          "comment": "canonical Ed25519 torsion point 2 of 7 (order 4)",
+          "flags": [
+            "SmallOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "c459280d27f66a3285aa648ca1cc444cdfcde27a6062d117c6cb399e0969d6edf8b80551824c3e7275922ac8751e59a42793406560453c4e366999f900480506",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc05"
+      },
+      "publicKeyDer": "302a300506032b657003210026e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc05",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAJuiVj8KyJ7BFw/SJ8u+Y8NXfrAXTxjM5sTgCiG1T/AU=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 155,
+          "comment": "canonical Ed25519 torsion point 3 of 7 (order 8)",
+          "flags": [
+            "SmallOrderPublicKey"
+          ],
+          "msg": "746f7273696f6e2d332d34",
+          "sig": "afd0270f467226b517fa8f911d1d320906df0065fe0045593c8fd0394770b83e6bb6f264bca826f9a4631816571f8f42681a94db6d3f032e64721265a06c7009",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f"
+      },
+      "publicKeyDer": "302a300506032b6570032100ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA7P///////////////////////////////////////38=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 156,
+          "comment": "canonical Ed25519 torsion point 4 of 7 (order 2)",
+          "flags": [
+            "SmallOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "f8cea2efb481e92ca61b8972098e07aa1c16f2166cbd8da7ae682b55e433693920b491d7e08ab6c8e521b2f0300befbfcbfd7078340bc153a251896ef8b7c805",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc85"
+      },
+      "publicKeyDer": "302a300506032b657003210026e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc85",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAJuiVj8KyJ7BFw/SJ8u+Y8NXfrAXTxjM5sTgCiG1T/IU=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 157,
+          "comment": "canonical Ed25519 torsion point 5 of 7 (order 8)",
+          "flags": [
+            "SmallOrderPublicKey"
+          ],
+          "msg": "746f7273696f6e2d352d3231",
+          "sig": "54df79ed63c1bfdc39fd6408ad5f04143bcfc22b7e1dd0e5ea3bc00eccbbbf8260faa75789f6428d7a8a5a3b850b6779171de7edd504ffcfb5db320dd9864b06",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "publicKeyDer": "302a300506032b65700321000000000000000000000000000000000000000000000000000000000000000000",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 158,
+          "comment": "canonical Ed25519 torsion point 6 of 7 (order 4)",
+          "flags": [
+            "SmallOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "520679470254237dbe8f93dc12e8b05363f5236b5671ebff01251649930f6c287531efeb34b73a6fe0f3170a211ce386ae269b0d145d5a7e63bb4ba15ce0c408",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa"
+      },
+      "publicKeyDer": "302a300506032b6570032100c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAxxdqcD1N2E+6PAt2DRBnDyogU/osOczGTsf9d5KsA/o=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 159,
+          "comment": "canonical Ed25519 torsion point 7 of 7 (order 8)",
+          "flags": [
+            "SmallOrderPublicKey"
+          ],
+          "msg": "746f7273696f6e2d372d39",
+          "sig": "b57aca4330dc58dcfd4ca75a1f7f3161aaf394a57769c7a9e9837d27cf7a80f7e88557a67e0b4792628285f53ed0f4fac97bc187e436fac5ea0513d320d5560f",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "15deb30729eb3e465c88f11b57d0c8d36eb0f670c3b22d2f80ea6049eeb2c23b"
+      },
+      "publicKeyDer": "302a300506032b657003210015deb30729eb3e465c88f11b57d0c8d36eb0f670c3b22d2f80ea6049eeb2c23b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAFd6zBynrPkZciPEbV9DI026w9nDDsi0vgOpgSe6ywjs=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 160,
+          "comment": "prime-order point 1 plus nonidentity torsion point 1",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d302d312d38",
+          "sig": "49b0d4daf5493b98c7220f7b785fdf10f4befad3262e00f2cd6813c90d1319f6a7c6c0d69149f691d0c6b428642bb08d7046e0abff7e68e6b83547129f51080b",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "31f20adf0f25a04f6d0940d2eb6a0b7d4aa2f18c9571a6f7eb74bf059b0d7215"
+      },
+      "publicKeyDer": "302a300506032b657003210031f20adf0f25a04f6d0940d2eb6a0b7d4aa2f18c9571a6f7eb74bf059b0d7215",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMfIK3w8loE9tCUDS62oLfUqi8YyVcab363S/BZsNchU=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 161,
+          "comment": "prime-order point 1 plus nonidentity torsion point 2",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "d9f1148f0b13b3e801455c65d8314e7103706166ac6844ad43ead64ee310cc9f04e345b79bca79e83fbe7511fb5d17b347e2a2a98c247a92ba81b4a182116b0f",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "db3274482b52f4937b405c00496b0511a364c58d4798ceae171262803d465729"
+      },
+      "publicKeyDer": "302a300506032b6570032100db3274482b52f4937b405c00496b0511a364c58d4798ceae171262803d465729",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA2zJ0SCtS9JN7QFwASWsFEaNkxY1HmM6uFxJigD1GVyk=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 162,
+          "comment": "prime-order point 1 plus nonidentity torsion point 3",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d302d332d31",
+          "sig": "989e808156e71fb17c146080890b2726d0e9ba1ab29a0832b680bac5849c41e04e97cb8d756d0890b1c8d7eff77de4b1a0301404338874b8819c4bb5bf204a08",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "fb8ae86afa72f86ab074c3a51440df0d72c13c44cd1c4ae510681b419504974a"
+      },
+      "publicKeyDer": "302a300506032b6570032100fb8ae86afa72f86ab074c3a51440df0d72c13c44cd1c4ae510681b419504974a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA+4roavpy+GqwdMOlFEDfDXLBPETNHErlEGgbQZUEl0o=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 163,
+          "comment": "prime-order point 1 plus nonidentity torsion point 4",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "df0ea594369382b35dd6c26bb71a7984f0fda2890a19bbb69bbbaf62242ee74dd7f1bba3c0da7caa20ebf1337bcc2d39a2547e4e95e132a2daaf272439af8a05",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "d8214cf8d614c1b9a3770ee4a82f372c914f098f3c4dd2d07f159fb6114d3dc4"
+      },
+      "publicKeyDer": "302a300506032b6570032100d8214cf8d614c1b9a3770ee4a82f372c914f098f3c4dd2d07f159fb6114d3dc4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA2CFM+NYUwbmjdw7kqC83LJFPCY88TdLQfxWfthFNPcQ=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 164,
+          "comment": "prime-order point 1 plus nonidentity torsion point 5",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d302d352d32",
+          "sig": "f31beed5c32641a1baca414ba1f6a39cd4e0da3fe95027d937a41df3d6a6e5a7f70d47674a0fb90b618e6465e7bd133f1615ae72eb790b05082342e12021180d",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "bc0df520f0da5fb092f6bf2d1495f482b55d0e736a8e5908148b40fa64f28dea"
+      },
+      "publicKeyDer": "302a300506032b6570032100bc0df520f0da5fb092f6bf2d1495f482b55d0e736a8e5908148b40fa64f28dea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAvA31IPDaX7CS9r8tFJX0grVdDnNqjlkIFItA+mTyjeo=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 165,
+          "comment": "prime-order point 1 plus nonidentity torsion point 6",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "bef3aa8b7c0a70ef4b689bc839aff99c7cb5d62b3ec733079338400ec5deb0ccabaafcae9ecd7d8cff17c1094353e85ec9d201e41f308589a3141c23895c030d",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "12cd8bb7d4ad0b6c84bfa3ffb694faee5c9b3a72b8673151e8ed9d7fc2b9a8d6"
+      },
+      "publicKeyDer": "302a300506032b657003210012cd8bb7d4ad0b6c84bfa3ffb694faee5c9b3a72b8673151e8ed9d7fc2b9a8d6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAEs2Lt9StC2yEv6P/tpT67lybOnK4ZzFR6O2df8K5qNY=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 166,
+          "comment": "prime-order point 1 plus nonidentity torsion point 7",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d302d372d33",
+          "sig": "71e7486ab6df0686580902797c785ffcfb2fe3b61d46c8e5da432e168e05d9c59ec91d092c7c8c635de89a97b37e383a4cec89d3c6015fb3fa7fbf43900dae04",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "c1b047f0106ff174487ba336a56d48127ed0563dcca139fd555cf113f609ac71"
+      },
+      "publicKeyDer": "302a300506032b6570032100c1b047f0106ff174487ba336a56d48127ed0563dcca139fd555cf113f609ac71",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAwbBH8BBv8XRIe6M2pW1IEn7QVj3MoTn9VVzxE/YJrHE=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 167,
+          "comment": "prime-order point 2 plus nonidentity torsion point 1",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "3c48db3cce8f2f154ddfe665a697de2f8dce6dd965eb0a18dbb95e90df01f2d595225ab03a2452216368b9f6f7590b72b804bb8d3258c4c9caa15922e3bff50a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "280fa1145bb421c1586eeadfb0f96ba1a25673111eca768773dafedf9b4e5a38"
+      },
+      "publicKeyDer": "302a300506032b6570032100280fa1145bb421c1586eeadfb0f96ba1a25673111eca768773dafedf9b4e5a38",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAKA+hFFu0IcFYburfsPlroaJWcxEeynaHc9r+35tOWjg=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 168,
+          "comment": "prime-order point 2 plus nonidentity torsion point 2",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d312d322d38",
+          "sig": "5c56e4644b99902901a9666a72c52ab6b029d4e81b07bb84b875c39f8f911938db1068dfa06b293fdeadafa97613fe10b2684b85184f5fccc6503096c316ba00",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "66f35e3ae56c736132dde77ae1faaeb01ebfc1bd79c98d43737e945b0744aaed"
+      },
+      "publicKeyDer": "302a300506032b657003210066f35e3ae56c736132dde77ae1faaeb01ebfc1bd79c98d43737e945b0744aaed",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAZvNeOuVsc2Ey3ed64fqusB6/wb15yY1Dc36UWwdEqu0=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 169,
+          "comment": "prime-order point 2 plus nonidentity torsion point 3",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "5caa2cb4b66f9db52ca1dfa1a3068e36ba0fa66f3a5912d7ab9a55808edb6fe29be93e6714f72d9a0d83e736b88a4a74bd7237d739c85edbbfa99d5c518c7505",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "c243dfb46f771baa41247bdb387f07475c78b8b9bb99b1089be6fd371420ccc3"
+      },
+      "publicKeyDer": "302a300506032b6570032100c243dfb46f771baa41247bdb387f07475c78b8b9bb99b1089be6fd371420ccc3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAwkPftG93G6pBJHvbOH8HR1x4uLm7mbEIm+b9NxQgzMM=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 170,
+          "comment": "prime-order point 2 plus nonidentity torsion point 4",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d312d342d31",
+          "sig": "66250edaea83744886f3dfa139424148ced9e0646be033ab72b75d8413afbea453eefb6735dabe1491aff1f308bbd73060c669c3c3772ae2f94ab4f387642a02",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "2c4fb80fef900e8bb7845cc95a92b7ed812fa9c2335ec602aaa30eec09f6538e"
+      },
+      "publicKeyDer": "302a300506032b65700321002c4fb80fef900e8bb7845cc95a92b7ed812fa9c2335ec602aaa30eec09f6538e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEALE+4D++QDou3hFzJWpK37YEvqcIzXsYCqqMO7An2U44=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 171,
+          "comment": "prime-order point 2 plus nonidentity torsion point 5",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "fc91f328ca137afe81ff69d75118b89455b96d6fd6cb88a46b99fc68074175b1ac6be310033c348fe42f41cbef8c004774563c77ab781217c165d13fc273b202",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "c5f05eeba44bde3ea79115204f06945e5da98ceee13589788c25012064b1a5c7"
+      },
+      "publicKeyDer": "302a300506032b6570032100c5f05eeba44bde3ea79115204f06945e5da98ceee13589788c25012064b1a5c7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAxfBe66RL3j6nkRUgTwaUXl2pjO7hNYl4jCUBIGSxpcc=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 172,
+          "comment": "prime-order point 2 plus nonidentity torsion point 6",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d312d362d34",
+          "sig": "cc93d04669be4a2b68dd7d82944563b4468fa1392ae97fa36fe388d89e3d81a59588aa307e357bd12635702d077014daf525afd7400acb78d0c9a2f9f506c60a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "870ca1c51a938c9ecd2218851e05514fe1403e42863672bc8c816ba4f8bb5512"
+      },
+      "publicKeyDer": "302a300506032b6570032100870ca1c51a938c9ecd2218851e05514fe1403e42863672bc8c816ba4f8bb5512",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAhwyhxRqTjJ7NIhiFHgVRT+FAPkKGNnK8jIFrpPi7VRI=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 173,
+          "comment": "prime-order point 2 plus nonidentity torsion point 7",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "c28aa73d32d98a6f0f956392279cd13fc35d9d67ea54c99941eadea5d08ba760398f5845bbbb509102326b53ab93e33398b6c673331a194dd85173495e13ff0a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "85e7bfc77e932799ae948a1abd8ea287c56dd48fb8b4221931e4f8652e1eea20"
+      },
+      "publicKeyDer": "302a300506032b657003210085e7bfc77e932799ae948a1abd8ea287c56dd48fb8b4221931e4f8652e1eea20",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAhee/x36TJ5mulIoavY6ih8Vt1I+4tCIZMeT4ZS4e6iA=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 174,
+          "comment": "prime-order point 3 plus nonidentity torsion point 1",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d322d312d30",
+          "sig": "e85ba67b317ad0f48848892ce0a585d2d47ccd49e7895bf93629bf3e4723f92c3de51cdced1b12654fc834d3e675488e98f2628fa0a01b058f17dfb81603c300",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "349a3840d09eb68a97b06eae781f4fbece569c6ffd70c238ff8406ec82fb587d"
+      },
+      "publicKeyDer": "302a300506032b6570032100349a3840d09eb68a97b06eae781f4fbece569c6ffd70c238ff8406ec82fb587d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEANJo4QNCetoqXsG6ueB9Pvs5WnG/9cMI4/4QG7IL7WH0=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 175,
+          "comment": "prime-order point 3 plus nonidentity torsion point 2",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "1505ddb0ea2479d7751bdb60693727d448d1c22193cfe548ce6905f8c5da1a0c13a889c2a7d2b30c3b78015086972386d377060c9a97ea15d6dd8da04f8c7702",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "0cf1b0a8da530a0f0b30f5b130391652f249680e0f3f7c80284bdc5ab955cfa3"
+      },
+      "publicKeyDer": "302a300506032b65700321000cf1b0a8da530a0f0b30f5b130391652f249680e0f3f7c80284bdc5ab955cfa3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEADPGwqNpTCg8LMPWxMDkWUvJJaA4PP3yAKEvcWrlVz6M=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 176,
+          "comment": "prime-order point 3 plus nonidentity torsion point 3",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d322d332d33",
+          "sig": "793423634e1945c284aa538008fa41767a46964acf14fddabc2ac7eeb3733b4a81b3075118fcaaf8499749a992df4949bc866de91ab0b1a98cae9459db2f710f",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "628c21a85bec28f1d0c0ea44b2c6e731f47a1b01be58d1028892f947351bfa61"
+      },
+      "publicKeyDer": "302a300506032b6570032100628c21a85bec28f1d0c0ea44b2c6e731f47a1b01be58d1028892f947351bfa61",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAYowhqFvsKPHQwOpEssbnMfR6GwG+WNECiJL5RzUb+mE=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 177,
+          "comment": "prime-order point 3 plus nonidentity torsion point 4",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "f8410c87623213d696e74b9a23b30926fbf8036a931678db8155956440ac192e4ed451d782a41df339f56cd4e8482de55601eefd92301d55bb067e90bb5db009",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "68184038816cd866516b75e542715d783a922b70474bdde6ce1b079ad1e115df"
+      },
+      "publicKeyDer": "302a300506032b657003210068184038816cd866516b75e542715d783a922b70474bdde6ce1b079ad1e115df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAaBhAOIFs2GZRa3XlQnFdeDqSK3BHS93mzhsHmtHhFd8=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 178,
+          "comment": "prime-order point 3 plus nonidentity torsion point 5",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d322d352d38",
+          "sig": "a02a0c28d4735b1fa7803ce1e1f410828ffd07018b0b1f5255fe69381a04d788d575682aceb9efe1c12f158b920ef213bfbcc53cdbb36dbd81383ecd91b7dc03",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "b965c7bf2f614975684f915187e0b04131a96390028f3dc7007bf9137d04a782"
+      },
+      "publicKeyDer": "302a300506032b6570032100b965c7bf2f614975684f915187e0b04131a96390028f3dc7007bf9137d04a782",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAuWXHvy9hSXVoT5FRh+CwQTGpY5ACjz3HAHv5E30Ep4I=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 179,
+          "comment": "prime-order point 3 plus nonidentity torsion point 6",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "",
+          "sig": "358d21d481ef812343dffa2b55b1398ade7d630c64ff2a4f48c9a634f7ae9b9f99766d982121c3ea719b338e942d95557cf41e3385c269ba6f51aa31a4956e0a",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "e10e4f5725acf5f0f4cf0a4ecfc6e9ad0db697f1f0c0837fd7b423a546aa305c"
+      },
+      "publicKeyDer": "302a300506032b6570032100e10e4f5725acf5f0f4cf0a4ecfc6e9ad0db697f1f0c0837fd7b423a546aa305c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA4Q5PVyWs9fD0zwpOz8bprQ22l/HwwIN/17QjpUaqMFw=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 180,
+          "comment": "prime-order point 3 plus nonidentity torsion point 7",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "6d697865642d6f726465722d322d372d32",
+          "sig": "abce1d42c9c8da97d4ecebbbf58934b5d0f86a775a43c57fc0261b39be7a1ea1b0f208edcf4093ef5c61c9552bbcdd2946be36d1a1e7878d669a42bc523c5d0d",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "f2741795058d07954f8b3c5aebbf20f28d3ec3bb32e3b51aef97e4be6afb68b5"
+      },
+      "publicKeyDer": "302a300506032b6570032100f2741795058d07954f8b3c5aebbf20f28d3ec3bb32e3b51aef97e4be6afb68b5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA8nQXlQWNB5VPizxa678g8o0+w7sy47Ua75fkvmr7aLU=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 181,
+          "comment": "valid control paired with torsion point 0",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d657373616765",
+          "sig": "854619fb2351b7a4f6ff982512e3be8c35bbb551991f42d241d44c7406dab4398188e758a19c325d24d683556dec79f7d72291a8e5c65f0ea440a95a28d4470d",
+          "result": "valid"
+        },
+        {
+          "tcId": 182,
+          "comment": "valid control paired with torsion point 1",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "746f7273696f6e2d312d3134",
+          "sig": "e1427249d2d8f07b7ed4ef639de59e17c823e821ad0d0b1e693b826bdc4cf29e94a83d6d3f382dfe0a0c1f18b73d6a1b501bb9bcd1f7232cd60db05c8a9dc009",
+          "result": "valid"
+        },
+        {
+          "tcId": 183,
+          "comment": "valid control paired with torsion point 2",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "8dfc13f28ef98fc6a766f3bbd0c80cde4f9cafe4ba7687e7a993851f82338844a371f634c6f2e16292429426226090347e4d19c6ce60eb0e169fe9a00003d30b",
+          "result": "valid"
+        },
+        {
+          "tcId": 184,
+          "comment": "valid control paired with torsion point 3",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "746f7273696f6e2d332d34",
+          "sig": "b149c4197787df8113491f36cb24dc5f11c1e80f9f51e1ae0031e674ea279f499df81717719f9c27b44611042cf20abb9bf0cbf0449a3b8040ea0fdaf1e93f01",
+          "result": "valid"
+        },
+        {
+          "tcId": 185,
+          "comment": "valid control paired with torsion point 4",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "7274931dbc8c3a18a739ff8f187bdb5e6b524320c6d3976b70ce7fc016449344cdfd9e0cc96ba9efe1bf71d8ef5339d9b70f8bceacfc66547e3b94d4e2deef06",
+          "result": "valid"
+        },
+        {
+          "tcId": 186,
+          "comment": "valid control paired with torsion point 5",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "746f7273696f6e2d352d3231",
+          "sig": "7e17e7cdfda11ab37b2bf09f724b0bc2c61bbbbe6516d261b291f44ac35238502071de037a3296bba04ee65258ae39b63407aba333342775a1d7b830b11c9a0a",
+          "result": "valid"
+        },
+        {
+          "tcId": 187,
+          "comment": "valid control paired with torsion point 6",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "42558ff4b1a47724c98fb3c15e1d64f68b49ab538b37c33f1c11d0fb44cc201d1b7557b725655fec353a5ae7a47d37e92ef62f9870ccd845298acb2e12246202",
+          "result": "valid"
+        },
+        {
+          "tcId": 188,
+          "comment": "valid control paired with torsion point 7",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "746f7273696f6e2d372d39",
+          "sig": "37dcc58c48d0bae5b932bcda52d52361abc2a5616bf77508a3978af9ca42964b9a481ff328c8b2263fdfd6e4a15cfa66908edb16891c9c05183cdfb87ea0fa0a",
+          "result": "valid"
+        },
+        {
+          "tcId": 189,
+          "comment": "valid control paired with mixed-order point 1/1",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d302d312d38",
+          "sig": "0ae8d293de2640c14c01f5a8c7c56d5a756128e90e436d3a2ffece7fd5830ba17181539db012fdf463ed03af9f531c663639fb86a9e2c3fee98690db160ae90a",
+          "result": "valid"
+        },
+        {
+          "tcId": 190,
+          "comment": "valid control paired with mixed-order point 1/2",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "61c6d52a5a68f19f24ba14e5cf78fd8a7152ca7d3d40094d58852b2adef86e6959159edc65f0e997d058f1921fe7a042a70e0b4663008187a531ecd3e83a8604",
+          "result": "valid"
+        },
+        {
+          "tcId": 191,
+          "comment": "valid control paired with mixed-order point 1/3",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d302d332d31",
+          "sig": "ec00e7504ffa36aec4fb8e721b7f808ec6ca0cfc04a5017af6cdd48efc73d730c40e1874e3e43ff521d62142c8d5dfcbcc214ba2c47f7b5825f2956bd9f19505",
+          "result": "valid"
+        },
+        {
+          "tcId": 192,
+          "comment": "valid control paired with mixed-order point 1/4",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "4be9edab3535cc97587f84f2ed5881338755702cdc975a572e328352a5450dd56ff0fb42afb2cb9a1028eebb3ee0fba061789d4f7abaab06ca38ea332b1ed90c",
+          "result": "valid"
+        },
+        {
+          "tcId": 193,
+          "comment": "valid control paired with mixed-order point 1/5",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d302d352d32",
+          "sig": "fe7c8cfaefecc01cae674fb2fc92626d175752824d9756548dd601be73e4353072fd18da1e55e552d1becb2d3be3fe7bb60a2748fd648faa5f08a46d1b963004",
+          "result": "valid"
+        },
+        {
+          "tcId": 194,
+          "comment": "valid control paired with mixed-order point 1/6",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "a0a03118b7d9746f89b3d5a0deb5147c0f440e7d914ceb181232b972a099caefad8258c0fb0fef3e1da74d413d1da6c38a06f2a93abf3cec796ea701c1b1d601",
+          "result": "valid"
+        },
+        {
+          "tcId": 195,
+          "comment": "valid control paired with mixed-order point 1/7",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d302d372d33",
+          "sig": "944b48f67a3d51c002e3781990778b57bf71017639e0441de7ae467c55fabc26bef8cf69bfda88633828d56751cfd6c8c8180cec5efe057f97fc6c20b2a5290a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "2bbc204b9088e455bedb8424c780f8b8a387474644664ef7641902c8ebdf333c"
+      },
+      "publicKeyDer": "302a300506032b65700321002bbc204b9088e455bedb8424c780f8b8a387474644664ef7641902c8ebdf333c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAK7wgS5CI5FW+24Qkx4D4uKOHR0ZEZk73ZBkCyOvfMzw=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 196,
+          "comment": "valid control paired with mixed-order point 2/1",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "98b7602a3e45efb7d899687ee0ec2f81f7afe8056837a720e703b3e803cf1f8f3bbb3adeeaf502dd7222db467d04c0a8859a6a80f67c33a84674e2d0476a860e",
+          "result": "valid"
+        },
+        {
+          "tcId": 197,
+          "comment": "valid control paired with mixed-order point 2/2",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d312d322d38",
+          "sig": "c0f317d6b580cfd42ac199e94ce489706b6f33bb31c5300b5e13e97ca93a3e5b1268b95e1c103624704528f1c56d456bf957f7b627b4a4c33ff53a4ffe3ea007",
+          "result": "valid"
+        },
+        {
+          "tcId": 198,
+          "comment": "valid control paired with mixed-order point 2/3",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "920dc46731eabe1a17f4ecc0c494fdf61f75e25f11e04de75f632d574a5d51fc61d298f11ca8e5c3f9ccae708b5b2dedb525bf543cfa7b15a0fee46450544e0c",
+          "result": "valid"
+        },
+        {
+          "tcId": 199,
+          "comment": "valid control paired with mixed-order point 2/4",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d312d342d31",
+          "sig": "26eb6f36777f5d04275cc0e5743c8ab428799288c2df0d5b8700aaebbfc0c664ffa55f90637bc6817390c114526dadfd3bd8a49e1512ddaf0b1b975778f1ea0b",
+          "result": "valid"
+        },
+        {
+          "tcId": 200,
+          "comment": "valid control paired with mixed-order point 2/5",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "f107a692bf3ce4f10338f7b546bc16a194f625bf034e57ea9259b6102bfd9082c74224294c828a41ff069bac623f26b815cafe1b4af1bc0cf8297d0e39ea0505",
+          "result": "valid"
+        },
+        {
+          "tcId": 201,
+          "comment": "valid control paired with mixed-order point 2/6",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d312d362d34",
+          "sig": "4683fec91d18d841760debf390e7d41cd92ea386b9bb095a5e4629ea7a0f1c41c1daeb539b4a9373858d5f4b843022e91051dbd461b1359c20e2a0775a671300",
+          "result": "valid"
+        },
+        {
+          "tcId": 202,
+          "comment": "valid control paired with mixed-order point 2/7",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "390a6f169020d371c8a63ff2580fac5b24cccda3929ccf88d9481aa97d32be2fe410f91c0a22ce4a008e2191a3fc1d6ea2f26afb6d764328c478b40f1322a804",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "8b73de57a413d70e2f3f15bb4d3918ce0b85e4fe41a72efd776d06b8cae4059e"
+      },
+      "publicKeyDer": "302a300506032b65700321008b73de57a413d70e2f3f15bb4d3918ce0b85e4fe41a72efd776d06b8cae4059e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAi3PeV6QT1w4vPxW7TTkYzguF5P5Bpy79d20GuMrkBZ4=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 203,
+          "comment": "valid control paired with mixed-order point 3/1",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d322d312d30",
+          "sig": "d637793ab7d172e2156000955e1fa77c3ba0641d9f6dd20362d208c8eb6d5de62d67eeebb72fe8fc50a77b5e7862dca0c5e40f1fde27a29e9a9c9fe81c545007",
+          "result": "valid"
+        },
+        {
+          "tcId": 204,
+          "comment": "valid control paired with mixed-order point 3/2",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "46d9381b0b3838aa7ee64fe8a1c7cfed680dc4c40e087417d5afe9bb38352ac06dfbfe9fac07dc83e62c61c1a75cfffee394644c5e3ff8431d3f41a119448b05",
+          "result": "valid"
+        },
+        {
+          "tcId": 205,
+          "comment": "valid control paired with mixed-order point 3/3",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d322d332d33",
+          "sig": "c12e8b07833d88c5c016117273fc60a9531c39ebf89de916839ae8789b535bbc6ebac6f1bc2f3523afa93142573d93643cb20a57f56a4c22dac587da32ddfd04",
+          "result": "valid"
+        },
+        {
+          "tcId": 206,
+          "comment": "valid control paired with mixed-order point 3/4",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "ea080c9adc37a7c93155883251286c8fd6dced33073582f6042c5a8cf02790f3b923a0a877b56c5dec0f79b7152f0192f74f3902281f165a4ccff2953d36590b",
+          "result": "valid"
+        },
+        {
+          "tcId": 207,
+          "comment": "valid control paired with mixed-order point 3/5",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d322d352d38",
+          "sig": "f6e379c50289cf1ac8c5c8caab924740c6bc07475104c9b714bda0288f7a91e986c33153568615a8d0f519d6a65b8821d2fcc7b1d8dc8d93fdef3f2142df100d",
+          "result": "valid"
+        },
+        {
+          "tcId": 208,
+          "comment": "valid control paired with mixed-order point 3/6",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "",
+          "sig": "c275256bd5699eea59126cd9f5b22c540ebb873c80c046eb4dc7523bd2367a982283d5edbc2042101e67b803a9725e9f7b23f809172845e9ce670d511fab580f",
+          "result": "valid"
+        },
+        {
+          "tcId": 209,
+          "comment": "valid control paired with mixed-order point 3/7",
+          "flags": [
+            "Valid"
+          ],
+          "msg": "6d697865642d6f726465722d322d372d32",
+          "sig": "845813c2ac916dc3977f05862e28fccb403d32f71fbcc817ae3ebe10d841c189dc8b663018aaa36438193f081ea7f57c904d32af78eb2fb20394d8eb640e6f06",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EddsaVerify",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "publicKey": {
+        "type": "EDDSAPublicKey",
+        "curve": "edwards25519",
+        "keySize": 255,
+        "pk": "d1e06adf4e05e248e1e52beca14b6be4da0af01b41645d2849b407ec22f41d47"
+      },
+      "publicKeyDer": "302a300506032b6570032100d1e06adf4e05e248e1e52beca14b6be4da0af01b41645d2849b407ec22f41d47",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA0eBq304F4kjh5SvsoUtr5NoK8BtBZF0oSbQH7CL0HUc=\n-----END PUBLIC KEY-----\n",
+      "tests": [
+        {
+          "tcId": 210,
+          "comment": "sodium_compat v2.5.1 mixed-order subgroup regression",
+          "flags": [
+            "MixedOrderPublicKey"
+          ],
+          "msg": "af82",
+          "sig": "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a",
           "result": "invalid"
         }
       ]

--- a/testvectors_v1/ed25519_to_x25519_test.json
+++ b/testvectors_v1/ed25519_to_x25519_test.json
@@ -1,0 +1,348 @@
+{
+  "algorithm": "EDDSA-to-XDH",
+  "header": [
+    "Test vectors for converting Ed25519 public keys to X25519 public keys."
+  ],
+  "notes": {
+    "Ktv": {
+      "bugType": "BASIC",
+      "description": "A known conversion result for a prime-order public key."
+    },
+    "SmallOrderPublicKey": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The Edwards public key is a canonical torsion point and conversion must fail."
+    },
+    "MixedOrderPublicKey": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The Edwards public key is not in the prime-order subgroup and conversion must fail.",
+      "links": [
+        "https://github.com/paragonie/sodium_compat/commit/e4d4933af9463a96a1a3cbaeb94327b90e3350ca"
+      ]
+    }
+  },
+  "numberOfTests": 34,
+  "schema": "eddsa_to_xdh_schema_v1.json",
+  "testGroups": [
+    {
+      "type": "EddsaToXdh",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "edwardsCurve": "edwards25519",
+      "montgomeryCurve": "curve25519",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "RFC 8032 prime-order control",
+          "publicKey": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+          "convertedPublicKey": "cbb22fc9f790bd3eba9b84680c157ca4950a9894362601701f89c3c4d9fda23a",
+          "result": "valid",
+          "flags": [
+            "Ktv"
+          ]
+        },
+        {
+          "tcId": 2,
+          "comment": "generated prime-order control 1",
+          "publicKey": "f2741795058d07954f8b3c5aebbf20f28d3ec3bb32e3b51aef97e4be6afb68b5",
+          "convertedPublicKey": "35b6b5368971acc9890ad3206a0801a3b8a1ec3b90088e26a713b421d4ea8d4a",
+          "result": "valid",
+          "flags": [
+            "Ktv"
+          ]
+        },
+        {
+          "tcId": 3,
+          "comment": "generated prime-order control 2",
+          "publicKey": "2bbc204b9088e455bedb8424c780f8b8a387474644664ef7641902c8ebdf333c",
+          "convertedPublicKey": "96acbfd3f6dea288286b243bab3452e033282f578d44714de1eab1be7676937b",
+          "result": "valid",
+          "flags": [
+            "Ktv"
+          ]
+        },
+        {
+          "tcId": 4,
+          "comment": "generated prime-order control 3",
+          "publicKey": "8b73de57a413d70e2f3f15bb4d3918ce0b85e4fe41a72efd776d06b8cae4059e",
+          "convertedPublicKey": "6fed7b67eb7ecb96a1eed7a8c75b35e00da832362d8c3e89a577c9f744d74a36",
+          "result": "valid",
+          "flags": [
+            "Ktv"
+          ]
+        },
+        {
+          "tcId": 5,
+          "comment": "reject canonical torsion point 0",
+          "publicKey": "0100000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "SmallOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 6,
+          "comment": "reject canonical torsion point 1",
+          "publicKey": "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a",
+          "result": "invalid",
+          "flags": [
+            "SmallOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 7,
+          "comment": "reject canonical torsion point 2",
+          "publicKey": "0000000000000000000000000000000000000000000000000000000000000080",
+          "result": "invalid",
+          "flags": [
+            "SmallOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 8,
+          "comment": "reject canonical torsion point 3",
+          "publicKey": "26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc05",
+          "result": "invalid",
+          "flags": [
+            "SmallOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 9,
+          "comment": "reject canonical torsion point 4",
+          "publicKey": "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+          "result": "invalid",
+          "flags": [
+            "SmallOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 10,
+          "comment": "reject canonical torsion point 5",
+          "publicKey": "26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc85",
+          "result": "invalid",
+          "flags": [
+            "SmallOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 11,
+          "comment": "reject canonical torsion point 6",
+          "publicKey": "0000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "SmallOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 12,
+          "comment": "reject canonical torsion point 7",
+          "publicKey": "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa",
+          "result": "invalid",
+          "flags": [
+            "SmallOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 13,
+          "comment": "reject prime-order point 1 plus torsion point 1",
+          "publicKey": "15deb30729eb3e465c88f11b57d0c8d36eb0f670c3b22d2f80ea6049eeb2c23b",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 14,
+          "comment": "reject prime-order point 1 plus torsion point 2",
+          "publicKey": "31f20adf0f25a04f6d0940d2eb6a0b7d4aa2f18c9571a6f7eb74bf059b0d7215",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 15,
+          "comment": "reject prime-order point 1 plus torsion point 3",
+          "publicKey": "db3274482b52f4937b405c00496b0511a364c58d4798ceae171262803d465729",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 16,
+          "comment": "reject prime-order point 1 plus torsion point 4",
+          "publicKey": "fb8ae86afa72f86ab074c3a51440df0d72c13c44cd1c4ae510681b419504974a",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 17,
+          "comment": "reject prime-order point 1 plus torsion point 5",
+          "publicKey": "d8214cf8d614c1b9a3770ee4a82f372c914f098f3c4dd2d07f159fb6114d3dc4",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 18,
+          "comment": "reject prime-order point 1 plus torsion point 6",
+          "publicKey": "bc0df520f0da5fb092f6bf2d1495f482b55d0e736a8e5908148b40fa64f28dea",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 19,
+          "comment": "reject prime-order point 1 plus torsion point 7",
+          "publicKey": "12cd8bb7d4ad0b6c84bfa3ffb694faee5c9b3a72b8673151e8ed9d7fc2b9a8d6",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 20,
+          "comment": "reject prime-order point 2 plus torsion point 1",
+          "publicKey": "c1b047f0106ff174487ba336a56d48127ed0563dcca139fd555cf113f609ac71",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 21,
+          "comment": "reject prime-order point 2 plus torsion point 2",
+          "publicKey": "280fa1145bb421c1586eeadfb0f96ba1a25673111eca768773dafedf9b4e5a38",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 22,
+          "comment": "reject prime-order point 2 plus torsion point 3",
+          "publicKey": "66f35e3ae56c736132dde77ae1faaeb01ebfc1bd79c98d43737e945b0744aaed",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 23,
+          "comment": "reject prime-order point 2 plus torsion point 4",
+          "publicKey": "c243dfb46f771baa41247bdb387f07475c78b8b9bb99b1089be6fd371420ccc3",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 24,
+          "comment": "reject prime-order point 2 plus torsion point 5",
+          "publicKey": "2c4fb80fef900e8bb7845cc95a92b7ed812fa9c2335ec602aaa30eec09f6538e",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 25,
+          "comment": "reject prime-order point 2 plus torsion point 6",
+          "publicKey": "c5f05eeba44bde3ea79115204f06945e5da98ceee13589788c25012064b1a5c7",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 26,
+          "comment": "reject prime-order point 2 plus torsion point 7",
+          "publicKey": "870ca1c51a938c9ecd2218851e05514fe1403e42863672bc8c816ba4f8bb5512",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 27,
+          "comment": "reject prime-order point 3 plus torsion point 1",
+          "publicKey": "85e7bfc77e932799ae948a1abd8ea287c56dd48fb8b4221931e4f8652e1eea20",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 28,
+          "comment": "reject prime-order point 3 plus torsion point 2",
+          "publicKey": "349a3840d09eb68a97b06eae781f4fbece569c6ffd70c238ff8406ec82fb587d",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 29,
+          "comment": "reject prime-order point 3 plus torsion point 3",
+          "publicKey": "0cf1b0a8da530a0f0b30f5b130391652f249680e0f3f7c80284bdc5ab955cfa3",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 30,
+          "comment": "reject prime-order point 3 plus torsion point 4",
+          "publicKey": "628c21a85bec28f1d0c0ea44b2c6e731f47a1b01be58d1028892f947351bfa61",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 31,
+          "comment": "reject prime-order point 3 plus torsion point 5",
+          "publicKey": "68184038816cd866516b75e542715d783a922b70474bdde6ce1b079ad1e115df",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 32,
+          "comment": "reject prime-order point 3 plus torsion point 6",
+          "publicKey": "b965c7bf2f614975684f915187e0b04131a96390028f3dc7007bf9137d04a782",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 33,
+          "comment": "reject prime-order point 3 plus torsion point 7",
+          "publicKey": "e10e4f5725acf5f0f4cf0a4ecfc6e9ad0db697f1f0c0837fd7b423a546aa305c",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        },
+        {
+          "tcId": 34,
+          "comment": "sodium_compat v2.5.1 mixed-order regression",
+          "publicKey": "d1e06adf4e05e248e1e52beca14b6be4da0af01b41645d2849b407ec22f41d47",
+          "result": "invalid",
+          "flags": [
+            "MixedOrderPublicKey"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testvectors_v1/ristretto255_scalar_invert_test.json
+++ b/testvectors_v1/ristretto255_scalar_invert_test.json
@@ -1,0 +1,74 @@
+{
+  "algorithm": "RISTRETTO255",
+  "header": [
+    "Test vectors for Ristretto255 scalar inversion."
+  ],
+  "notes": {
+    "ZeroInverse": {
+      "bugType": "DEFINED",
+      "description": "Inversion of zero must fail; returning an all-zero scalar is not an inverse."
+    },
+    "Ktv": {
+      "bugType": "BASIC",
+      "description": "A known scalar inversion result."
+    },
+    "EdgeCase": {
+      "bugType": "EDGE_CASE",
+      "description": "The scalar is at the upper canonical field boundary."
+    }
+  },
+  "numberOfTests": 4,
+  "schema": "ristretto_scalar_test_schema_v1.json",
+  "testGroups": [
+    {
+      "type": "RistrettoScalarTest",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "curve": "ristretto255",
+      "operation": "invert",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "zero has no multiplicative inverse",
+          "scalar": "0000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid",
+          "flags": [
+            "ZeroInverse"
+          ]
+        },
+        {
+          "tcId": 2,
+          "comment": "inverse of one",
+          "scalar": "0100000000000000000000000000000000000000000000000000000000000000",
+          "resultScalar": "0100000000000000000000000000000000000000000000000000000000000000",
+          "result": "valid",
+          "flags": [
+            "Ktv"
+          ]
+        },
+        {
+          "tcId": 3,
+          "comment": "inverse of the scalar field order minus one",
+          "scalar": "ecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "resultScalar": "ecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result": "valid",
+          "flags": [
+            "EdgeCase"
+          ]
+        },
+        {
+          "tcId": 4,
+          "comment": "inverse of two",
+          "scalar": "0200000000000000000000000000000000000000000000000000000000000000",
+          "resultScalar": "f7e97a2e8d31092c6bce7b51ef7c6f0a00000000000000000000000000000008",
+          "result": "valid",
+          "flags": [
+            "Ktv"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testvectors_v1/xchacha20_poly1305_secretstream_test.json
+++ b/testvectors_v1/xchacha20_poly1305_secretstream_test.json
@@ -1,0 +1,190 @@
+{
+  "algorithm": "XCHACHA20-POLY1305-SECRETSTREAM",
+  "header": [
+    "State-checkpoint vectors for Secretstream automatic-rekey boundaries."
+  ],
+  "notes": {
+    "Ktv": {
+      "bugType": "BASIC",
+      "description": "A known Secretstream state transition from the initial state derived from an all-zero key and header."
+    },
+    "NoPrematureRekey": {
+      "bugType": "FUNCTIONALITY",
+      "description": "The 32-bit message counter must not be treated as a 16-bit counter.",
+      "effect": "Premature rekeying causes state and ciphertext divergence."
+    },
+    "CounterWrapRekey": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "Automatic rekeying must occur when the 32-bit message counter wraps.",
+      "effect": "Failure to rekey before counter reuse can repeat a nonce under the same subkey."
+    }
+  },
+  "numberOfTests": 7,
+  "schema": "secretstream_test_schema_v1.json",
+  "testGroups": [
+    {
+      "type": "SecretStreamTest",
+      "source": {
+        "name": "github/paragonie/sodium_compat/boundary-regressions",
+        "version": "2.5.2"
+      },
+      "operation": "push",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "initial-state control",
+          "initialState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "01000000",
+            "inonce": "000000000000000000000000"
+          },
+          "tag": 0,
+          "aad": "",
+          "msg": "",
+          "ct": "5da50ee77068246b2499ce9dfc4dd24dde",
+          "expectedState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "02000000",
+            "inonce": "a50ee77068246b2400000000"
+          },
+          "result": "valid",
+          "flags": [
+            "Ktv"
+          ]
+        },
+        {
+          "tcId": 2,
+          "comment": "counter 65,534 does not rekey",
+          "initialState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "feff0000",
+            "inonce": "000000000000000000000000"
+          },
+          "tag": 0,
+          "aad": "",
+          "msg": "",
+          "ct": "b31543f965cfa0bf11ebd23a87a89544ab",
+          "expectedState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "ffff0000",
+            "inonce": "1543f965cfa0bf1100000000"
+          },
+          "result": "valid",
+          "flags": [
+            "NoPrematureRekey"
+          ]
+        },
+        {
+          "tcId": 3,
+          "comment": "counter 65,535 does not rekey",
+          "initialState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "ffff0000",
+            "inonce": "1543f965cfa0bf1100000000"
+          },
+          "tag": 0,
+          "aad": "",
+          "msg": "",
+          "ct": "d05e06eba3f8f23f6188d72f0e4c7576fd",
+          "expectedState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "00000100",
+            "inonce": "4b4512c63752807000000000"
+          },
+          "result": "valid",
+          "flags": [
+            "NoPrematureRekey"
+          ]
+        },
+        {
+          "tcId": 4,
+          "comment": "counter 65,536 remains on the same subkey",
+          "initialState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "00000100",
+            "inonce": "4b4512c63752807000000000"
+          },
+          "tag": 0,
+          "aad": "",
+          "msg": "",
+          "ct": "741598a55266b62d318621fba2213b9293",
+          "expectedState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "01000100",
+            "inonce": "5eddb79451e4ad4100000000"
+          },
+          "result": "valid",
+          "flags": [
+            "NoPrematureRekey"
+          ]
+        },
+        {
+          "tcId": 5,
+          "comment": "counter 4,294,967,294 does not rekey",
+          "initialState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "feffffff",
+            "inonce": "000000000000000000000000"
+          },
+          "tag": 0,
+          "aad": "",
+          "msg": "",
+          "ct": "6cdd1ff40f483b4ad240cac7ed11e547fb",
+          "expectedState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "ffffffff",
+            "inonce": "dd1ff40f483b4ad200000000"
+          },
+          "result": "valid",
+          "flags": [
+            "CounterWrapRekey"
+          ]
+        },
+        {
+          "tcId": 6,
+          "comment": "counter 4,294,967,295 triggers automatic rekey",
+          "initialState": {
+            "key": "1140704c328d1d5d0e30086cdf209dbd6a43b8f41518a11cc387b669b2ee6586",
+            "counter": "ffffffff",
+            "inonce": "dd1ff40f483b4ad200000000"
+          },
+          "tag": 0,
+          "aad": "",
+          "msg": "",
+          "ct": "cce16cb5a2176fe1bb765f3e9d8bdf525c",
+          "expectedState": {
+            "key": "6d34a37ad38bc5bac119de90b665450b6581136eed8d6280b8cf0cf1449c75c4",
+            "counter": "01000000",
+            "inonce": "59f5af4626ded52500000000"
+          },
+          "result": "valid",
+          "flags": [
+            "CounterWrapRekey"
+          ]
+        },
+        {
+          "tcId": 7,
+          "comment": "first message after automatic rekey",
+          "initialState": {
+            "key": "6d34a37ad38bc5bac119de90b665450b6581136eed8d6280b8cf0cf1449c75c4",
+            "counter": "01000000",
+            "inonce": "59f5af4626ded52500000000"
+          },
+          "tag": 0,
+          "aad": "",
+          "msg": "",
+          "ct": "a5dc20740410bf3ee7c481b8bfcf3bf3f4",
+          "expectedState": {
+            "key": "6d34a37ad38bc5bac119de90b665450b6581136eed8d6280b8cf0cf1449c75c4",
+            "counter": "02000000",
+            "inonce": "85d5db423661ebc200000000"
+          },
+          "result": "valid",
+          "flags": [
+            "CounterWrapRekey"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds 146 regression vectors derived from cryptographic boundary fixes in `sodium_compat` [v2.5.1](https://github.com/paragonie/sodium_compat/releases/tag/v2.5.1) and [v2.5.2](https://github.com/paragonie/sodium_compat/releases/tag/v2.5.2), using [vector-forge](https://github.com/trailofbits/skills/tree/main/plugins/trailmark/skills/vector-forge):

- 59 Ed25519 small- and mixed-order subgroup cases
- 34 Ed25519-to-X25519 conversion cases
- 42 ChaCha20/XChaCha20 counter carry and overflow cases
- 4 Ristretto255 scalar-inversion cases
- 7 Secretstream counter and rekey state checkpoints

This also adds four schemas for the new vector formats.

The main idea behind this PR was to write stable test vectors to exercise the attack surface in those releases so that other implementations that currently test with Wycheproof can ensure they are resilient to similar bugs.